### PR TITLE
fix(audio channels): making the play_loop and receive methods robust to audio inputs/outputs shapes

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -106,6 +106,15 @@ class LocalStream:
                 input_sample_rate, audio_data = handler_output
                 output_sample_rate = self._robot.media.get_output_audio_samplerate()
 
+                # Reshape if needed
+                if audio_data.ndim == 2:
+                    # Scipy channels last convention
+                    if audio_data.shape[1] > audio_data.shape[0]:
+                        audio_data = audio_data.T
+                    # Multiple channels -> Mono channel
+                    if audio_data.shape[1] > 1:
+                        audio_data = audio_data[:, 0]
+
                 # Cast if needed
                 audio_frame = audio_to_float32(audio_data)
 

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -349,9 +349,10 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         if not self.connection:
             return
         input_sample_rate, audio_frame = frame
-        # Make mono if it's stereo
+
+        #Reshape if needed
         if audio_frame.ndim == 2:
-            # Sounndevice channels last convention
+            # Scipy channels last convention
             if audio_frame.shape[1] > audio_frame.shape[0]:
                 audio_frame = audio_frame.T
             # Multiple channels -> Mono channel
@@ -360,7 +361,10 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
         # Resample if needed
         if self.input_sample_rate != input_sample_rate:
-            audio_frame = resample(audio_frame, int(len(audio_frame) * self.input_sample_rate / input_sample_rate))
+            audio_frame = resample(
+                audio_frame,
+                int(len(audio_frame) * self.input_sample_rate / input_sample_rate)
+            )
 
         # Cast if needed
         audio_frame = audio_to_int16(audio_frame)


### PR DESCRIPTION
This PR makes the `play_loop` and `receive` methods compliant with the expected audio devices inputs/outputs, and more robust.

Both functions now handles any 1D/2D numpy array with one dimension larger than the other (assumption `channels < samples`).

## Category
- [x ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ x] CI green (Ruff, Tests, Mypy)
- [x ] Code update is clear (types, docs, comments)

### Run modes
- [x ] Headless mode (default)
- [x ] Gradio UI (`--gradio`)
- [x ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `pyproject.toml` if deps/extras changed
- [ ] Regenerated `uv.lock` if deps changed
- [ ] Updated `.env.example` if new config vars added