### PR TITLE
Migrate to official huggingface/hub-sync action

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -15,16 +15,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Checkout huggingface-sync-action fork
-        uses: actions/checkout@v4
-        with:
-          repository: alozowski/huggingface-sync-action
-          path: .github/actions/huggingface-sync-action
-
-      - name: Sync with Hugging Face Space
-        uses: ./.github/actions/huggingface-sync-action
+        uses: actions/checkout@v6
+      - name: Sync GitHub to Hugging Face Hub
+        uses: huggingface/hub-sync@v0.1.0
         with:
           github_repo_id: pollen-robotics/reachy_mini_conversation_app
           huggingface_repo_id: pollen-robotics/reachy_mini_conversation_app


### PR DESCRIPTION
Migrates from the [alozowski/huggingface-sync-action](https://github.com/alozowski/huggingface-sync-action) fork to the official [huggingface/hub-sync](https://github.com/marketplace/actions/sync-github-to-hugging-face-hub) action (v0.1.0). Also bumps actions/checkout from v4 to v6.

## Summary
<!-- What does this PR change and why? -->

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI/CD
- [ ] Other

## Check before merging
### Basic
- [x] CI green (Ruff, Tests, Mypy)
- [x] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added