### PR TITLE
Update pyproject syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aiortc>=1.13.0",
-    "fastrtc",
+    "fastrtc@git+ssh://git@github.com/gradio-app/fastrtc.git@main",
     "gradio>=5.49.0",
     "huggingface_hub>=0.34.4",
     "mediapipe>=0.10.14",
@@ -21,9 +21,9 @@ dependencies = [
     "openai>=2.1",
     "PyGObject>=3.42.2,<=3.46.0",
     "python-dotenv",
-    "reachy_mini_dances_library",
-    "reachy_mini_toolbox",
-    "reachy_mini",
+    "reachy_mini_dances_library@git+ssh://git@github.com/pollen-robotics/reachy_mini_dances_library@main",
+    "reachy_mini_toolbox@git+ssh://git@github.com/pollen-robotics/reachy_mini_toolbox@main",
+    "reachy_mini@git+ssh://git@github.com/pollen-robotics/reachy_mini@develop",
     "supervision",
     "torch",
     "transformers",
@@ -35,12 +35,6 @@ reachy-mini-conversation-demo = "reachy_mini_conversation_demo.main:main"
 
 [dependency-groups]
 dev = ["pytest", "ruff==0.12.0"]
-
-[tool.uv.sources]
-reachy_mini_dances_library = { path = "../reachy_mini_dances_library", editable = true }
-reachy_mini = { git = "ssh://git@github.com/pollen-robotics/reachy_mini.git", branch = "develop" }
-reachy_mini_toolbox = { git = "ssh://git@github.com/pollen-robotics/reachy_mini_toolbox.git", branch = "main" }
-fastrtc = { git = "ssh://git@github.com/gradio-app/fastrtc.git", branch = "main" }
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -961,7 +961,7 @@ wheels = [
 [[package]]
 name = "fastrtc"
 version = "0.0.33"
-source = { git = "ssh://git@github.com/gradio-app/fastrtc.git?branch=main#27f054934f15070750ee0383a94c103231bd0bbb" }
+source = { git = "ssh://git@github.com/gradio-app/fastrtc.git?rev=main#27f054934f15070750ee0383a94c103231bd0bbb" }
 dependencies = [
     { name = "aioice" },
     { name = "aiortc" },
@@ -2448,7 +2448,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2459,7 +2459,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2486,9 +2486,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2499,7 +2499,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3556,7 +3556,7 @@ wheels = [
 [[package]]
 name = "reachy-mini"
 version = "0.1.0"
-source = { git = "ssh://git@github.com/pollen-robotics/reachy_mini?branch=develop#ba10625dd2431850eff04f18b413b415a9ac188a" }
+source = { git = "ssh://git@github.com/pollen-robotics/reachy_mini?rev=develop#6988c959826968ec416336d9fc4c1bb4f70fb2d7" }
 dependencies = [
     { name = "aiohttp" },
     { name = "asgiref" },
@@ -3612,7 +3612,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiortc", specifier = ">=1.13.0" },
-    { name = "fastrtc", git = "ssh://git@github.com/gradio-app/fastrtc.git?branch=main" },
+    { name = "fastrtc", git = "ssh://git@github.com/gradio-app/fastrtc.git?rev=main" },
     { name = "gradio", specifier = ">=5.49.0" },
     { name = "huggingface-hub", specifier = ">=0.34.4" },
     { name = "mediapipe", specifier = ">=0.10.14" },
@@ -3622,9 +3622,9 @@ requires-dist = [
     { name = "opencv-python", specifier = ">=4.12.0.88" },
     { name = "pygobject", specifier = ">=3.42.2,<=3.46.0" },
     { name = "python-dotenv" },
-    { name = "reachy-mini", git = "ssh://git@github.com/pollen-robotics/reachy_mini.git?branch=develop" },
-    { name = "reachy-mini-dances-library", editable = "../reachy_mini_dances_library" },
-    { name = "reachy-mini-toolbox", git = "ssh://git@github.com/pollen-robotics/reachy_mini_toolbox.git?branch=main" },
+    { name = "reachy-mini", git = "ssh://git@github.com/pollen-robotics/reachy_mini?rev=develop" },
+    { name = "reachy-mini-dances-library", git = "ssh://git@github.com/pollen-robotics/reachy_mini_dances_library?rev=main" },
+    { name = "reachy-mini-toolbox", git = "ssh://git@github.com/pollen-robotics/reachy_mini_toolbox?rev=main" },
     { name = "supervision" },
     { name = "torch" },
     { name = "transformers" },
@@ -3640,18 +3640,10 @@ dev = [
 [[package]]
 name = "reachy-mini-dances-library"
 version = "0.1.2"
-source = { editable = "../reachy_mini_dances_library" }
+source = { git = "ssh://git@github.com/pollen-robotics/reachy_mini_dances_library?rev=main#ca0b86cbe5c2c4031ea8c618a62dc936fba4ca92" }
 dependencies = [
     { name = "reachy-mini" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "reachy-mini", git = "ssh://git@github.com/pollen-robotics/reachy_mini?branch=develop" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.0" },
-]
-provides-extras = ["dev"]
 
 [[package]]
 name = "reachy-mini-motor-controller"
@@ -3812,7 +3804,7 @@ wheels = [
 [[package]]
 name = "reachy-mini-toolbox"
 version = "0.1.0"
-source = { git = "ssh://git@github.com/pollen-robotics/reachy_mini_toolbox.git?branch=main#c4b18a56e51db9ce0fd9286c54554c89bf968a48" }
+source = { git = "ssh://git@github.com/pollen-robotics/reachy_mini_toolbox?rev=main#c4b18a56e51db9ce0fd9286c54554c89bf968a48" }
 
 [[package]]
 name = "regex"
@@ -4501,7 +4493,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/ee/0ee5f64a87eeda19bbad9bc54ae5ca5b98186ed00055281fd40fb4beb10e/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ff2785de9bc02f500e085420273bb5cc9c9bb767584a4aa28d6e360cec70128", size = 155430069, upload-time = "2025-07-30T19:58:21.715Z" },


### PR DESCRIPTION
Migrating from `[tool.uv.sources]` to specifying branches in `dependencies`. It's going to be easier for pip / conda people, and it still works correctly with uv 