### PR TITLE
feat(memory): add long-term memory persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,11 @@ HF_TOKEN=
 
 # To select a specific profile with custom instructions and tools, to be placed in profiles/<myprofile>/__init__.py
 REACHY_MINI_CUSTOM_PROFILE="example"
+
+# Long-term memory configuration
+# Path to the memory file (default: ~/.reachy_mini/memory.txt)
+# MEMORY_FILE_PATH=~/.reachy_mini/memory.txt
+# Maximum tokens for memory summary (default: 2000)
+# MEMORY_MAX_TOKENS=2000
+# Interval in seconds for automatic memory sync (default: 300 = 5 minutes)
+# MEMORY_SYNC_INTERVAL=300

--- a/README.md
+++ b/README.md
@@ -113,6 +113,31 @@ Some wheels (e.g. PyTorch) are large and require compatible CUDA or CPU builds�
 | `HF_TOKEN` | Optional token for Hugging Face models (only used with `--local-vision` flag, falls back to `huggingface-cli login`).
 | `LOCAL_VISION_MODEL` | Hugging Face model path for local vision processing (only used with `--local-vision` flag, defaults to `HuggingFaceTB/SmolVLM2-2.2B-Instruct`).
 
+### Long-Term Memory
+
+The app supports persistent memory across sessions. Reachy can remember information about the user from previous conversations.
+
+| Variable | Description |
+|----------|-------------|
+| `MEMORY_FILE_PATH` | Path to the memory file (defaults to `~/.reachy_mini/memory.txt`). |
+| `MEMORY_MAX_TOKENS` | Maximum tokens for memory summary (defaults to `2000`). |
+| `MEMORY_SYNC_INTERVAL` | Interval in seconds between memory syncs (defaults to `300` = 5 minutes). |
+
+**How it works:**
+1. During conversation, the app accumulates a transcript of the dialogue.
+2. Periodically (every `MEMORY_SYNC_INTERVAL` seconds) and at session close, the transcript is synthesized into a narrative summary using `gpt-4o-mini`.
+3. The summary is merged with existing memories and saved to `MEMORY_FILE_PATH`.
+4. On startup, memories are loaded and injected into the system prompt.
+
+**Memory format:**
+Memories are stored as a narrative summary (not a list of facts), making them natural for the LLM to process. Example:
+
+```
+L'utilisateur s'appelle Alice et travaille comme développeuse Python.
+Elle est passionnée par la robotique et développe actuellement un projet
+appelé "RobotArm". Elle préfère communiquer en français.
+```
+
 ## Running the app
 
 Activate your virtual environment, ensure the Reachy Mini robot (or simulator) is reachable, then launch:

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -34,6 +34,16 @@ class Config:
     REACHY_MINI_CUSTOM_PROFILE = os.getenv("REACHY_MINI_CUSTOM_PROFILE")
     logger.debug(f"Custom Profile: {REACHY_MINI_CUSTOM_PROFILE}")
 
+    # Long-term memory configuration
+    MEMORY_FILE_PATH: str = os.getenv(
+        "MEMORY_FILE_PATH", os.path.expanduser("~/.reachy_mini/memory.txt")
+    )
+    MEMORY_MAX_TOKENS: int = int(os.getenv("MEMORY_MAX_TOKENS", "2000"))
+    MEMORY_SYNC_INTERVAL: int = int(os.getenv("MEMORY_SYNC_INTERVAL", "300"))  # 5 min
+    logger.debug(
+        f"Memory: {MEMORY_FILE_PATH}, max_tokens={MEMORY_MAX_TOKENS}, sync_interval={MEMORY_SYNC_INTERVAL}s"
+    )
+
 
 config = Config()
 

--- a/src/reachy_mini_conversation_app/memory/__init__.py
+++ b/src/reachy_mini_conversation_app/memory/__init__.py
@@ -1,6 +1,7 @@
 """Long-term memory module for persisting user information across sessions."""
 
 from .store import load_memories, save_memories, estimate_tokens
+from .synthesizer import synthesize_conversation
 
 
-__all__ = ["load_memories", "save_memories", "estimate_tokens"]
+__all__ = ["load_memories", "save_memories", "estimate_tokens", "synthesize_conversation"]

--- a/src/reachy_mini_conversation_app/memory/__init__.py
+++ b/src/reachy_mini_conversation_app/memory/__init__.py
@@ -1,0 +1,6 @@
+"""Long-term memory module for persisting user information across sessions."""
+
+from .store import load_memories, save_memories, estimate_tokens
+
+
+__all__ = ["load_memories", "save_memories", "estimate_tokens"]

--- a/src/reachy_mini_conversation_app/memory/store.py
+++ b/src/reachy_mini_conversation_app/memory/store.py
@@ -1,0 +1,54 @@
+"""Memory storage utilities for reading and writing memory files."""
+
+import logging
+from pathlib import Path
+
+from reachy_mini_conversation_app.config import config
+
+
+logger = logging.getLogger(__name__)
+
+
+def load_memories() -> str:
+    """Load existing memory summary from file.
+
+    Returns:
+        The memory summary as a string, or empty string if no file exists.
+
+    """
+    path = Path(config.MEMORY_FILE_PATH)
+    if path.exists():
+        content = path.read_text(encoding="utf-8").strip()
+        logger.debug(f"Loaded memories from {path} ({len(content)} chars)")
+        return content
+    logger.debug(f"No memory file found at {path}")
+    return ""
+
+
+def save_memories(summary: str) -> None:
+    """Save memory summary to file, creating parent directories if needed.
+
+    Args:
+        summary: The memory summary to save.
+
+    """
+    path = Path(config.MEMORY_FILE_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(summary, encoding="utf-8")
+    logger.info(f"Memory saved to {path} ({len(summary)} chars)")
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count for text.
+
+    Uses a simple heuristic of ~4 characters per token, which is a reasonable
+    approximation for English and many other languages.
+
+    Args:
+        text: The text to estimate tokens for.
+
+    Returns:
+        Estimated number of tokens.
+
+    """
+    return len(text) // 4

--- a/src/reachy_mini_conversation_app/memory/synthesizer.py
+++ b/src/reachy_mini_conversation_app/memory/synthesizer.py
@@ -1,0 +1,109 @@
+"""Conversation synthesis for long-term memory using LLM."""
+
+import logging
+
+from openai import OpenAI
+
+from .store import load_memories, save_memories, estimate_tokens
+from reachy_mini_conversation_app.config import config
+
+
+logger = logging.getLogger(__name__)
+
+
+def synthesize_conversation(conversation_transcript: str) -> str:
+    """Synthesize conversation into memory, merging with existing memories.
+
+    Uses gpt-4o-mini to extract important facts from the conversation and
+    integrate them with existing memories into a coherent narrative summary.
+
+    Args:
+        conversation_transcript: The conversation text to analyze.
+
+    Returns:
+        The updated memory summary.
+
+    """
+    if not conversation_transcript.strip():
+        logger.debug("Empty conversation transcript, skipping synthesis")
+        return load_memories()
+
+    client = OpenAI()
+    existing = load_memories()
+
+    prompt = f"""You are a memory synthesis assistant. Analyze this conversation and update the user memory.
+
+Existing memory about the user:
+{existing if existing else "(No existing memories)"}
+
+Recent conversation:
+{conversation_transcript}
+
+Write an updated memory summary that:
+1. Extracts important facts about the user (name, preferences, interests, context)
+2. Integrates new information with existing memories
+3. Stays concise (max 500 words)
+4. Uses narrative style
+5. Keeps the same language as the conversation
+6. Only keeps information that would be useful in future conversations
+
+If the conversation contains no useful information to remember, return the existing memory unchanged.
+
+Updated memory summary:"""
+
+    logger.info("Synthesizing conversation into memory...")
+
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=800,
+        temperature=0.3,
+    )
+
+    updated = (response.choices[0].message.content or "").strip()
+
+    if not updated:
+        logger.warning("Empty response from LLM, keeping existing memory")
+        return existing
+
+    # Check token limit and condense if needed
+    estimated = estimate_tokens(updated)
+    if estimated > config.MEMORY_MAX_TOKENS:
+        logger.warning(
+            f"Memory exceeds token limit ({estimated} > {config.MEMORY_MAX_TOKENS}), "
+            "requesting condensed version"
+        )
+        updated = _condense_memory(client, updated)
+
+    save_memories(updated)
+    logger.info(f"Memory synthesized successfully ({estimate_tokens(updated)} tokens)")
+    return updated
+
+
+def _condense_memory(client: OpenAI, memory: str) -> str:
+    """Condense memory to fit within token limit.
+
+    Args:
+        client: OpenAI client instance.
+        memory: The memory text to condense.
+
+    Returns:
+        Condensed memory text.
+
+    """
+    prompt = f"""Condense this memory summary to be more concise while keeping the most important information.
+Target length: approximately {config.MEMORY_MAX_TOKENS * 4} characters.
+
+Memory to condense:
+{memory}
+
+Condensed memory:"""
+
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=600,
+        temperature=0.3,
+    )
+
+    return (response.choices[0].message.content or memory).strip()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,0 +1,120 @@
+"""Tests for memory store module."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestLoadMemories:
+    """Tests for load_memories function."""
+
+    def test_load_memories_file_exists(self, tmp_path: Path) -> None:
+        """Test loading memories when file exists."""
+        memory_file = tmp_path / "memory.txt"
+        memory_file.write_text("User is Alice, a developer.", encoding="utf-8")
+
+        with patch("reachy_mini_conversation_app.memory.store.config") as mock_config:
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            from reachy_mini_conversation_app.memory.store import load_memories
+
+            result = load_memories()
+            assert result == "User is Alice, a developer."
+
+    def test_load_memories_file_not_exists(self, tmp_path: Path) -> None:
+        """Test loading memories when file does not exist."""
+        memory_file = tmp_path / "nonexistent.txt"
+
+        with patch("reachy_mini_conversation_app.memory.store.config") as mock_config:
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            from reachy_mini_conversation_app.memory.store import load_memories
+
+            result = load_memories()
+            assert result == ""
+
+    def test_load_memories_strips_whitespace(self, tmp_path: Path) -> None:
+        """Test that loaded memories are stripped of whitespace."""
+        memory_file = tmp_path / "memory.txt"
+        memory_file.write_text("  User prefers Python.  \n\n", encoding="utf-8")
+
+        with patch("reachy_mini_conversation_app.memory.store.config") as mock_config:
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            from reachy_mini_conversation_app.memory.store import load_memories
+
+            result = load_memories()
+            assert result == "User prefers Python."
+
+
+class TestSaveMemories:
+    """Tests for save_memories function."""
+
+    def test_save_memories_creates_file(self, tmp_path: Path) -> None:
+        """Test saving memories creates the file."""
+        memory_file = tmp_path / "memory.txt"
+
+        with patch("reachy_mini_conversation_app.memory.store.config") as mock_config:
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            from reachy_mini_conversation_app.memory.store import save_memories
+
+            save_memories("User is Bob.")
+
+            assert memory_file.exists()
+            assert memory_file.read_text(encoding="utf-8") == "User is Bob."
+
+    def test_save_memories_creates_parent_directories(self, tmp_path: Path) -> None:
+        """Test saving memories creates parent directories if needed."""
+        memory_file = tmp_path / "subdir" / "nested" / "memory.txt"
+
+        with patch("reachy_mini_conversation_app.memory.store.config") as mock_config:
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            from reachy_mini_conversation_app.memory.store import save_memories
+
+            save_memories("User likes robotics.")
+
+            assert memory_file.exists()
+            assert memory_file.read_text(encoding="utf-8") == "User likes robotics."
+
+    def test_save_memories_overwrites_existing(self, tmp_path: Path) -> None:
+        """Test saving memories overwrites existing content."""
+        memory_file = tmp_path / "memory.txt"
+        memory_file.write_text("Old content", encoding="utf-8")
+
+        with patch("reachy_mini_conversation_app.memory.store.config") as mock_config:
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            from reachy_mini_conversation_app.memory.store import save_memories
+
+            save_memories("New content")
+
+            assert memory_file.read_text(encoding="utf-8") == "New content"
+
+
+class TestEstimateTokens:
+    """Tests for estimate_tokens function."""
+
+    def test_estimate_tokens_empty_string(self) -> None:
+        """Test token estimation for empty string."""
+        from reachy_mini_conversation_app.memory.store import estimate_tokens
+
+        assert estimate_tokens("") == 0
+
+    def test_estimate_tokens_short_text(self) -> None:
+        """Test token estimation for short text."""
+        from reachy_mini_conversation_app.memory.store import estimate_tokens
+
+        # 12 characters -> 3 tokens
+        assert estimate_tokens("Hello World!") == 3
+
+    def test_estimate_tokens_longer_text(self) -> None:
+        """Test token estimation for longer text."""
+        from reachy_mini_conversation_app.memory.store import estimate_tokens
+
+        # 100 characters -> 25 tokens
+        text = "a" * 100
+        assert estimate_tokens(text) == 25
+
+    def test_estimate_tokens_approximation(self) -> None:
+        """Test that token estimation is approximately 4 chars per token."""
+        from reachy_mini_conversation_app.memory.store import estimate_tokens
+
+        text = "This is a sample text for testing token estimation."
+        estimated = estimate_tokens(text)
+        # Should be roughly len(text) / 4
+        assert estimated == len(text) // 4

--- a/tests/test_memory_synthesizer.py
+++ b/tests/test_memory_synthesizer.py
@@ -1,0 +1,254 @@
+"""Tests for memory synthesizer module."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestSynthesizeConversation:
+    """Tests for synthesize_conversation function."""
+
+    def test_empty_transcript_returns_existing(self, tmp_path) -> None:
+        """Test that empty transcript returns existing memories without API call."""
+        memory_file = tmp_path / "memory.txt"
+        memory_file.write_text("Existing memories", encoding="utf-8")
+
+        with (
+            patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config,
+            patch("reachy_mini_conversation_app.memory.store.config") as mock_store_config,
+        ):
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            mock_config.MEMORY_MAX_TOKENS = 2000
+            mock_store_config.MEMORY_FILE_PATH = str(memory_file)
+
+            from reachy_mini_conversation_app.memory.synthesizer import (
+                synthesize_conversation,
+            )
+
+            result = synthesize_conversation("")
+
+            assert result == "Existing memories"
+
+    def test_empty_transcript_whitespace_only(self, tmp_path) -> None:
+        """Test that whitespace-only transcript is treated as empty."""
+        memory_file = tmp_path / "memory.txt"
+        memory_file.write_text("Existing memories", encoding="utf-8")
+
+        with (
+            patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config,
+            patch("reachy_mini_conversation_app.memory.store.config") as mock_store_config,
+        ):
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            mock_config.MEMORY_MAX_TOKENS = 2000
+            mock_store_config.MEMORY_FILE_PATH = str(memory_file)
+
+            from reachy_mini_conversation_app.memory.synthesizer import (
+                synthesize_conversation,
+            )
+
+            result = synthesize_conversation("   \n\t  ")
+
+            assert result == "Existing memories"
+
+    def test_synthesize_calls_openai(self, tmp_path) -> None:
+        """Test that synthesize_conversation calls OpenAI API."""
+        memory_file = tmp_path / "memory.txt"
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Updated memory summary"
+
+        with (
+            patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config,
+            patch("reachy_mini_conversation_app.memory.synthesizer.OpenAI") as mock_openai_class,
+            patch("reachy_mini_conversation_app.memory.store.config") as mock_store_config,
+        ):
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            mock_config.MEMORY_MAX_TOKENS = 2000
+            mock_store_config.MEMORY_FILE_PATH = str(memory_file)
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai_class.return_value = mock_client
+
+            from reachy_mini_conversation_app.memory.synthesizer import (
+                synthesize_conversation,
+            )
+
+            synthesize_conversation("User: Hello\nAssistant: Hi there!")
+
+            mock_client.chat.completions.create.assert_called_once()
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["model"] == "gpt-4o-mini"
+            assert "Hello" in call_kwargs["messages"][0]["content"]
+
+    def test_synthesize_saves_result(self, tmp_path) -> None:
+        """Test that synthesize_conversation saves the result to file."""
+        memory_file = tmp_path / "memory.txt"
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "New memory content"
+
+        with (
+            patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config,
+            patch("reachy_mini_conversation_app.memory.synthesizer.OpenAI") as mock_openai_class,
+            patch("reachy_mini_conversation_app.memory.store.config") as mock_store_config,
+        ):
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            mock_config.MEMORY_MAX_TOKENS = 2000
+            mock_store_config.MEMORY_FILE_PATH = str(memory_file)
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai_class.return_value = mock_client
+
+            from reachy_mini_conversation_app.memory.synthesizer import (
+                synthesize_conversation,
+            )
+
+            synthesize_conversation("User: My name is Alice")
+
+            assert memory_file.exists()
+            assert memory_file.read_text(encoding="utf-8") == "New memory content"
+
+    def test_synthesize_empty_response_keeps_existing(self, tmp_path) -> None:
+        """Test that empty LLM response preserves existing memory."""
+        memory_file = tmp_path / "memory.txt"
+        memory_file.write_text("Existing content", encoding="utf-8")
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+
+        with (
+            patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config,
+            patch("reachy_mini_conversation_app.memory.synthesizer.OpenAI") as mock_openai_class,
+            patch("reachy_mini_conversation_app.memory.store.config") as mock_store_config,
+        ):
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            mock_config.MEMORY_MAX_TOKENS = 2000
+            mock_store_config.MEMORY_FILE_PATH = str(memory_file)
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai_class.return_value = mock_client
+
+            from reachy_mini_conversation_app.memory.synthesizer import (
+                synthesize_conversation,
+            )
+
+            result = synthesize_conversation("Some conversation")
+
+            assert result == "Existing content"
+
+    def test_synthesize_none_response_keeps_existing(self, tmp_path) -> None:
+        """Test that None LLM response preserves existing memory."""
+        memory_file = tmp_path / "memory.txt"
+        memory_file.write_text("Existing content", encoding="utf-8")
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+
+        with (
+            patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config,
+            patch("reachy_mini_conversation_app.memory.synthesizer.OpenAI") as mock_openai_class,
+            patch("reachy_mini_conversation_app.memory.store.config") as mock_store_config,
+        ):
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            mock_config.MEMORY_MAX_TOKENS = 2000
+            mock_store_config.MEMORY_FILE_PATH = str(memory_file)
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai_class.return_value = mock_client
+
+            from reachy_mini_conversation_app.memory.synthesizer import (
+                synthesize_conversation,
+            )
+
+            result = synthesize_conversation("Some conversation")
+
+            assert result == "Existing content"
+
+
+class TestCondenseMemory:
+    """Tests for _condense_memory function."""
+
+    def test_condense_memory_calls_api(self) -> None:
+        """Test that _condense_memory calls OpenAI API."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Condensed memory"
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config:
+            mock_config.MEMORY_MAX_TOKENS = 500
+
+            from reachy_mini_conversation_app.memory.synthesizer import _condense_memory
+
+            result = _condense_memory(mock_client, "Very long memory text")
+
+            mock_client.chat.completions.create.assert_called_once()
+            assert result == "Condensed memory"
+
+    def test_condense_memory_returns_original_on_none(self) -> None:
+        """Test that _condense_memory returns original if API returns None."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = None
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config:
+            mock_config.MEMORY_MAX_TOKENS = 500
+
+            from reachy_mini_conversation_app.memory.synthesizer import _condense_memory
+
+            result = _condense_memory(mock_client, "Original memory")
+
+            assert result == "Original memory"
+
+
+class TestTokenLimitHandling:
+    """Tests for token limit handling in synthesize_conversation."""
+
+    def test_exceeds_token_limit_triggers_condensation(self, tmp_path) -> None:
+        """Test that exceeding token limit triggers condensation."""
+        memory_file = tmp_path / "memory.txt"
+
+        # Response that exceeds token limit (8004 chars = 2001 tokens > 2000)
+        long_response = "x" * 8004
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = long_response
+
+        condense_response = MagicMock()
+        condense_response.choices = [MagicMock()]
+        condense_response.choices[0].message.content = "Condensed"
+
+        with (
+            patch("reachy_mini_conversation_app.memory.synthesizer.config") as mock_config,
+            patch("reachy_mini_conversation_app.memory.synthesizer.OpenAI") as mock_openai_class,
+            patch("reachy_mini_conversation_app.memory.store.config") as mock_store_config,
+        ):
+            mock_config.MEMORY_FILE_PATH = str(memory_file)
+            mock_config.MEMORY_MAX_TOKENS = 2000
+            mock_store_config.MEMORY_FILE_PATH = str(memory_file)
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.side_effect = [mock_response, condense_response]
+            mock_openai_class.return_value = mock_client
+
+            from reachy_mini_conversation_app.memory.synthesizer import (
+                synthesize_conversation,
+            )
+
+            result = synthesize_conversation("Test conversation")
+
+            # Should have called API twice (synthesize + condense)
+            assert mock_client.chat.completions.create.call_count == 2
+            assert result == "Condensed"

--- a/tests/test_memory_synthesizer.py
+++ b/tests/test_memory_synthesizer.py
@@ -1,12 +1,13 @@
 """Tests for memory synthesizer module."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
 class TestSynthesizeConversation:
     """Tests for synthesize_conversation function."""
 
-    def test_empty_transcript_returns_existing(self, tmp_path) -> None:
+    def test_empty_transcript_returns_existing(self, tmp_path: Path) -> None:
         """Test that empty transcript returns existing memories without API call."""
         memory_file = tmp_path / "memory.txt"
         memory_file.write_text("Existing memories", encoding="utf-8")
@@ -27,7 +28,7 @@ class TestSynthesizeConversation:
 
             assert result == "Existing memories"
 
-    def test_empty_transcript_whitespace_only(self, tmp_path) -> None:
+    def test_empty_transcript_whitespace_only(self, tmp_path: Path) -> None:
         """Test that whitespace-only transcript is treated as empty."""
         memory_file = tmp_path / "memory.txt"
         memory_file.write_text("Existing memories", encoding="utf-8")
@@ -48,7 +49,7 @@ class TestSynthesizeConversation:
 
             assert result == "Existing memories"
 
-    def test_synthesize_calls_openai(self, tmp_path) -> None:
+    def test_synthesize_calls_openai(self, tmp_path: Path) -> None:
         """Test that synthesize_conversation calls OpenAI API."""
         memory_file = tmp_path / "memory.txt"
 
@@ -80,7 +81,7 @@ class TestSynthesizeConversation:
             assert call_kwargs["model"] == "gpt-4o-mini"
             assert "Hello" in call_kwargs["messages"][0]["content"]
 
-    def test_synthesize_saves_result(self, tmp_path) -> None:
+    def test_synthesize_saves_result(self, tmp_path: Path) -> None:
         """Test that synthesize_conversation saves the result to file."""
         memory_file = tmp_path / "memory.txt"
 
@@ -110,7 +111,7 @@ class TestSynthesizeConversation:
             assert memory_file.exists()
             assert memory_file.read_text(encoding="utf-8") == "New memory content"
 
-    def test_synthesize_empty_response_keeps_existing(self, tmp_path) -> None:
+    def test_synthesize_empty_response_keeps_existing(self, tmp_path: Path) -> None:
         """Test that empty LLM response preserves existing memory."""
         memory_file = tmp_path / "memory.txt"
         memory_file.write_text("Existing content", encoding="utf-8")
@@ -140,7 +141,7 @@ class TestSynthesizeConversation:
 
             assert result == "Existing content"
 
-    def test_synthesize_none_response_keeps_existing(self, tmp_path) -> None:
+    def test_synthesize_none_response_keeps_existing(self, tmp_path: Path) -> None:
         """Test that None LLM response preserves existing memory."""
         memory_file = tmp_path / "memory.txt"
         memory_file.write_text("Existing content", encoding="utf-8")
@@ -215,7 +216,7 @@ class TestCondenseMemory:
 class TestTokenLimitHandling:
     """Tests for token limit handling in synthesize_conversation."""
 
-    def test_exceeds_token_limit_triggers_condensation(self, tmp_path) -> None:
+    def test_exceeds_token_limit_triggers_condensation(self, tmp_path: Path) -> None:
         """Test that exceeding token limit triggers condensation."""
         memory_file = tmp_path / "memory.txt"
 


### PR DESCRIPTION
## Summary

Related to #1 

Add long-term memory feature allowing Reachy to remember information about the user across sessions.

**Implementation:**
- New `memory/` module with `store.py` (file I/O) and `synthesizer.py` (LLM synthesis)
- Automatic conversation synthesis using `gpt-4o-mini` (periodic + on shutdown)
- Memory injection into system prompt at session start
- Configurable via `MEMORY_FILE_PATH`, `MEMORY_MAX_TOKENS`, `MEMORY_SYNC_INTERVAL`

**How it works:**
1. Conversation transcript accumulates during the session
2. Every 5 minutes (configurable) and at shutdown, transcript is synthesized into a narrative summary
3. Summary is merged with existing memories and saved to `~/.reachy_mini/memory.txt`
4. On startup, memories are loaded and injected into the system prompt

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [x] CI green (Ruff, Tests, Mypy)
- [x] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [x] Updated `.env.example` if new config vars added

## Notes

Memory feature works across all profiles (global feature). Requires `OPENAI_API_KEY` for synthesis (uses `gpt-4o-mini`).

---

Made with ❤️ by [@goabonga](https://github.com/goabonga)

