### PR TITLE
Create automation to sync GitHub repo and Hugging Face Space

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -1,0 +1,28 @@
+name: Sync to Hugging Face Space
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: hf-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync with Hugging Face Space
+        uses: nateraw/huggingface-sync-action@v0.0.5
+        with:
+          github_repo_id: pollen-robotics/reachy_mini_conversation_app
+          huggingface_repo_id: alozowski/reachy_mini_conversation_app_test
+          hf_token: ${{ secrets.HF_TOKEN }}
+          repo_type: space
+          space_sdk: gradio
+          private: false


### PR DESCRIPTION
## Summary
This PR solves [issue 175](https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/175), so we can automatically sync this repository with [the same repository on hugging face hub](https://huggingface.co/spaces/pollen-robotics/reachy_mini_conversation_app)

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
For test purposes I use [a test space](https://huggingface.co/spaces/alozowski/reachy_mini_conversation_app_test) – to change to a production space if everything works well.
