### PR TITLE
Fixing librosa.resample import and first call overhead

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -8,8 +8,8 @@ import asyncio
 import logging
 from typing import List
 
-from librosa import resample
 from fastrtc import AdditionalOutputs, audio_to_int16, audio_to_float32
+from librosa import resample
 
 from reachy_mini import ReachyMini
 from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
@@ -30,7 +30,7 @@ class LocalStream:
         # Allow the handler to flush the player queue when appropriate.
         self.handler._clear_queue = self.clear_audio_queue
 
-        # Hack to avoid the first lenghty call to resample at runtime. 
+        # Hack to avoid the first lenghty call to resample at runtime.
         # This is likely caused by cache initialization overhead.
         import numpy as np
         resample(np.array([0.0]), orig_sr=1, target_sr=1)


### PR DESCRIPTION
This PR introduces a "hacky" fix to remove the overhead caused by :
- Importing only `librosa` and then calling `librosa.resample`;
- The first very lengthy call to `librosa.resample`, likely caused by cache initialization.

Here is a minimal reproducible example illustrating the problem :

```
import time
import numpy as np
import sys

import librosa

start = time.time()
librosa.resample(np.ones(1000), orig_sr=24000, target_sr=16000)
end = time.time()
print(f"Time taken: {end - start} seconds")

start = time.time()
librosa.resample(np.ones(1000), orig_sr=24000, target_sr=16000)
end = time.time()
print(f"Time taken: {end - start} seconds")
```

And 

```
import time
import numpy as np
import sys

from librosa import resample

start = time.time()
resample(np.ones(1000), orig_sr=24000, target_sr=16000)
end = time.time()
print(f"Time taken: {end - start} seconds")

start = time.time()
resample(np.ones(1000), orig_sr=24000, target_sr=16000)
end = time.time()
print(f"Time taken: {end - start} seconds")
```

You should notice a decrease in the first call duration when using `from librosa import resample`.