### PR TITLE
Improve interruptions

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -438,6 +438,8 @@ class LocalStream:
         if self._robot.media.backend == MediaBackend.GSTREAMER:
             # Directly flush gstreamer audio pipe
             self._robot.media.audio.clear_player()
+        elif self._robot.media.backend == MediaBackend.DEFAULT or self._robot.media.backend == MediaBackend.DEFAULT_NO_VIDEO:
+            self._robot.media.audio.clear_output_buffer()
         self.handler.output_queue = asyncio.Queue()
 
     async def record_loop(self) -> None:

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -286,7 +286,6 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 if event.type == "input_audio_buffer.speech_started":
                     if hasattr(self, "_clear_queue") and callable(self._clear_queue):
                         self._clear_queue()
-                    self.empty_output_queue()
                     if self.deps.head_wobbler is not None:
                         self.deps.head_wobbler.reset()
                     self.deps.movement_manager.set_listening(True)
@@ -550,10 +549,6 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 self.connection = None
 
         # Clear any remaining items in the output queue
-        self.empty_output_queue()
-
-    def empty_output_queue(self) -> None:
-        """Empty the output queue."""
         while not self.output_queue.empty():
             try:
                 self.output_queue.get_nowait()


### PR DESCRIPTION
## Summary
Fix interruptions. Because OpenAI sends chunks of audio, I saw in the logs that we were interrupting the robot, and everything seemed to work, except that the robot would continue to speak. I suspected this was the output buffer from audiosounddevice not beeing emptied, so I added that. This PR requires [this one in reachy mini](https://github.com/pollen-robotics/reachy_mini/pull/574) to be merged.

## Category
- [X] Fix

