### PR TITLE
Update stop function to reset to neutral position

### DIFF
--- a/src/reachy_mini_conversation_app/moves.py
+++ b/src/reachy_mini_conversation_app/moves.py
@@ -48,7 +48,6 @@ from reachy_mini.utils import create_head_pose
 from reachy_mini.motion.move import Move
 from reachy_mini.utils.interpolation import (
     compose_world_offset,
-    distance_between_poses,
     linear_pose_interpolation,
 )
 


### PR DESCRIPTION
## Summary
When stopping the conversation app, the robot now smoothly returns to a neutral position (head centered, antennas at 0 degree) over 1.5 seconds before shutting down, preventing it from ending in awkward or extreme poses. This is implemented by queuing a `GotoQueueMove` in the `MovementManager.stop()` method that interpolates from the current position to neutral before terminating the control loop.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [x] CI green (Ruff, Tests, Mypy)
- [x] Code update is clear (types, docs, comments)

### Run modes
- [x] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [x] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `pyproject.toml` if deps/extras changed
- [ ] Regenerated `uv.lock` if deps changed
- [ ] Updated `.env.example` if new config vars added
