### PR TITLE
fixing shutdown

### DIFF
--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -190,6 +190,12 @@ def run(
         if vision_manager:
             vision_manager.stop()
 
+        # Ensure media is explicitly closed before disconnecting
+        try:
+            robot.media.close()
+        except Exception as e:
+            logger.debug(f"Error closing media during shutdown: {e}")
+
         # prevent connection to keep alive some threads
         robot.client.disconnect()
         time.sleep(1)


### PR DESCRIPTION
## Summary
Fixing an error I was getting during shutdown:

```bash
Traceback (most recent call last):
  File "/Users/andresmarafioti/Documents/tmp/reachy_mini_conversation_app/.venv/lib/python3.12/site-packages/reachy_mini/media/media_manager.py", line 77, in __del__
    self.close()
  File "/Users/andresmarafioti/Documents/tmp/reachy_mini_conversation_app/.venv/lib/python3.12/site-packages/reachy_mini/media/media_manager.py", line 72, in close
    self.audio.stop_recording()
  File "/Users/andresmarafioti/Documents/tmp/reachy_mini_conversation_app/.venv/lib/python3.12/site-packages/reachy_mini/media/audio_sounddevice.py", line 139, in stop_recording
    if self._is_recording:
       ^^^^^^^^^^^^^^^^^^
  File "/Users/andresmarafioti/Documents/tmp/reachy_mini_conversation_app/.venv/lib/python3.12/site-packages/reachy_mini/media/audio_sounddevice.py", line 57, in _is_recording
    return self._input_stream is not None and self._input_stream.active
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/andresmarafioti/Documents/tmp/reachy_mini_conversation_app/.venv/lib/python3.12/site-packages/sounddevice.py", line 1032, in active
    return _check(_lib.Pa_IsStreamActive(self._ptr)) == 1
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/andresmarafioti/Documents/tmp/reachy_mini_conversation_app/.venv/lib/python3.12/site-packages/sounddevice.py", line 2796, in _check
    raise PortAudioError(errormsg, err)
sounddevice.PortAudioError: PortAudio not initialized [PaErrorCode -10000]
```


## Category
- [X] Fix
