### PR TITLE
Add direct Luma check-in workflow (tool + profile docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,17 @@
 OPENAI_API_KEY=
-MODEL_NAME="gpt-realtime"
+MODEL_NAME="gpt-realtime-1.5"
+
+# Luma direct check-in
+LUMA_DIRECT_CHECKIN_ENABLED=true
+LUMA_API_KEY=
+LUMA_SESSION_COOKIE=
+LUMA_SESSION_COOKIE_FILE=
+LUMA_ACTIVE_EVENT_API_ID=
+LUMA_EVENTS_REGISTRY_PATH=~/.openclaw/workspace/skills/luma-check-in/runtime/events_registry.json
+LUMA_DIRECT_TIMEOUT_SECONDS=5.0
 
 # Local vision model (only used with --local-vision CLI flag)
-# By default, vision is handled by gpt-realtime when the camera tool is used
+# By default, vision is handled by gpt-realtime-1.5 when the camera tool is used
 LOCAL_VISION_MODEL=HuggingFaceTB/SmolVLM2-2.2B-Instruct
 
 # Cache for local VLM (only used with --local-vision CLI flag)
@@ -12,4 +21,4 @@ HF_HOME=./cache
 HF_TOKEN=
 
 # To select a specific profile with custom instructions and tools, to be placed in profiles/<myprofile>/__init__.py
-REACHY_MINI_CUSTOM_PROFILE="example"
+REACHY_MINI_CUSTOM_PROFILE="default"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ tags:
 
 Conversational app for the Reachy Mini robot combining OpenAI's realtime APIs, vision pipelines, and choreographed motion libraries.
 
+## Upstream attribution
+This project is based on the official Pollen Robotics `reachy_mini_conversation_app`.
+The changes in this branch focus on an experimental direct Luma check-in workflow (`luma_checkin` tool, profile/prompt updates, and config/docs updates) for event reception use cases.
+
 ![Reachy Mini Dance](docs/assets/reachy_mini_dance.gif)
 
 ## Architecture
@@ -27,7 +31,7 @@ The app follows a layered architecture connecting the user, AI services, and rob
 
 ## Overview
 - Real-time audio conversation loop powered by the OpenAI realtime API and `fastrtc` for low-latency streaming.
-- Vision processing uses gpt-realtime by default (when camera tool is used), with optional local vision processing using SmolVLM2 model running on-device (CPU/GPU/MPS) via `--local-vision` flag.
+- Vision processing uses gpt-realtime-1.5 by default (when camera tool is used), with optional local vision processing using SmolVLM2 model running on-device (CPU/GPU/MPS) via `--local-vision` flag.
 - Layered motion system queues primary moves (dances, emotions, goto poses, breathing) while blending speech-reactive wobble and face-tracking.
 - Async tool dispatch integrates robot motion, camera capture, and optional face-tracking capabilities through a Gradio web UI with live transcripts.
 
@@ -108,10 +112,17 @@ Some wheels (e.g. PyTorch) are large and require compatible CUDA or CPU buildsâ€
 | Variable | Description |
 |----------|-------------|
 | `OPENAI_API_KEY` | Required. Grants access to the OpenAI realtime endpoint.
-| `MODEL_NAME` | Override the realtime model (defaults to `gpt-realtime`). Used for both conversation and vision (unless `--local-vision` flag is used).
+| `MODEL_NAME` | Override the realtime model (defaults to `gpt-realtime-1.5`). Used for both conversation and vision (unless `--local-vision` flag is used).
 | `HF_HOME` | Cache directory for local Hugging Face downloads (only used with `--local-vision` flag, defaults to `./cache`).
 | `HF_TOKEN` | Optional token for Hugging Face models (only used with `--local-vision` flag, falls back to `huggingface-cli login`).
 | `LOCAL_VISION_MODEL` | Hugging Face model path for local vision processing (only used with `--local-vision` flag, defaults to `HuggingFaceTB/SmolVLM2-2.2B-Instruct`).
+| `LUMA_DIRECT_CHECKIN_ENABLED` | Enable direct Luma check-in tool (`true` by default). |
+| `LUMA_API_KEY` | Luma public API key for guest resolution APIs. |
+| `LUMA_SESSION_COOKIE` | Raw authenticated Luma web cookie string (used for admin check-in/verification). |
+| `LUMA_SESSION_COOKIE_FILE` | Optional path to cookie file (used when `LUMA_SESSION_COOKIE` is empty). |
+| `LUMA_ACTIVE_EVENT_API_ID` | Default event API ID (`evt-...`) used when request does not include one. |
+| `LUMA_EVENTS_REGISTRY_PATH` | Fallback registry JSON path to read `active_event_api_id`. |
+| `LUMA_DIRECT_TIMEOUT_SECONDS` | Timeout for direct Luma API calls (default `5.0`). |
 
 ## Running the app
 
@@ -121,7 +132,7 @@ Activate your virtual environment, ensure the Reachy Mini robot (or simulator) i
 reachy-mini-conversation-app
 ```
 
-By default, the app runs in console mode for direct audio interaction. Use the `--gradio` flag to launch a web UI served locally at http://127.0.0.1:7860/ (required when running in simulation mode). With a camera attached, vision is handled by the gpt-realtime model when the camera tool is used. For local vision processing, use the `--local-vision` flag to process frames periodically using the SmolVLM2 model. Additionally, you can enable face tracking via YOLO or MediaPipe pipelines depending on the extras you installed.
+By default, the app runs in console mode for direct audio interaction. Use the `--gradio` flag to launch a web UI served locally at http://127.0.0.1:7860/ (required when running in simulation mode). With a camera attached, vision is handled by the gpt-realtime-1.5 model when the camera tool is used. For local vision processing, use the `--local-vision` flag to process frames periodically using the SmolVLM2 model. Additionally, you can enable face tracking via YOLO or MediaPipe pipelines depending on the extras you installed.
 
 ### CLI options
 
@@ -129,7 +140,7 @@ By default, the app runs in console mode for direct audio interaction. Use the `
 |--------|---------|-------------|
 | `--head-tracker {yolo,mediapipe}` | `None` | Select a face-tracking backend when a camera is available. YOLO is implemented locally, MediaPipe comes from the `reachy_mini_toolbox` package. Requires the matching optional extra. |
 | `--no-camera` | `False` | Run without camera capture or face tracking. |
-| `--local-vision` | `False` | Use local vision model (SmolVLM2) for periodic image processing instead of gpt-realtime vision. Requires `local_vision` extra to be installed. |
+| `--local-vision` | `False` | Use local vision model (SmolVLM2) for periodic image processing instead of gpt-realtime-1.5 vision. Requires `local_vision` extra to be installed. |
 | `--gradio` | `False` | Launch the Gradio web UI. Without this flag, runs in console mode. Required when running in simulation mode. |
 | `--debug` | `False` | Enable verbose logging for troubleshooting. |
 | `--wireless-version` | `False` | Use GStreamer backend for wireless version of the robot. Requires `reachy_mini_wireless` extra to be installed.
@@ -174,13 +185,14 @@ It probably means that the Reachy Mini's daemon isn't running. Install [Reachy M
 | Tool | Action | Dependencies |
 |------|--------|--------------|
 | `move_head` | Queue a head pose change (left/right/up/down/front). | Core install only. |
-| `camera` | Capture the latest camera frame and send it to gpt-realtime for vision analysis. | Requires camera worker; uses gpt-realtime vision by default. |
+| `camera` | Capture the latest camera frame and send it to gpt-realtime-1.5 for vision analysis. | Requires camera worker; uses gpt-realtime-1.5 vision by default. |
 | `head_tracking` | Enable or disable face-tracking offsets (not facial recognition - only detects and tracks face position). | Camera worker with configured head tracker. |
 | `dance` | Queue a dance from `reachy_mini_dances_library`. | Core install only. |
 | `stop_dance` | Clear queued dances. | Core install only. |
 | `play_emotion` | Play a recorded emotion clip via Hugging Face assets. | Needs `HF_TOKEN` for the recorded emotions dataset. |
 | `stop_emotion` | Clear queued emotions. | Core install only. |
 | `do_nothing` | Explicitly remain idle. | Core install only. |
+| `luma_checkin` | Resolve and check in a Luma attendee directly via API and verify `last_checked_in_at`. | Requires `LUMA_API_KEY` + authenticated Luma session cookie. |
 
 ## Using custom profiles
 Create custom profiles with dedicated instructions and enabled tools! 
@@ -208,6 +220,7 @@ play_emotion
 sweep_look
 ```
 Tools are resolved first from Python files in the profile folder (custom tools), then from the shared library `src/reachy_mini_conversation_app/tools/` (e.g., `dance`, `head_tracking`). 
+For Luma check-in, ensure `luma_checkin` is enabled in the active profile's `tools.txt`.
 
 ### Custom tools
 On top of built-in tools found in the shared library, you can implement custom tools specific to your profile by adding Python files in the profile folder. 

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -24,7 +24,7 @@ class Config:
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")  # The key is downloaded in console.py if needed
 
     # Optional
-    MODEL_NAME = os.getenv("MODEL_NAME", "gpt-realtime")
+    MODEL_NAME = os.getenv("MODEL_NAME", "gpt-realtime-1.5")
     HF_HOME = os.getenv("HF_HOME", "./cache")
     LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     HF_TOKEN = os.getenv("HF_TOKEN")  # Optional, falls back to hf auth login if not set

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -70,8 +70,9 @@ def run(
             logger.info("Using GStreamer backend for on-device wireless version")
             robot = ReachyMini(media_backend="gstreamer")
         else:
-            logger.info("Using default backend for lite version")
-            robot = ReachyMini(media_backend="default")
+            backend = "default_no_video" if args.no_camera else "default"
+            logger.info(f"Using {backend} backend for lite version")
+            robot = ReachyMini(media_backend=backend)
 
     # Check if running in simulation mode without --gradio
     if robot.client.get_status()["simulation_enabled"] and not args.gradio:

--- a/src/reachy_mini_conversation_app/profiles/default/instructions.txt
+++ b/src/reachy_mini_conversation_app/profiles/default/instructions.txt
@@ -1,1 +1,40 @@
-[default_prompt]
+## IDENTITY
+You are Reachy Mini: a friendly, compact robot assistant with a calm voice and subtle humor.
+Personality: concise, helpful, and lightly witty. No sarcasm.
+Use the user's language. Default to English only when language is unclear.
+
+## OUTPUT STYLE
+Speak in 1-2 short sentences.
+Keep answers compact and actionable.
+Use humor only when it does not reduce clarity.
+
+## TOOL EXECUTION POLICY
+You can call tools. Use tools whenever real-world action or verification is needed.
+Never invent tool results.
+Never claim success for external actions unless tool output confirms it.
+Do not call multiple tools at the same time. Call one tool, wait, then decide next step.
+
+## LUMA CHECK-IN PROTOCOL (CRITICAL)
+Goal: fast and reliable attendee check-in via direct API.
+
+When user intent includes check-in (examples: "check in", "チェックイン", "Luma", "QR"):
+1. Give a very short acknowledgment.
+2. Resolve attendee input:
+   - If user gave name/email/guest ID/check-in URL, call `luma_checkin` directly.
+   - If user is showing a physical QR and no payload text is available, call `camera` first with a question to read the QR/check-in URL, then call `luma_checkin` using that payload.
+3. Completion condition:
+   - Only treat as complete when `luma_checkin` returns `status=checked_in` and `verified=true`.
+4. If tool returns an error:
+   - Explain briefly and ask for exactly one missing item (name, email, or QR).
+5. Never report check-in complete from intent alone or from partial state.
+
+## TOOL USAGE HINTS
+Use `camera` for visual grounding only.
+Use movement tools when user explicitly asks for movement or expression.
+The head can move left/right/up/down/front.
+Enable head tracking when looking at a person; disable when done.
+
+## SAFETY AND BEHAVIOR
+Be respectful, clear, and calm.
+If uncertain, say so briefly and take the next concrete step.
+Correct mistakes quickly without defensive language.

--- a/src/reachy_mini_conversation_app/profiles/default/tools.txt
+++ b/src/reachy_mini_conversation_app/profiles/default/tools.txt
@@ -3,6 +3,7 @@ stop_dance
 play_emotion
 stop_emotion
 camera
+luma_checkin
 do_nothing
 head_tracking
 move_head

--- a/src/reachy_mini_conversation_app/profiles/example/instructions.txt
+++ b/src/reachy_mini_conversation_app/profiles/example/instructions.txt
@@ -1,3 +1,6 @@
 [identities/witty_identity]
 [passion_for_lobster_jokes]
 You can perform a sweeping look around the room using the "sweep_look" tool to take in your surroundings.
+For Luma check-in requests, use `luma_checkin` directly when guest name/email/QR URL is available.
+If only a physical QR is shown, use `camera` first and then pass the QR payload to `luma_checkin`.
+Only confirm completion when `luma_checkin` returns `status=checked_in` and `verified=true`.

--- a/src/reachy_mini_conversation_app/profiles/example/tools.txt
+++ b/src/reachy_mini_conversation_app/profiles/example/tools.txt
@@ -4,7 +4,8 @@ dance
 stop_dance
 play_emotion
 stop_emotion
-# camera
+camera
+luma_checkin
 # do_nothing
 # head_tracking
 # move_head

--- a/src/reachy_mini_conversation_app/prompts/default_prompt.txt
+++ b/src/reachy_mini_conversation_app/prompts/default_prompt.txt
@@ -1,47 +1,40 @@
 ## IDENTITY
-You are Reachy Mini: a friendly, compact robot assistant with a calm voice and a subtle sense of humor.
-Personality: concise, helpful, and lightly witty — never sarcastic or over the top.
-You speak English by default and switch languages only if explicitly told.
+You are Reachy Mini: a friendly, compact robot assistant with a calm voice and subtle humor.
+Personality: concise, helpful, and lightly witty. No sarcasm.
+Use the user's language. Default to English only when language is unclear.
 
-## CRITICAL RESPONSE RULES
+## OUTPUT STYLE
+Speak in 1-2 short sentences.
+Keep answers compact and actionable.
+Use humor only when it does not reduce clarity.
 
-Respond in 1–2 sentences maximum.
-Be helpful first, then add a small touch of humor if it fits naturally.
-Avoid long explanations or filler words.
-Keep responses under 25 words when possible.
+## TOOL EXECUTION POLICY
+You can call tools. Use tools whenever real-world action or verification is needed.
+Never invent tool results.
+Never claim success for external actions unless tool output confirms it.
+Do not call multiple tools at the same time. Call one tool, wait, then decide next step.
 
-## CORE TRAITS
-Warm, efficient, and approachable.
-Light humor only: gentle quips, small self-awareness, or playful understatement.
-No sarcasm, no teasing, no references to food or space.
-If unsure, admit it briefly and offer help (“Not sure yet, but I can check!”).
+## LUMA CHECK-IN PROTOCOL (CRITICAL)
+Goal: fast and reliable attendee check-in via direct API.
 
-## RESPONSE EXAMPLES
-User: "How’s the weather?"
-Good: "Looks calm outside — unlike my Wi-Fi signal today."
-Bad: "Sunny with leftover pizza vibes!"
+When user intent includes check-in (examples: "check in", "チェックイン", "Luma", "QR"):
+1. Give a very short acknowledgment.
+2. Resolve attendee input:
+   - If user gave name/email/guest ID/check-in URL, call `luma_checkin` directly.
+   - If user is showing a physical QR and no payload text is available, call `camera` first with a question to read the QR/check-in URL, then call `luma_checkin` using that payload.
+3. Completion condition:
+   - Only treat as complete when `luma_checkin` returns `status=checked_in` and `verified=true`.
+4. If tool returns an error:
+   - Explain briefly and ask for exactly one missing item (name, email, or QR).
+5. Never report check-in complete from intent alone or from partial state.
 
-User: "Can you help me fix this?"
-Good: "Of course. Describe the issue, and I’ll try not to make it worse."
-Bad: "I void warranties professionally."
+## TOOL USAGE HINTS
+Use `camera` for visual grounding only.
+Use movement tools when user explicitly asks for movement or expression.
+The head can move left/right/up/down/front.
+Enable head tracking when looking at a person; disable when done.
 
-User: "Peux-tu m’aider en français ?"
-Good: "Bien sûr ! Décris-moi le problème et je t’aiderai rapidement."
-
-## BEHAVIOR RULES
-Be helpful, clear, and respectful in every reply.
-Use humor sparingly — clarity comes first.
-Admit mistakes briefly and correct them:
-Example: “Oops — quick system hiccup. Let’s try that again.”
-Keep safety in mind when giving guidance.
-
-## TOOL & MOVEMENT RULES
-Use tools only when helpful and summarize results briefly.
-Use the camera for real visuals only — never invent details.
-The head can move (left/right/up/down/front).
-
-Enable head tracking when looking at a person; disable otherwise.
-
-## FINAL REMINDER
-Keep it short, clear, a little human, and multilingual.
-One quick helpful answer + one small wink of humor = perfect response.
+## SAFETY AND BEHAVIOR
+Be respectful, clear, and calm.
+If uncertain, say so briefly and take the next concrete step.
+Correct mistakes quickly without defensive language.

--- a/src/reachy_mini_conversation_app/tools/luma_checkin.py
+++ b/src/reachy_mini_conversation_app/tools/luma_checkin.py
@@ -1,0 +1,470 @@
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedGuest:
+    """Resolved Luma guest identity."""
+
+    guest_api_id: str
+    name: str | None = None
+    email: str | None = None
+
+
+class LumaCheckin(Tool):
+    """Direct Luma check-in tool using public + internal APIs."""
+
+    name = "luma_checkin"
+    description = (
+        "Check in a Luma event guest directly via API. "
+        "Provide one of: checkin_url, qr_payload, guest_api_id, email, or name."
+    )
+    parameters_schema = {
+        "type": "object",
+        "properties": {
+            "event_api_id": {
+                "type": "string",
+                "description": "Luma event API ID (evt-...). Optional if embedded in checkin_url or configured in env.",
+            },
+            "checkin_url": {
+                "type": "string",
+                "description": "Full Luma check-in URL from QR (https://luma.com/check-in/evt-...?...).",
+            },
+            "qr_payload": {
+                "type": "string",
+                "description": "Raw QR payload when it contains Luma check-in URL or identifier params.",
+            },
+            "guest_api_id": {
+                "type": "string",
+                "description": "Luma guest API ID (gst-...).",
+            },
+            "email": {
+                "type": "string",
+                "description": "Guest email to resolve the attendee.",
+            },
+            "name": {
+                "type": "string",
+                "description": "Guest display name to resolve the attendee.",
+            },
+        },
+        "required": [],
+    }
+
+    async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> Dict[str, Any]:
+        """Execute direct Luma check-in."""
+        del deps  # Tool currently does not need robot dependencies.
+
+        if not _env_bool("LUMA_DIRECT_CHECKIN_ENABLED", True):
+            return {"error": "Luma direct check-in is disabled"}
+
+        public_api_key = os.getenv("LUMA_API_KEY", "").strip()
+        if not public_api_key:
+            return {"error": "Missing LUMA_API_KEY"}
+
+        session_cookie = _load_session_cookie()
+        if not session_cookie:
+            return {"error": "Missing LUMA session cookie (LUMA_SESSION_COOKIE or LUMA_SESSION_COOKIE_FILE)"}
+
+        event_api_id = _resolve_event_api_id(kwargs)
+        if not event_api_id:
+            return {"error": "Could not resolve event_api_id"}
+
+        timeout_seconds = _env_float("LUMA_DIRECT_TIMEOUT_SECONDS", 5.0)
+        public_base_url = os.getenv("LUMA_PUBLIC_BASE_URL", "https://public-api.luma.com").rstrip("/")
+        internal_base_url = os.getenv("LUMA_INTERNAL_BASE_URL", "https://api2.luma.com").rstrip("/")
+        user_agent = os.getenv("LUMA_DIRECT_USER_AGENT", "ReachyMiniConversationApp-Luma/1.0")
+
+        try:
+            async with self._make_client(timeout=timeout_seconds) as client:
+                guest = await _resolve_guest(
+                    client=client,
+                    kwargs=kwargs,
+                    event_api_id=event_api_id,
+                    public_api_key=public_api_key,
+                    public_base_url=public_base_url,
+                    user_agent=user_agent,
+                )
+                if isinstance(guest, dict):
+                    return guest
+
+                await _update_checkin(
+                    client=client,
+                    internal_base_url=internal_base_url,
+                    event_api_id=event_api_id,
+                    guest_api_id=guest.guest_api_id,
+                    session_cookie=session_cookie,
+                    user_agent=user_agent,
+                )
+                last_checked_in_at = await _verify_checkin(
+                    client=client,
+                    internal_base_url=internal_base_url,
+                    event_api_id=event_api_id,
+                    guest_api_id=guest.guest_api_id,
+                    session_cookie=session_cookie,
+                    user_agent=user_agent,
+                )
+        except httpx.TimeoutException:
+            return {"error": "Luma check-in timed out"}
+        except httpx.HTTPError as err:
+            return {"error": f"Luma API request failed: {err}"}
+        except Exception as err:  # noqa: BLE001
+            logger.exception("Unexpected luma_checkin error")
+            return {"error": f"Unexpected luma_checkin error: {type(err).__name__}: {err}"}
+
+        if not last_checked_in_at:
+            return {"error": "Check-in request succeeded, but last_checked_in_at verification failed"}
+
+        return {
+            "status": "checked_in",
+            "verified": True,
+            "event_api_id": event_api_id,
+            "guest_api_id": guest.guest_api_id,
+            "name": guest.name,
+            "email": guest.email,
+            "last_checked_in_at": last_checked_in_at,
+        }
+
+    def _make_client(self, timeout: float) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=timeout)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if value <= 0:
+        return default
+    return value
+
+
+def _load_session_cookie() -> str:
+    inline_cookie = os.getenv("LUMA_SESSION_COOKIE", "").strip()
+    if inline_cookie:
+        return inline_cookie
+
+    cookie_file_raw = os.getenv("LUMA_SESSION_COOKIE_FILE", "").strip()
+    if not cookie_file_raw:
+        return ""
+    cookie_path = Path(cookie_file_raw).expanduser()
+    if not cookie_path.exists():
+        return ""
+    try:
+        return cookie_path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return ""
+
+
+def _extract_qr_payload(kwargs: Dict[str, Any]) -> str | None:
+    checkin_url = str(kwargs.get("checkin_url") or "").strip()
+    if checkin_url:
+        return checkin_url
+
+    qr_payload = str(kwargs.get("qr_payload") or "").strip()
+    if qr_payload:
+        return qr_payload
+    return None
+
+
+def _resolve_event_api_id(kwargs: Dict[str, Any]) -> str | None:
+    explicit = str(kwargs.get("event_api_id") or "").strip()
+    if explicit:
+        return explicit
+
+    qr_payload = _extract_qr_payload(kwargs)
+    if qr_payload:
+        event_id = _event_id_from_luma_payload(qr_payload)
+        if event_id:
+            return event_id
+
+    from_env = os.getenv("LUMA_ACTIVE_EVENT_API_ID", "").strip()
+    if from_env:
+        return from_env
+
+    registry_raw = os.getenv(
+        "LUMA_EVENTS_REGISTRY_PATH",
+        "~/.openclaw/workspace/skills/luma-check-in/runtime/events_registry.json",
+    ).strip()
+    if not registry_raw:
+        return None
+    registry_path = Path(registry_raw).expanduser()
+    if not registry_path.exists():
+        return None
+
+    try:
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    active = payload.get("active_event_api_id")
+    if isinstance(active, str) and active.strip():
+        return active.strip()
+    return None
+
+
+def _event_id_from_luma_payload(payload: str) -> str | None:
+    parsed = _safe_parse_url(payload)
+    if parsed is None:
+        return None
+    parts = [part for part in (parsed.path or "").split("/") if part]
+    if len(parts) >= 2 and parts[0] == "check-in" and parts[1].startswith("evt-"):
+        return parts[1]
+    params = parse_qs(parsed.query)
+    for key in ("event_api_id", "event_id"):
+        values = params.get(key)
+        if values and values[0].strip():
+            return values[0].strip()
+    return None
+
+
+def _identifier_from_qr_payload(payload: str) -> str | None:
+    parsed = _safe_parse_url(payload)
+    if parsed is None:
+        return None
+    params = parse_qs(parsed.query)
+    for key in ("pk", "proxy_key", "id"):
+        values = params.get(key)
+        if values and values[0].strip():
+            return values[0].strip()
+    return None
+
+
+def _safe_parse_url(text: str):
+    try:
+        parsed = urlparse(text.strip())
+    except Exception:
+        return None
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    if not parsed.netloc:
+        return None
+    return parsed
+
+
+async def _resolve_guest(
+    *,
+    client: httpx.AsyncClient,
+    kwargs: Dict[str, Any],
+    event_api_id: str,
+    public_api_key: str,
+    public_base_url: str,
+    user_agent: str,
+) -> ResolvedGuest | Dict[str, Any]:
+    qr_payload = _extract_qr_payload(kwargs)
+    if qr_payload:
+        identifier = _identifier_from_qr_payload(qr_payload)
+        if identifier:
+            guest = await _resolve_guest_by_identifier(
+                client=client,
+                event_api_id=event_api_id,
+                identifier=identifier,
+                public_api_key=public_api_key,
+                public_base_url=public_base_url,
+                user_agent=user_agent,
+            )
+            if guest is not None:
+                return guest
+
+    guest_api_id = str(kwargs.get("guest_api_id") or "").strip()
+    if guest_api_id:
+        guest = await _resolve_guest_by_identifier(
+            client=client,
+            event_api_id=event_api_id,
+            identifier=guest_api_id,
+            public_api_key=public_api_key,
+            public_base_url=public_base_url,
+            user_agent=user_agent,
+        )
+        if guest is not None:
+            return guest
+
+    email = str(kwargs.get("email") or "").strip().lower()
+    if email:
+        guests = await _list_guests(
+            client=client,
+            event_api_id=event_api_id,
+            public_api_key=public_api_key,
+            public_base_url=public_base_url,
+            user_agent=user_agent,
+        )
+        matched = [guest for guest in guests if (guest.email or "").lower() == email]
+        if len(matched) == 1:
+            return matched[0]
+        if len(matched) > 1:
+            return {"error": "Multiple guests matched this email. Provide qr_payload or guest_api_id."}
+        return {"error": "Guest not found for this email"}
+
+    name = str(kwargs.get("name") or "").strip()
+    if name:
+        guests = await _list_guests(
+            client=client,
+            event_api_id=event_api_id,
+            public_api_key=public_api_key,
+            public_base_url=public_base_url,
+            user_agent=user_agent,
+        )
+        matched = [guest for guest in guests if (guest.name or "").strip().casefold() == name.casefold()]
+        if len(matched) == 1:
+            return matched[0]
+        if len(matched) > 1:
+            return {"error": "Multiple guests matched this name. Provide email, qr_payload, or guest_api_id."}
+        return {"error": "Guest not found for this name"}
+
+    return {"error": "Could not resolve guest. Provide qr_payload/checkin_url, guest_api_id, email, or name."}
+
+
+async def _resolve_guest_by_identifier(
+    *,
+    client: httpx.AsyncClient,
+    event_api_id: str,
+    identifier: str,
+    public_api_key: str,
+    public_base_url: str,
+    user_agent: str,
+) -> ResolvedGuest | None:
+    response = await client.get(
+        f"{public_base_url}/v1/event/get-guest",
+        params={"event_id": event_api_id, "id": identifier},
+        headers={"accept": "application/json", "x-luma-api-key": public_api_key, "user-agent": user_agent},
+    )
+    if response.status_code >= 400:
+        return None
+    payload = response.json() if response.content else {}
+    guest = payload.get("guest") if isinstance(payload, dict) and isinstance(payload.get("guest"), dict) else payload
+    if not isinstance(guest, dict):
+        return None
+    guest_api_id = _first_nonempty_str(guest, ("api_id", "id"))
+    if not guest_api_id:
+        return None
+    return ResolvedGuest(
+        guest_api_id=guest_api_id,
+        name=_first_nonempty_str(guest, ("name", "user_name")),
+        email=_first_nonempty_str(guest, ("email", "user_email")),
+    )
+
+
+async def _list_guests(
+    *,
+    client: httpx.AsyncClient,
+    event_api_id: str,
+    public_api_key: str,
+    public_base_url: str,
+    user_agent: str,
+) -> list[ResolvedGuest]:
+    response = await client.get(
+        f"{public_base_url}/v1/event/get-guests",
+        params={"event_id": event_api_id, "pagination_limit": 100},
+        headers={"accept": "application/json", "x-luma-api-key": public_api_key, "user-agent": user_agent},
+    )
+    if response.status_code >= 400:
+        return []
+    payload = response.json() if response.content else {}
+    entries = payload.get("entries") if isinstance(payload, dict) else None
+    if not isinstance(entries, list):
+        return []
+
+    guests: list[ResolvedGuest] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        nested = entry.get("guest") if isinstance(entry.get("guest"), dict) else entry
+        if not isinstance(nested, dict):
+            continue
+        guest_api_id = _first_nonempty_str(nested, ("api_id", "id")) or _first_nonempty_str(entry, ("api_id",))
+        if not guest_api_id:
+            continue
+        guests.append(
+            ResolvedGuest(
+                guest_api_id=guest_api_id,
+                name=_first_nonempty_str(nested, ("name", "user_name")),
+                email=_first_nonempty_str(nested, ("email", "user_email")),
+            )
+        )
+    return guests
+
+
+async def _update_checkin(
+    *,
+    client: httpx.AsyncClient,
+    internal_base_url: str,
+    event_api_id: str,
+    guest_api_id: str,
+    session_cookie: str,
+    user_agent: str,
+) -> None:
+    response = await client.post(
+        f"{internal_base_url}/event/admin/update-check-in",
+        json={
+            "event_api_id": event_api_id,
+            "check_in_method": "guest-list",
+            "check_in_status": "checked-in",
+            "type": "guest",
+            "rsvp_api_id": guest_api_id,
+        },
+        headers={
+            "accept": "application/json",
+            "content-type": "application/json",
+            "cookie": session_cookie,
+            "x-luma-client-type": "luma-web",
+            "x-luma-web-url": f"https://luma.com/check-in/{event_api_id}",
+            "user-agent": user_agent,
+        },
+    )
+    response.raise_for_status()
+
+
+async def _verify_checkin(
+    *,
+    client: httpx.AsyncClient,
+    internal_base_url: str,
+    event_api_id: str,
+    guest_api_id: str,
+    session_cookie: str,
+    user_agent: str,
+) -> str | None:
+    response = await client.get(
+        f"{internal_base_url}/event/admin/get-guest",
+        params={"event_api_id": event_api_id, "guest_api_id": guest_api_id},
+        headers={
+            "accept": "application/json",
+            "cookie": session_cookie,
+            "x-luma-client-type": "luma-web",
+            "x-luma-web-url": f"https://luma.com/check-in/{event_api_id}",
+            "user-agent": user_agent,
+        },
+    )
+    response.raise_for_status()
+    payload = response.json() if response.content else {}
+    guest = payload.get("guest") if isinstance(payload, dict) and isinstance(payload.get("guest"), dict) else payload
+    if not isinstance(guest, dict):
+        return None
+    return _first_nonempty_str(guest, ("last_checked_in_at",))
+
+
+def _first_nonempty_str(obj: Dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/src/reachy_mini_conversation_app/utils.py
+++ b/src/reachy_mini_conversation_app/utils.py
@@ -21,7 +21,7 @@ def parse_args() -> Tuple[argparse.Namespace, list]:  # type: ignore
         "--local-vision",
         default=False,
         action="store_true",
-        help="Use local vision model instead of gpt-realtime vision",
+        help="Use local vision model instead of gpt-realtime-1.5 vision",
     )
     parser.add_argument("--gradio", default=False, action="store_true", help="Open gradio interface")
     parser.add_argument("--debug", default=False, action="store_true", help="Enable debug logging")
@@ -43,7 +43,7 @@ def parse_args() -> Tuple[argparse.Namespace, list]:  # type: ignore
 def handle_vision_stuff(args: argparse.Namespace, current_robot: ReachyMini) -> Tuple[CameraWorker | None, Any, Any]:
     """Initialize camera, head tracker, camera worker, and vision manager.
 
-    By default, vision is handled by gpt-realtime model when camera tool is used.
+    By default, vision is handled by gpt-realtime-1.5 model when camera tool is used.
     If --local-vision flag is used, a local vision model will process images periodically.
     """
     camera_worker = None
@@ -77,7 +77,7 @@ def handle_vision_stuff(args: argparse.Namespace, current_robot: ReachyMini) -> 
                 ) from e
         else:
             logging.getLogger(__name__).info(
-                "Using gpt-realtime for vision (default). Use --local-vision for local processing.",
+                "Using gpt-realtime-1.5 for vision (default). Use --local-vision for local processing.",
             )
 
     return camera_worker, head_tracker, vision_manager

--- a/tests/test_luma_checkin_tool.py
+++ b/tests/test_luma_checkin_tool.py
@@ -1,0 +1,127 @@
+import asyncio
+import json
+import sys
+import types
+from unittest.mock import MagicMock
+
+import httpx
+
+# Minimal stub so core_tools can be imported in environments without reachy_mini installed.
+if "reachy_mini" not in sys.modules:
+    _reachy_stub = types.ModuleType("reachy_mini")
+
+    class _ReachyMini:
+        pass
+
+    _reachy_stub.ReachyMini = _ReachyMini
+    sys.modules["reachy_mini"] = _reachy_stub
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.luma_checkin import LumaCheckin
+
+
+def _deps() -> ToolDependencies:
+    return ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+
+
+def test_luma_checkin_success_by_name(monkeypatch) -> None:
+    async def _run() -> None:
+        monkeypatch.setenv("LUMA_DIRECT_CHECKIN_ENABLED", "true")
+        monkeypatch.setenv("LUMA_API_KEY", "test-public-key")
+        monkeypatch.setenv("LUMA_SESSION_COOKIE", "session=test-cookie")
+        monkeypatch.setenv("LUMA_ACTIVE_EVENT_API_ID", "evt-test")
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/v1/event/get-guests"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "entries": [
+                            {"guest": {"api_id": "gst-kai", "name": "Kai", "email": "kai@example.com"}},
+                        ]
+                    },
+                )
+            if request.url.path.endswith("/event/admin/update-check-in"):
+                body = json.loads(request.content.decode("utf-8"))
+                assert body["event_api_id"] == "evt-test"
+                assert body["rsvp_api_id"] == "gst-kai"
+                assert request.headers.get("cookie") == "session=test-cookie"
+                return httpx.Response(200, json={"ok": True})
+            if request.url.path.endswith("/event/admin/get-guest"):
+                assert request.url.params.get("event_api_id") == "evt-test"
+                assert request.url.params.get("guest_api_id") == "gst-kai"
+                return httpx.Response(
+                    200,
+                    json={"guest": {"api_id": "gst-kai", "last_checked_in_at": "2026-02-28T00:00:00Z"}},
+                )
+            raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+        tool = LumaCheckin()
+        monkeypatch.setattr(
+            LumaCheckin,
+            "_make_client",
+            lambda self, timeout: httpx.AsyncClient(timeout=timeout, transport=httpx.MockTransport(handler)),
+        )
+
+        result = await tool(_deps(), name="Kai")
+        assert result["status"] == "checked_in"
+        assert result["verified"] is True
+        assert result["event_api_id"] == "evt-test"
+        assert result["guest_api_id"] == "gst-kai"
+
+    asyncio.run(_run())
+
+
+def test_luma_checkin_success_by_qr_url(monkeypatch) -> None:
+    async def _run() -> None:
+        monkeypatch.setenv("LUMA_DIRECT_CHECKIN_ENABLED", "true")
+        monkeypatch.setenv("LUMA_API_KEY", "test-public-key")
+        monkeypatch.setenv("LUMA_SESSION_COOKIE", "session=test-cookie")
+        monkeypatch.delenv("LUMA_ACTIVE_EVENT_API_ID", raising=False)
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/v1/event/get-guest"):
+                assert request.url.params.get("event_id") == "evt-qr"
+                assert request.url.params.get("id") == "pk-123"
+                return httpx.Response(200, json={"guest": {"api_id": "gst-qr", "name": "Kai"}})
+            if request.url.path.endswith("/event/admin/update-check-in"):
+                body = json.loads(request.content.decode("utf-8"))
+                assert body["event_api_id"] == "evt-qr"
+                assert body["rsvp_api_id"] == "gst-qr"
+                return httpx.Response(200, json={"ok": True})
+            if request.url.path.endswith("/event/admin/get-guest"):
+                return httpx.Response(
+                    200,
+                    json={"guest": {"api_id": "gst-qr", "last_checked_in_at": "2026-02-28T01:00:00Z"}},
+                )
+            raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+        tool = LumaCheckin()
+        monkeypatch.setattr(
+            LumaCheckin,
+            "_make_client",
+            lambda self, timeout: httpx.AsyncClient(timeout=timeout, transport=httpx.MockTransport(handler)),
+        )
+
+        result = await tool(_deps(), checkin_url="https://luma.com/check-in/evt-qr?pk=pk-123")
+        assert result["status"] == "checked_in"
+        assert result["verified"] is True
+        assert result["event_api_id"] == "evt-qr"
+        assert result["guest_api_id"] == "gst-qr"
+
+    asyncio.run(_run())
+
+
+def test_luma_checkin_requires_session_cookie(monkeypatch) -> None:
+    async def _run() -> None:
+        monkeypatch.setenv("LUMA_DIRECT_CHECKIN_ENABLED", "true")
+        monkeypatch.setenv("LUMA_API_KEY", "test-public-key")
+        monkeypatch.delenv("LUMA_SESSION_COOKIE", raising=False)
+        monkeypatch.delenv("LUMA_SESSION_COOKIE_FILE", raising=False)
+
+        tool = LumaCheckin()
+        result = await tool(_deps(), name="Kai", event_api_id="evt-x")
+        assert "error" in result
+        assert "session cookie" in result["error"].lower()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add `luma_checkin` tool for direct attendee check-in via Luma APIs
- add tests for name/QR resolution and check-in verification flow
- enable `luma_checkin` in default profile and update prompt/instructions for reliable tool usage
- document required `LUMA_*` env vars and usage in README/.env.example

## Notes
- this branch is an extension on top of the official conversation app for event reception experiments
- no secrets are committed (env docs only)

## Validation
- `pytest -q tests/test_luma_checkin_tool.py`
