### PR TITLE
fix: add auto-enable gradio flag for simulation mode

### DIFF
--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -90,13 +90,13 @@ def run(
             logger.error("Please check your configuration and try again.")
             sys.exit(1)
 
-    # Check if running in simulation mode without --gradio
-    if robot.client.get_status()["simulation_enabled"] and not args.gradio:
-        logger.error(
-            "Simulation mode requires Gradio interface. Please use --gradio flag when running in simulation mode."
-        )
-        robot.client.disconnect()
-        sys.exit(1)
+    # Auto-enable Gradio in simulation mode (both MuJoCo for deamon and mockup-sim for desktop app)
+    status = robot.client.get_status()
+    is_simulation = status.get("simulation_enabled", False) or status.get("mockup_sim_enabled", False)
+
+    if is_simulation and not args.gradio:
+        logger.info("Simulation mode detected. Automatically enabling gradio flag.")
+        args.gradio = True
 
     camera_worker, _, vision_manager = handle_vision_stuff(args, robot)
 


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->
fixes issue #197 
auto enable --gradio flag when using simualtion mode (both for deamon and desktop) for app to be used in simulation as well

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [x] CI green (Ruff, Tests, Mypy)
- [x] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)   --> cannot test without physical robot but this fix only affects simulation
- [x] Gradio UI (`--gradio`)
- [x] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
<!-- Optional: context, caveats, migration notes -->
