### PR TITLE
ci: automate Hugging Face sync on release

### DIFF
--- a/.github/workflows/hf-sync.yml
+++ b/.github/workflows/hf-sync.yml
@@ -1,0 +1,42 @@
+name: Sync to Hugging Face Hub
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  bump_version:
+    if: "startsWith(github.event.head_commit.message, 'chore: release a new version') && !startsWith(github.event.head_commit.message, 'bump:')"
+    runs-on: ubuntu-latest
+    name: Bump version, create changelog and sync to HF
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          changelog_increment_filename: changes.md
+          changelog: true
+          debug: false
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: changes.md
+          tag_name: ${{ env.REVISION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync to Hugging Face Hub
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO_ID: ${{ vars.HF_REPO_ID }}
+        run: |
+          git remote add hf https://huggingface.co/spaces/${HF_REPO_ID} || true
+          git remote set-url hf https://user:${HF_TOKEN}@huggingface.co/spaces/${HF_REPO_ID}
+          git push hf main --force
+          git push hf --tags --force

--- a/README.md
+++ b/README.md
@@ -227,5 +227,12 @@ Note: The “Personality” panel updates the conversation instructions. Tool se
 - Execute the test suite: `pytest`.
 - When iterating on robot motions, keep the control loop responsive => offload blocking work using the helpers in `tools.py`.
 
+### Triggering a release
+To trigger the CI/CD pipeline (version bump, changelog generation, and Hugging Face sync), push an empty commit:
+```bash
+git commit --allow-empty -m "chore: release a new version"
+git push
+```
+
 ## License
 Apache 2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,3 +120,12 @@ ignore_missing_imports = true
 strict = true
 show_error_codes = true
 warn_unused_ignores = true
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.1.0"
+tag_format = "$version"
+version_files = [
+    "pyproject.toml:^version"
+]
+update_changelog_on_bump = true


### PR DESCRIPTION
## Summary

Related #175 

Automates synchronization between this repository and the Hugging Face space. When a release is triggered via `chore: release a new version` commit, the workflow bumps the version using commitizen, generates a changelog, creates a GitHub release, and pushes to the Hugging Face space.

**Changes:**
- Add GitHub Actions workflow (`hf-sync.yml`) triggered on develop branch
- Configure commitizen in `pyproject.toml` for conventional commits versioning
- Document release process in README

**Required configuration:**
- Secret: `HF_TOKEN` (Hugging Face write token)
- Variable: `HF_REPO_ID` (e.g., `pollen-robotics/reachy-mini-conversation-app`)

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI/CD
- [ ] Other

## Check before merging
### Basic
- [x] CI green (Ruff, Tests, Mypy)
- [x] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
This is a CI/CD change only - no runtime code is affected. The workflow will only run when:
1. A commit starting with `chore: release a new version` is pushed to develop
2. The commit does NOT start with `bump:` (to prevent infinite loops from commitizen auto-commits)

---

Made with ❤️ by [@goabonga](https://github.com/goabonga)
