### PR TITLE
bug #51: fix close function missing. renamed stop to close

### DIFF
--- a/src/reachy_mini_conversation_demo/console.py
+++ b/src/reachy_mini_conversation_demo/console.py
@@ -50,8 +50,8 @@ class LocalStream:
 
         asyncio.run(runner())
 
-    def stop(self) -> None:
-        """Stop the stream and underlying GStreamer pipelines.
+    def close(self) -> None:
+        """Stop the stream and underlying media pipelines.
 
         This method:
         - Sets the stop event to signal async loops to terminate


### PR DESCRIPTION
The `stream_mananger` in main.py is an "interface" to abstract the fastrtc stream or the localstream.
localstream needs to expose launch and close to match the fastrtc api.