### PR TITLE
enhancement #76: Migrate from beta OpenAI to GA

### DIFF
--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -132,9 +132,6 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     "response.completed",             # text-only completion
                 ):
                     logger.debug("response completed")
-                    # TODO: remove later
-                    # if self.deps.head_wobbler is not None:
-                    #     self.deps.head_wobbler.reset()
 
                 if event.type == "response.created":
                     logger.debug("Response created")


### PR DESCRIPTION
This PR fixes the following:
- Migrate from OpenAI Realtime Beta to GA – ensures full compatibility with the GA Realtime API, [see this issue](https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/73)