### PR TITLE
fastrtc is now installed from repo to fix print spamming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     #Media
     "aiortc>=1.13.0",
-    #"fastrtc>=0.0.33", --> replaced by git version until new release is made to fix print spamming
-    "fastrtc @ git+https://github.com/gradio-app/fastrtc.git@27f054934f15070750ee0383a94c103231bd0bbb",
+    "fastrtc>=0.0.34",
     "gradio>=5.49.0",
     "huggingface_hub>=0.34.4",
     "opencv-python>=4.12.0.88",


### PR DESCRIPTION
The latest release of fastrtc (0.0.33) doesn't contain this fix:
https://github.com/gradio-app/fastrtc/commit/27f054934f15070750ee0383a94c103231bd0bbb

So installing from repo fixes the issue. This is temporary and will be replaced once the fastrtc release is done.