### PR TITLE
168 benchmark the head wobbler and optimize if possible

### DIFF
--- a/src/reachy_mini_conversation_app/audio/head_wobbler.py
+++ b/src/reachy_mini_conversation_app/audio/head_wobbler.py
@@ -132,7 +132,6 @@ class HeadWobbler:
                     i = 0
                     chunk_processed = True
                     while i < len_results:
-                        iteration_start = time.perf_counter()
                         with self._state_lock:
                             if self._generation != current_generation:
                                 chunk_processed = False

--- a/src/reachy_mini_conversation_app/audio/head_wobbler.py
+++ b/src/reachy_mini_conversation_app/audio/head_wobbler.py
@@ -267,13 +267,10 @@ class HeadWobbler:
             queue_ref = self.audio_queue
             queue_poll_start = time.perf_counter()
             try:
-                chunk_generation, sr, chunk = queue_ref.get_nowait()  # (gen, sr, data)
+                chunk_generation, sr, chunk = queue_ref.get(timeout=hop_dt / 2.0)  # the timeout throttles the loop
             except queue.Empty:
                 poll_duration = time.perf_counter() - queue_poll_start
                 self._benchmark.add_duration("queue.poll", poll_duration)
-                # avoid while to never exit
-                sleep_start = time.perf_counter()
-                time.sleep(MOVEMENT_LATENCY_S)
                 continue
             else:
                 poll_duration = time.perf_counter() - queue_poll_start

--- a/src/reachy_mini_conversation_app/audio/head_wobbler.py
+++ b/src/reachy_mini_conversation_app/audio/head_wobbler.py
@@ -4,136 +4,18 @@ import time
 import queue
 import base64
 import threading
-from dataclasses import dataclass
-from typing import Iterator, Tuple
+from typing import Tuple
 from collections.abc import Callable
-from contextlib import contextmanager
 
 import numpy as np
 from numpy.typing import NDArray
 
 from reachy_mini_conversation_app.audio.speech_tapper import HOP_MS, SwayRollRT
+from reachy_mini_conversation_app.audio.head_wobbler_benchmark import HeadWobblerDiagnostics
 
 
 SAMPLE_RATE = 24000
 MOVEMENT_LATENCY_S = 0.08  # seconds between audio and robot movement
-
-@dataclass
-class _SectionStat:
-    """Aggregated statistics for a benchmark section."""
-
-    count: int = 0
-    total: float = 0.0
-    mean: float = 0.0
-    m2: float = 0.0  # Sum of squared differences for variance (Welford)
-    minimum: float = float("inf")
-    maximum: float = float("-inf")
-
-    def update(self, duration: float) -> None:
-        """Update the aggregates in-place."""
-        self.count += 1
-        delta = duration - self.mean
-        self.mean += delta / self.count
-        self.m2 += delta * (duration - self.mean)
-        self.total += duration
-        self.minimum = min(self.minimum, duration)
-        self.maximum = max(self.maximum, duration)
-
-    def variance(self) -> float:
-        """Return the population variance for the section."""
-        if self.count == 0:
-            return 0.0
-        return self.m2 / self.count
-
-    def snapshot(self) -> dict[str, float]:
-        """Create a serializable snapshot of the metrics."""
-        if self.count == 0:
-            return {
-                "count": 0,
-                "avg_s": 0.0,
-                "var_s2": 0.0,
-                "total_s": 0.0,
-                "min_s": 0.0,
-                "max_s": 0.0,
-            }
-
-        return {
-            "count": float(self.count),
-            "avg_s": self.mean,
-            "var_s2": self.variance(),
-            "total_s": self.total,
-            "min_s": self.minimum,
-            "max_s": self.maximum,
-        }
-
-
-class HeadWobblerBenchmark:
-    """Collect timing statistics for the wobble pipeline."""
-
-    def __init__(self, enabled: bool) -> None:
-        self.enabled = enabled
-        self._stats: dict[str, _SectionStat] = {}
-        self._stats_lock = threading.Lock()
-
-    def _record(self, name: str, duration: float) -> None:
-        with self._stats_lock:
-            stat = self._stats.setdefault(name, _SectionStat())
-            stat.update(duration)
-
-    @contextmanager
-    def section(self, name: str) -> Iterator[None]:
-        """Context manager to accumulate timing for a named section."""
-        if not self.enabled:
-            yield
-            return
-
-        start = time.perf_counter()
-        try:
-            yield
-        finally:
-            end = time.perf_counter()
-            self._record(name, end - start)
-
-    def add_duration(self, name: str, duration: float) -> None:
-        """Directly add a measured duration to the aggregates."""
-        if not self.enabled:
-            return
-        if duration < 0:
-            duration = 0.0
-        self._record(name, duration)
-
-    def snapshot(self) -> dict[str, dict[str, float]]:
-        """Return copies of the collected metrics."""
-        if not self.enabled:
-            return {}
-        with self._stats_lock:
-            return {name: stat.snapshot() for name, stat in self._stats.items()}
-
-    def format_report(self) -> str:
-        """Format a human-readable summary of the metrics."""
-        if not self.enabled:
-            return "Head wobble benchmark disabled"
-        snap = self.snapshot()
-        if not snap:
-            return "Head wobble benchmark enabled but no samples recorded"
-
-        total_sum = sum(section["total_s"] for section in snap.values())
-        lines = ["Section                     Count    Avg (ms)   Var (ms^2)  Total (ms)   %Total  Min/Max (ms)"]
-        for name, stats in sorted(snap.items(), key=lambda item: item[1]["total_s"], reverse=True):
-            avg_ms = stats["avg_s"] * 1000.0
-            var_ms = stats["var_s2"] * 1_000_000.0
-            total_ms = stats["total_s"] * 1000.0
-            min_ms = stats["min_s"] * 1000.0
-            max_ms = stats["max_s"] * 1000.0
-            pct = (stats["total_s"] / total_sum * 100.0) if total_sum else 0.0
-            indent = "  " * name.count(".")
-            section_name = f"{indent}{name}"
-            lines.append(
-                f"{section_name:<27} {int(stats['count']):>6}  "
-                f"{avg_ms:>10.3f}  {var_ms:>11.3f}  {total_ms:>10.3f}  "
-                f"{pct:>6.2f}%  {min_ms:>5.2f}/{max_ms:>5.2f}",
-            )
-        return "\n".join(lines)
 
 
 class HeadWobbler:
@@ -159,19 +41,11 @@ class HeadWobbler:
 
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
-        self._benchmark = HeadWobblerBenchmark(enabled=enable_benchmark if enable_benchmark is not None else True)
+        enable_diag = enable_benchmark if enable_benchmark is not None else True
+        self._benchmark = HeadWobblerDiagnostics(HOP_MS, enable_diag)
         self._benchmark_log_interval = 5.0
         self._next_benchmark_log = time.monotonic() + self._benchmark_log_interval
-        self._realtime_audio_total = 0.0
-        self._realtime_compute_total = 0.0
-        self._realtime_max_ratio = 0.0
-        self._realtime_overruns = 0
-        self._realtime_chunks = 0
-        self._realtime_slack_total = 0.0
-        self._realtime_deficit_total = 0.0
-        self._realtime_worst_slack = 0.0
-        self._realtime_worst_deficit = 0.0
-        self._realtime_lock = threading.Lock()
+        self._chunk_counter = 0
 
     def feed(self, delta_b64: str) -> None:
         """Thread-safe: push audio into the consumer queue."""
@@ -200,58 +74,9 @@ class HeadWobbler:
         if self._benchmark.enabled:
             print("Head wobble benchmark results:\n%s" % self.benchmark_report(), flush=True)
 
-    def benchmark_snapshot(self) -> dict[str, dict[str, float]]:
-        """Return raw benchmark data."""
-        return self._benchmark.snapshot()
-
     def benchmark_report(self) -> str:
         """Return a formatted benchmark report."""
-        base_report = self._benchmark.format_report()
-        status_line = self._realtime_status_line()
-        if status_line:
-            return f"{base_report}\n{status_line}"
-        return base_report
-
-    def _realtime_snapshot(self) -> dict[str, float]:
-        with self._realtime_lock:
-            return {
-                "audio_s": self._realtime_audio_total,
-                "compute_s": self._realtime_compute_total,
-                "max_ratio": self._realtime_max_ratio,
-                "chunks": float(self._realtime_chunks),
-                "overruns": float(self._realtime_overruns),
-                "slack_s": self._realtime_slack_total,
-                "deficit_s": self._realtime_deficit_total,
-                "worst_slack_s": self._realtime_worst_slack,
-                "worst_deficit_s": self._realtime_worst_deficit,
-            }
-
-    def _realtime_status_line(self) -> str:
-        snap = self._realtime_snapshot()
-        chunks = int(snap["chunks"])
-        audio = snap["audio_s"]
-        compute = snap["compute_s"]
-        if chunks == 0 or audio <= 0.0:
-            return ""
-        avg_ratio = compute / audio
-        max_ratio = snap["max_ratio"]
-        overruns = int(snap["overruns"])
-        status = "PASS" if avg_ratio <= 1.0 and max_ratio <= 1.1 else "WARN"
-        detail = (
-            f"avg utilization {avg_ratio * 100.0:.1f}%, "
-            f"peak {max_ratio * 100.0:.1f}%, chunks={chunks}"
-        )
-        if overruns:
-            detail += f", overruns={overruns}"
-        if snap["slack_s"] > 0:
-            avg_slack = (snap["slack_s"] / chunks) * 1000.0
-            detail += f", avg slack {avg_slack:.2f}ms"
-            detail += f", peak slack {snap['worst_slack_s'] * 1000.0:.2f}ms"
-        if snap["deficit_s"] > 0:
-            avg_deficit = (snap["deficit_s"] / overruns) * 1000.0 if overruns else snap["deficit_s"] * 1000.0
-            detail += f", avg deficit {avg_deficit:.2f}ms"
-            detail += f", worst deficit {snap['worst_deficit_s'] * 1000.0:.2f}ms"
-        return f"Realtime status: {status} ({detail})"
+        return self._benchmark.benchmark_report()
 
     def working_loop(self) -> None:
         """Convert audio deltas into head movement offsets."""
@@ -262,119 +87,128 @@ class HeadWobbler:
             if self._benchmark.enabled and time.monotonic() >= self._next_benchmark_log:
                 self._next_benchmark_log = time.monotonic() + self._benchmark_log_interval
                 print("Head wobble benchmark (live):\n%s" % self.benchmark_report(), flush=True)
-            chunk_start: float | None = None
-            chunk_audio_span = 0.0
+
             queue_ref = self.audio_queue
-            queue_poll_start = time.perf_counter()
             try:
-                chunk_generation, sr, chunk = queue_ref.get(timeout=hop_dt / 2.0)  # the timeout throttles the loop
+                chunk_generation, sr, chunk = queue_ref.get(timeout=hop_dt / 2.0)
             except queue.Empty:
-                poll_duration = time.perf_counter() - queue_poll_start
-                self._benchmark.add_duration("queue.poll", poll_duration)
                 continue
-            else:
-                poll_duration = time.perf_counter() - queue_poll_start
-                self._benchmark.add_duration("queue.poll", poll_duration)
 
+            chunk_index = self._benchmark.next_chunk_index()
+            chunk_wall_start = time.perf_counter()
+            chunk_audio_span = 0.0
+            processed_results = 0
+            drop_count = 0
+            len_results = 0
+            chunk_processed = False
+
+            # Here we have a chunk to process
             try:
-                with self._state_lock:
-                    current_generation = self._generation
-                if chunk_generation != current_generation:
-                    continue
-
-                chunk_start = time.perf_counter()
-                if self._base_ts is None:
+                with self._benchmark.section("chunk.total"):
                     with self._state_lock:
-                        if self._base_ts is None:
-                            self._base_ts = time.monotonic()
+                        current_generation = self._generation
 
-                pcm = np.asarray(chunk).squeeze(0)
-                chunk_audio_span = float(pcm.shape[-1]) / float(sr) if sr > 0 else 0.0
-                with self._benchmark.section("sway.feed"):
-                    with self._sway_lock:
-                        results = self.sway.feed(pcm, sr)
+                    if chunk_generation != current_generation:
+                        continue
 
-                i = 0
-                while i < len(results):
-                    iteration_start = time.perf_counter()
-                    with self._state_lock:
-                        if self._generation != current_generation:
-                            break
-                        base_ts = self._base_ts
-                        hops_done = self._hops_done
-
-                    if base_ts is None:
-                        base_ts = time.monotonic()
+                    if self._base_ts is None:
                         with self._state_lock:
                             if self._base_ts is None:
-                                self._base_ts = base_ts
-                                hops_done = self._hops_done
+                                self._base_ts = time.monotonic()
 
-                    target = base_ts + MOVEMENT_LATENCY_S + hops_done * hop_dt
-                    now = time.monotonic()
+                    pcm = np.asarray(chunk).squeeze(0)
+                    # Each chunk is ~250 ms of audio, so with a 10 ms hop we generally get ~25 offsets per sway call.
+                    chunk_audio_span = float(pcm.shape[-1]) / float(sr) if sr > 0 else 0.0
+                    with self._benchmark.section("chunk.sway.feed"):
+                        with self._sway_lock:
+                            results = self.sway.feed(pcm, sr)
+                    len_results = len(results)
 
-                    if now - target >= hop_dt:
-                        lag_hops = int((now - target) / hop_dt)
-                        drop = min(lag_hops, len(results) - i - 1)
-                        if drop > 0:
-                            with self._state_lock:
-                                self._hops_done += drop
-                                hops_done = self._hops_done
-                            i += drop
-                            continue
-
-                    if target > now:
-                        sleep_duration = target - now
-                        sleep_start = time.perf_counter()
-                        time.sleep(sleep_duration)
-                        self._benchmark.add_duration("schedule.sleep", time.perf_counter() - sleep_start)
+                    i = 0
+                    chunk_processed = True
+                    while i < len_results:
+                        iteration_start = time.perf_counter()
                         with self._state_lock:
                             if self._generation != current_generation:
+                                chunk_processed = False
+                                break
+                            base_ts = self._base_ts
+                            hops_done = self._hops_done
+
+                        if base_ts is None:
+                            base_ts = time.monotonic()
+                            with self._state_lock:
+                                if self._base_ts is None:
+                                    self._base_ts = base_ts
+                                    hops_done = self._hops_done
+
+                        target = base_ts + MOVEMENT_LATENCY_S + hops_done * hop_dt
+                        now = time.monotonic()
+
+                        if now - target >= hop_dt:
+                            # We're late for the scheduled hop, so drop older offsets to catch up.
+                            lag_hops = int((now - target) / hop_dt)
+                            drop = min(lag_hops, len_results - i - 1)
+                            if drop > 0:
+                                drop_count += drop
+                                with self._state_lock:
+                                    self._hops_done += drop
+                                    hops_done = self._hops_done
+                                i += drop
+                                continue
+
+                        if target > now:
+                            # We're ahead of schedule, so wait until the hop should be applied.
+                            sleep_duration = target - now
+                            sleep_start = time.perf_counter()
+                            time.sleep(sleep_duration)
+                            self._benchmark.add_duration("chunk.schedule.sleep", time.perf_counter() - sleep_start)
+                            with self._state_lock:
+                                if self._generation != current_generation:
+                                    chunk_processed = False
+                                    break
+
+                        r = results[i]
+                        offsets = (
+                            r["x_mm"] / 1000.0,
+                            r["y_mm"] / 1000.0,
+                            r["z_mm"] / 1000.0,
+                            r["roll_rad"],
+                            r["pitch_rad"],
+                            r["yaw_rad"],
+                        )
+
+                        with self._state_lock:
+                            if self._generation != current_generation:
+                                chunk_processed = False
                                 break
 
-                    r = results[i]
-                    offsets = (
-                        r["x_mm"] / 1000.0,
-                        r["y_mm"] / 1000.0,
-                        r["z_mm"] / 1000.0,
-                        r["roll_rad"],
-                        r["pitch_rad"],
-                        r["yaw_rad"],
-                    )
+                        with self._benchmark.section("chunk.apply.offsets"):
+                            self._apply_offsets(offsets)
 
-                    with self._state_lock:
-                        if self._generation != current_generation:
-                            break
-
-                    with self._benchmark.section("apply.offsets"):
-                        self._apply_offsets(offsets)
-
-                    with self._state_lock:
-                        self._hops_done += 1
-                    i += 1
-                    self._benchmark.add_duration("result.iteration", time.perf_counter() - iteration_start)
+                        with self._state_lock:
+                            self._hops_done += 1
+                        processed_results += 1
+                        i += 1
+                        self._benchmark.add_duration("chunk.result.iteration", time.perf_counter() - iteration_start)
             finally:
                 queue_ref.task_done()
-                if chunk_start is not None:
-                    chunk_duration = time.perf_counter() - chunk_start
-                    self._benchmark.add_duration("chunk.total", chunk_duration)
-                    if chunk_audio_span > 0:
-                        ratio = chunk_duration / chunk_audio_span if chunk_audio_span > 0 else 0.0
-                        with self._realtime_lock:
-                            self._realtime_audio_total += chunk_audio_span
-                            self._realtime_compute_total += chunk_duration
-                            self._realtime_chunks += 1
-                            self._realtime_max_ratio = max(self._realtime_max_ratio, ratio)
-                            if ratio > 1.0:
-                                self._realtime_overruns += 1
-                            diff = chunk_audio_span - chunk_duration
-                            if diff >= 0:
-                                self._realtime_slack_total += diff
-                                self._realtime_worst_slack = max(self._realtime_worst_slack, diff)
-                            else:
-                                deficit = -diff
-                                self._realtime_deficit_total += deficit
-                                self._realtime_worst_deficit = max(self._realtime_worst_deficit, deficit)
+                chunk_duration = time.perf_counter() - chunk_wall_start
+                if chunk_processed:
+                    self._benchmark.record_chunk(processed_results, len_results)
+                print(
+                    self._benchmark.chunk_summary(
+                        chunk_index,
+                        chunk_audio_span,
+                        chunk_duration,
+                        processed_results,
+                        len_results,
+                        drop_count,
+                        chunk_processed,
+                    ),
+                    flush=True,
+                )
+            # Here we finished processing the chunk
         print("Head wobbler thread exited", flush=True)
 
     '''

--- a/src/reachy_mini_conversation_app/audio/head_wobbler_benchmark.py
+++ b/src/reachy_mini_conversation_app/audio/head_wobbler_benchmark.py
@@ -1,0 +1,198 @@
+"""Benchmark helpers for the head wobbler."""
+
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator
+
+
+@dataclass
+class _SectionStat:
+    """Aggregated statistics for a benchmark section."""
+
+    count: int = 0
+    total: float = 0.0
+    mean: float = 0.0
+    m2: float = 0.0
+    minimum: float = float("inf")
+    maximum: float = float("-inf")
+
+    def update(self, duration: float) -> None:
+        self.count += 1
+        delta = duration - self.mean
+        self.mean += delta / self.count
+        self.m2 += delta * (duration - self.mean)
+        self.total += duration
+        self.minimum = min(self.minimum, duration)
+        self.maximum = max(self.maximum, duration)
+
+    def variance(self) -> float:
+        if self.count == 0:
+            return 0.0
+        return self.m2 / self.count
+
+    def snapshot(self) -> dict[str, float]:
+        if self.count == 0:
+            return {
+                "count": 0.0,
+                "avg_s": 0.0,
+                "var_s2": 0.0,
+                "total_s": 0.0,
+                "min_s": 0.0,
+                "max_s": 0.0,
+            }
+
+        return {
+            "count": float(self.count),
+            "avg_s": self.mean,
+            "var_s2": self.variance(),
+            "total_s": self.total,
+            "min_s": self.minimum,
+            "max_s": self.maximum,
+        }
+
+
+class _TimingCollector:
+    """Context-manager driven timing collector."""
+
+    def __init__(self, enabled: bool) -> None:
+        self.enabled = enabled
+        self._stats: dict[str, _SectionStat] = {}
+        self._lock = threading.Lock()
+
+    def _record(self, name: str, duration: float) -> None:
+        with self._lock:
+            stat = self._stats.setdefault(name, _SectionStat())
+            stat.update(duration)
+
+    @contextmanager
+    def section(self, name: str) -> Iterator[None]:
+        if not self.enabled:
+            yield
+            return
+
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._record(name, time.perf_counter() - start)
+
+    def add_duration(self, name: str, duration: float) -> None:
+        if not self.enabled:
+            return
+        if duration < 0:
+            duration = 0.0
+        self._record(name, duration)
+
+    def snapshot(self) -> dict[str, dict[str, float]]:
+        if not self.enabled:
+            return {}
+        with self._lock:
+            return {name: stat.snapshot() for name, stat in self._stats.items()}
+
+    def format_report(self) -> str:
+        snap = self.snapshot()
+        if not snap:
+            return "Head wobble benchmark enabled but no samples recorded"
+
+        total_sum = sum(section["total_s"] for section in snap.values())
+        lines = ["Section                     Count    Avg (ms)   Var (ms^2)  Total (ms)   %Total  Min/Max (ms)"]
+        for name, stats in sorted(snap.items(), key=lambda item: item[1]["total_s"], reverse=True):
+            parts = name.split(".")
+            indent = "  " * (len(parts) - 1)
+            display = f"{indent}{name}"
+            avg_ms = stats["avg_s"] * 1000.0
+            var_ms = stats["var_s2"] * 1_000_000.0
+            total_ms = stats["total_s"] * 1000.0
+            min_ms = stats["min_s"] * 1000.0
+            max_ms = stats["max_s"] * 1000.0
+            pct = (stats["total_s"] / total_sum * 100.0) if total_sum else 0.0
+            lines.append(
+                f"{display:<27} {int(stats['count']):>6}  "
+                f"{avg_ms:>10.3f}  {var_ms:>11.3f}  {total_ms:>10.3f}  "
+                f"{pct:>6.2f}%  {min_ms:>5.2f}/{max_ms:>5.2f}",
+            )
+        return "\n".join(lines)
+
+
+class _ChunkCounters:
+    """Track chunk and offset counts for summary."""
+
+    def __init__(self) -> None:
+        self._chunks = 0
+        self._offsets_sent = 0
+        self._offsets_total = 0
+        self._lock = threading.Lock()
+
+    def record(self, processed_offsets: int, total_offsets: int) -> None:
+        with self._lock:
+            self._chunks += 1
+            self._offsets_sent += processed_offsets
+            self._offsets_total += total_offsets
+
+    def summary(self) -> tuple[int, int, int]:
+        with self._lock:
+            return self._chunks, self._offsets_sent, self._offsets_total
+
+
+class HeadWobblerDiagnostics:
+    """Wrapper exposing benchmark utilities to the head wobbler."""
+
+    def __init__(self, hop_ms: float, enabled: bool) -> None:
+        self.enabled = enabled
+        self._hop_ms = hop_ms
+        self._timing = _TimingCollector(enabled)
+        self._chunk_counter = 0
+        self._chunk_lock = threading.Lock()
+        self._chunk_counters = _ChunkCounters()
+
+    def section(self, name: str) -> Iterator[None]:
+        return self._timing.section(name)
+
+    def add_duration(self, name: str, duration: float) -> None:
+        self._timing.add_duration(name, duration)
+
+    def snapshot(self) -> dict[str, dict[str, float]]:
+        return self._timing.snapshot()
+
+    def benchmark_report(self) -> str:
+        hop_info = f"HOP_DT={self._hop_ms / 1000.0:.4f}s ({self._hop_ms:.1f} ms per offset)"
+        timer_report = self._timing.format_report()
+        chunks, offsets_sent, offsets_total = self._chunk_counters.summary()
+        footer = f"Chunks={chunks}, offsets_sent/total={offsets_sent}/{offsets_total}"
+        return f"{hop_info}\n{timer_report}\n{footer}"
+
+    def next_chunk_index(self) -> int:
+        with self._chunk_lock:
+            idx = self._chunk_counter
+            self._chunk_counter += 1
+            return idx
+
+    def record_chunk(self, processed_offsets: int, total_offsets: int) -> None:
+        self._chunk_counters.record(processed_offsets, total_offsets)
+
+    def chunk_summary(
+        self,
+        chunk_index: int,
+        audio_span: float,
+        duration: float,
+        processed_offsets: int,
+        total_offsets: int,
+        drops: int,
+        processed: bool,
+    ) -> str:
+        audio_ms = audio_span * 1000.0
+        duration_ms = duration * 1000.0
+        ratio_pct = (duration / audio_span * 100.0) if audio_span > 0 else 0.0
+        status = "OK" if processed and audio_span > 0 else "SKIPPED"
+        return (
+            f"Chunk#{chunk_index:05d} [{status}] "
+            f"audio={audio_ms:7.2f}ms "
+            f"wall={duration_ms:7.2f}ms "
+            f"ratio={ratio_pct:6.2f}% "
+            f"offsets={processed_offsets}/{total_offsets} "
+            f"drops={drops}"
+        )

--- a/src/reachy_mini_conversation_app/audio/head_wobbler_benchmark.py
+++ b/src/reachy_mini_conversation_app/audio/head_wobbler_benchmark.py
@@ -8,18 +8,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 
 
-DISPLAY_NAMES: dict[str, str] = {
-    "chunk.total": "chunk.total",
-    "chunk.main_calc.sway_feed": "(main calc) sway.feed",
-    "chunk.communicate.apply_offsets": "(communicate) apply.offsets",
-    "chunk.slack.sleep": "(slack) sleep",
-    "chunk.logic.rest": "(rest) logic",
-    "queue.wait": "queue.wait",
-    "receive.total": "receive.audio",
-    "receive.decode": "decode",
-    "receive.numpy_view": "numpy_view",
-}
-
 PARENT_SECTIONS: dict[str, str | None] = {
     "chunk.total": None,
     "chunk.main_calc.sway_feed": "chunk.total",
@@ -30,6 +18,13 @@ PARENT_SECTIONS: dict[str, str | None] = {
     "receive.total": None,
     "receive.decode": "receive.total",
     "receive.numpy_view": "receive.total",
+    "sway.feed.total": None,
+    "sway.feed.convert": "sway.feed.total",
+    "sway.feed.resample": "sway.feed.total",
+    "sway.feed.hop_processing": "sway.feed.total",
+    "sway.feed.hop.frame": "sway.feed.hop_processing",
+    "sway.feed.hop.vad_env": "sway.feed.hop_processing",
+    "sway.feed.hop.oscillators": "sway.feed.hop_processing",
 }
 
 
@@ -135,14 +130,13 @@ class _TimingCollector:
             parent_total = snap[parent]["total_s"] if parent and parent in snap else stats["total_s"]
             pct = (stats["total_s"] / parent_total * 100.0) if parent_total else 0.0
             indent = "  " if parent else ""
-            display = DISPLAY_NAMES.get(name, name)
             avg_ms = stats["avg_s"] * 1000.0
             var_ms = stats["var_s2"] * 1_000_000.0
             total_ms = stats["total_s"] * 1000.0
             min_ms = stats["min_s"] * 1000.0
             max_ms = stats["max_s"] * 1000.0
             lines.append(
-                f"{indent}{display:<25} {int(stats['count']):>6}  "
+                f"{indent}{name:<25} {int(stats['count']):>6}  "
                 f"{avg_ms:>10.3f}  {var_ms:>11.3f}  {total_ms:>10.3f}  "
                 f"{pct:>6.2f}%  {min_ms:>5.2f}/{max_ms:>5.2f}",
             )

--- a/src/reachy_mini_conversation_app/audio/speech_tapper.py
+++ b/src/reachy_mini_conversation_app/audio/speech_tapper.py
@@ -11,7 +11,7 @@ from numpy.typing import NDArray
 # Tunables
 SR = 16_000
 FRAME_MS = 20
-HOP_MS = 10
+HOP_MS = 50
 
 SWAY_MASTER = 1.5
 SENS_DB_OFFSET = +4.0


### PR DESCRIPTION
I'll be using this PR to document this work as I go. First benchmark:

```
Section                     Count    Avg (ms)   Var (ms^2)  Total (ms)   %Total  Min/Max (ms)
  chunk.total                  111     254.656     3952.351   28266.847   33.74%  149.50/699.94
  result.iteration            2810       9.729        5.927   27337.228   32.63%   0.01/79.72
  schedule.sleep              2761       9.867        4.326   27242.064   32.52%   0.25/79.67
  sway.feed                    111       8.267       24.609     917.659    1.10%   0.40/32.74
  apply.offsets               2810       0.003        0.000       8.739    0.01%   0.00/ 0.05
  queue.poll                   579       0.010        0.000       5.992    0.01%   0.00/ 0.06
  feed.decode                  111       0.028        0.000       3.112    0.00%   0.01/ 0.06
  feed.numpy_view              111       0.008        0.000       0.893    0.00%   0.00/ 0.02
Realtime status: WARN (avg utilization 100.4%, peak 160.3%, chunks=111, overruns=23, avg slack 0.06ms, peak slack 1.33ms, avg deficit 5.36ms, worst deficit 60.34ms)

```