### PR TITLE
Fix delay caused by self.sway.feed in HeadWobbler

### DIFF
--- a/src/reachy_mini_conversation_app/audio/head_wobbler.py
+++ b/src/reachy_mini_conversation_app/audio/head_wobbler.py
@@ -80,14 +80,14 @@ class HeadWobbler:
                 if chunk_generation != current_generation:
                     continue
 
-                pcm = np.asarray(chunk).squeeze(0)
-                with self._sway_lock:
-                    results = self.sway.feed(pcm, sr)
-
                 if self._base_ts is None:
                     with self._state_lock:
                         if self._base_ts is None:
                             self._base_ts = time.time()
+
+                pcm = np.asarray(chunk).squeeze(0)
+                with self._sway_lock:
+                    results = self.sway.feed(pcm, sr)
 
                 i = 0
                 while i < len(results):


### PR DESCRIPTION
This PR simply puts the `self_base_ts` initialization before the `self.sway.feed` call to deduce the sway computation duration from the target time. 
This is particularly relevant when the received audio sample is quite long.