### PR TITLE
Improve env file loading in config.py

### DIFF
--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -9,15 +9,12 @@ logger = logging.getLogger(__name__)
 # Locate .env file (search upward from current working directory)
 dotenv_path = find_dotenv(usecwd=True)
 
-if not dotenv_path:
-    raise RuntimeError(
-        f".env file not found at: {dotenv_path}\n"
-        "Create one from .env.example and add required variables."
-    )
-
-# Load .env without overriding real environment variables
-load_dotenv(dotenv_path=dotenv_path, override=False)
-logger.info(f"Configuration loaded from {dotenv_path}")
+if dotenv_path:
+    # Load .env and override environment variables
+    load_dotenv(dotenv_path=dotenv_path, override=True)
+    logger.info(f"Configuration loaded from {dotenv_path}")
+else:
+    logger.warning("No .env file found, using environment variables")
 
 
 class Config:
@@ -27,8 +24,10 @@ class Config:
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
     if not OPENAI_API_KEY or not OPENAI_API_KEY.strip():
         raise RuntimeError(
-            "OPENAI_API_KEY is missing or empty. Add it to .env as:\n"
-            "OPENAI_API_KEY=your_api_key_here"
+            "OPENAI_API_KEY is missing or empty.\n"
+            "Either:\n"
+            "  1. Create a .env file with: OPENAI_API_KEY=your_api_key_here (recomended)\n"
+            "  2. Set environment variable: export OPENAI_API_KEY=your_api_key_here"
         )
 
     # Optional


### PR DESCRIPTION
Use `find_dotenv(usecwd=True)` to search for the `.env` file starting from the current working directory, walking up the directory tree to find it. Besides, if `.env` is missing but `OPENAI_API_KEY` is already exported in the environment, the app will still run using that key