### PR TITLE
Align mypy workflow with reachy-mini

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,18 @@
 name: Type check
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - "src/**"
+      - "tests/**"
+      - ".github/workflows/**"
+      - "pyproject.toml"
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/**"
+      - ".github/workflows/**"
+      - "pyproject.toml"
 
 permissions:
   contents: read
@@ -14,16 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@v5
 
       - name: Install deps (locked) incl. vision extras
         run: uv sync --frozen --group dev --extra all_vision
 
       - name: Run mypy
-        run: .venv/bin/mypy --pretty --show-error-codes .
+        run: uv run mypy


### PR DESCRIPTION
## Summary
Linked to https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/207. Replace `actions/setup-python` with python-version passed directly to `setup-uv`, bump `setup-uv` from v5 to v7, switch from `.venv/bin/mypy` with CLI flags to `uv run mypy` (flags are already covered by `[tool.mypy]` in `pyproject.toml`), and add path filters on push and pull_request to only trigger the workflow when relevant files change.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
<!-- Optional: context, caveats, migration notes -->
