### PR TITLE
non-blocking tool execution + response serialisation

### DIFF
--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 import base64
 import random
 import asyncio
@@ -21,7 +22,11 @@ from reachy_mini_conversation_app.prompts import get_session_voice, get_session_
 from reachy_mini_conversation_app.tools.core_tools import (
     ToolDependencies,
     get_tool_specs,
-    dispatch_tool_call,
+)
+from reachy_mini_conversation_app.tools.background_tool_manager import (
+    ToolCallRoutine,
+    ToolNotification,
+    BackgroundToolManager,
 )
 
 
@@ -36,6 +41,8 @@ AUDIO_OUTPUT_COST_PER_1M = 64.0
 TEXT_INPUT_COST_PER_1M = 4.0
 TEXT_OUTPUT_COST_PER_1M = 16.0
 IMAGE_INPUT_COST_PER_1M = 5.0
+
+_RESPONSE_DONE_TIMEOUT: Final[float] = 30.0
 
 
 def _compute_response_cost(usage: Any) -> float:
@@ -95,8 +102,19 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         self._shutdown_requested: bool = False
         self._connected_event: asyncio.Event = asyncio.Event()
 
+        # Background tool manager
+        self.tool_manager = BackgroundToolManager()
+
         # Cost tracking
         self.cumulative_cost: float = 0.0
+
+        # Response-in-progress guard: the Realtime API only allows one active
+        # response per conversation at a time.  A dedicated worker task
+        # (_response_sender_loop) dequeues and sends one request at a time
+        self._pending_responses: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._response_done_event: asyncio.Event = asyncio.Event()
+        self._response_done_event.set()
+        self._last_response_rejected: bool = False
 
     def copy(self) -> "OpenaiRealtimeHandler":
         """Create a copy of the handler."""
@@ -254,6 +272,172 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         except Exception as e:
             logger.warning("_restart_session failed: %s", e)
 
+    async def _safe_response_create(self, **kwargs: Any) -> None:
+        """Enqueue a response.create() kwargs for the sender worker _response_sender_loop().
+
+        This method never blocks the caller.
+        """
+        await self._pending_responses.put(kwargs)
+
+    async def _response_sender_loop(self) -> None:
+        """Dedicated worker that sends ``response.create()`` calls serially.
+
+        This logic was designed to comply with the response.create() docstring specification for event ordering:
+        https://github.com/openai/openai-python/blob/3e0c05b84a2056870abf3bd6a5e7849020209cc3/src/openai/resources/realtime/realtime.py#L649C1-L651C30
+
+        For each queued request the worker:
+        1. Waits until no response is active (_response_done_event).
+        2. Sends response.create().
+        3. Waits for the response cycle to complete (response.done).
+        4. If the server rejected with active_response, retries from step 1.
+        """
+        while self.connection:
+            try:
+                kwargs = await self._pending_responses.get()
+            except asyncio.CancelledError:
+                return
+
+            sent = False
+            max_retries = 5
+            attempts = 0
+            while not sent and self.connection and attempts < max_retries:
+                try:
+                    await asyncio.wait_for(self._response_done_event.wait(), timeout=_RESPONSE_DONE_TIMEOUT)
+                except asyncio.TimeoutError:
+                    logger.debug("Timed out waiting for previous response to finish; forcing ahead")
+                    self._response_done_event.set()
+
+                if not self.connection:
+                    break
+
+                self._last_response_rejected = False
+                try:
+                    await self.connection.response.create(**kwargs)
+                except Exception as e:
+                    logger.debug("_response_sender_loop: send failed: %s", e)
+                    self._response_done_event.set()
+                    break
+
+                try:
+                    await asyncio.wait_for(self._response_done_event.wait(), timeout=_RESPONSE_DONE_TIMEOUT)
+                except asyncio.TimeoutError:
+                    logger.debug("Timed out waiting for response.done; assuming response completed")
+                    self._response_done_event.set()
+                    break
+
+                # Check if we were rejected
+                if self._last_response_rejected:
+                    attempts += 1
+                    if attempts >= max_retries:
+                        logger.debug("response.create rejected %d times; giving up", attempts)
+                        break
+                    logger.debug("response.create was rejected; retrying (%d/%d)", attempts, max_retries)
+                    continue
+
+                sent = True
+
+    async def _handle_tool_result(self, bg_tool: ToolNotification) -> None:
+        """Process the result of a tool call."""
+        if bg_tool.error is not None:
+            logger.error("Tool '%s' (id=%s) failed with error: %s", bg_tool.tool_name, bg_tool.id, bg_tool.error)
+            tool_result = {"error": bg_tool.error}
+        elif bg_tool.result is not None:
+            tool_result = bg_tool.result
+            logger.info(
+                "Tool '%s' (id=%s) executed successfully.",
+                bg_tool.tool_name, bg_tool.id,
+            )
+            logger.debug("Tool '%s' full result: %s", bg_tool.tool_name, tool_result)
+        else:
+            logger.warning("Tool '%s' (id=%s) returned no result and no error", bg_tool.tool_name, bg_tool.id)
+            tool_result = {"error": "No result returned from tool execution"}
+
+        # Connection may have closed while tool was running
+        if not self.connection:
+            logger.warning("Connection closed during tool '%s' (id=%s) execution; cannot send result back", bg_tool.tool_name, bg_tool.id)
+            return
+
+        try:
+            # Send the tool result back
+            if isinstance(bg_tool.id, str):
+                await self.connection.conversation.item.create(
+                    item={
+                        "type": "function_call_output",
+                        "call_id": bg_tool.id,
+                        "output": json.dumps(tool_result),
+                    },
+                )
+
+            await self.output_queue.put(
+                AdditionalOutputs(
+                    {
+                        "role": "assistant",
+                        "content": json.dumps(tool_result),
+                        # Gradio UI metadata.status accept only "pending" and "done". Do not accept bg.tool.status values.
+                        "metadata": {
+                            "title": f"🛠️ Used tool {bg_tool.tool_name}",
+                            "status": "done",
+                        },
+                    },
+                ),
+            )
+
+            if bg_tool.tool_name == "camera" and "b64_im" in tool_result:
+                # use raw base64, don't json.dumps (which adds quotes)
+                b64_im = tool_result["b64_im"]
+                if not isinstance(b64_im, str):
+                    logger.warning("Unexpected type for b64_im: %s", type(b64_im))
+                    b64_im = str(b64_im)
+                await self.connection.conversation.item.create(
+                    item={
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_image",
+                                "image_url": f"data:image/jpeg;base64,{b64_im}",
+                            },
+                        ],
+                    },
+                )
+                logger.info("Added camera image to conversation")
+
+                if self.deps.camera_worker is not None:
+                    np_img = self.deps.camera_worker.get_latest_frame()
+                    if np_img is not None:
+                        # Camera frames are BGR from OpenCV; convert so Gradio displays correct colors.
+                        rgb_frame = cv2.cvtColor(np_img, cv2.COLOR_BGR2RGB)
+                    else:
+                        rgb_frame = None
+                    img = gr.Image(value=rgb_frame)
+
+                    await self.output_queue.put(
+                        AdditionalOutputs(
+                            {
+                                "role": "assistant",
+                                "content": img,
+                            },
+                        ),
+                    )
+
+            # If this tool call was triggered by an idle signal, don't make the robot speak.
+            # For other tool calls, let the robot reply out loud.
+            if not bg_tool.is_idle_tool_call:
+                await self._safe_response_create(
+                    response={
+                        "instructions": "Use the tool result just returned and answer concisely in speech.",
+                    },
+                )
+
+            # Re-synchronize the head wobble after a tool call that may have taken some time
+            if self.deps.head_wobbler is not None:
+                self.deps.head_wobbler.reset()
+
+        except ConnectionClosedError:
+            logger.warning("Connection closed while sending tool result")
+            self.connection = None
+            self._response_done_event.set()
+
     async def _run_realtime_session(self) -> None:
         """Establish and manage a single realtime session."""
         async with self.client.realtime.connect(model=config.MODEL_NAME) as conn:
@@ -306,203 +490,192 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 self._connected_event.set()
             except Exception:
                 pass
-            async for event in self.connection:
-                logger.debug(f"OpenAI event: {event.type}")
-                if event.type == "input_audio_buffer.speech_started":
-                    if hasattr(self, "_clear_queue") and callable(self._clear_queue):
-                        self._clear_queue()
-                    if self.deps.head_wobbler is not None:
-                        self.deps.head_wobbler.reset()
-                    self.deps.movement_manager.set_listening(True)
-                    logger.debug("User speech started")
-
-                if event.type == "input_audio_buffer.speech_stopped":
-                    self.deps.movement_manager.set_listening(False)
-                    logger.debug("User speech stopped - server will auto-commit with VAD")
-
-                if event.type in (
-                    "response.audio.done",  # GA
-                    "response.output_audio.done",  # GA alias
-                    "response.audio.completed",  # legacy (for safety)
-                    "response.completed",  # text-only completion
-                ):
-                    logger.debug("response completed")
-
-                if event.type == "response.created":
-                    logger.debug("Response created")
-
-                if event.type == "response.done":
-                    # Doesn't mean the audio is done playing
-                    logger.debug("Response done")
 
 
+            response_sender_task: asyncio.Task[None] | None = None
+            try:
+                # Start the background tool manager
+                self.tool_manager.start_up(tool_callbacks=[self._handle_tool_result])
 
-                    response = getattr(event, "response", None)
-                    usage = getattr(response, "usage", None) if response else None
-                    if usage:
-                        cost = _compute_response_cost(usage)
-                        self.cumulative_cost += cost
-                        logger.debug("Cost: $%.4f | Cumulative: $%.4f", cost, self.cumulative_cost)
-                    else:
-                        logger.warning("No usage data available for cost tracking")
+                # Start the response sender worker
+                response_sender_task = asyncio.create_task(
+                    self._response_sender_loop(), name="response-sender"
+                )
 
-                # Handle partial transcription (user speaking in real-time)
-                if event.type == "conversation.item.input_audio_transcription.partial":
-                    logger.debug(f"User partial transcript: {event.transcript}")
+                async for event in self.connection:
+                    logger.debug(f"OpenAI event: {event.type}")
+                    if event.type == "input_audio_buffer.speech_started":
+                        if hasattr(self, "_clear_queue") and callable(self._clear_queue):
+                            self._clear_queue()
+                        if self.deps.head_wobbler is not None:
+                            self.deps.head_wobbler.reset()
+                        self.deps.movement_manager.set_listening(True)
+                        logger.debug("User speech started")
 
-                    # Increment sequence
-                    self.partial_transcript_sequence += 1
-                    current_sequence = self.partial_transcript_sequence
+                    if event.type == "input_audio_buffer.speech_stopped":
+                        self.deps.movement_manager.set_listening(False)
+                        logger.debug("User speech stopped - server will auto-commit with VAD")
 
-                    # Cancel previous debounce task if it exists
-                    if self.partial_transcript_task and not self.partial_transcript_task.done():
-                        self.partial_transcript_task.cancel()
-                        try:
-                            await self.partial_transcript_task
-                        except asyncio.CancelledError:
-                            pass
+                    if event.type in (
+                        "response.audio.done",  # GA
+                        "response.output_audio.done",  # GA alias
+                        "response.audio.completed",  # legacy (for safety)
+                        "response.completed",  # text-only completion
+                    ):
+                        logger.debug("response completed")
 
-                    # Start new debounce timer with sequence number
-                    self.partial_transcript_task = asyncio.create_task(
-                        self._emit_debounced_partial(event.transcript, current_sequence)
-                    )
+                    if event.type == "response.created":
+                        self._response_done_event.clear()
+                        logger.debug("Response created (active)")
 
-                # Handle completed transcription (user finished speaking)
-                if event.type == "conversation.item.input_audio_transcription.completed":
-                    logger.debug(f"User transcript: {event.transcript}")
+                    if event.type == "response.done":
+                        # Doesn't mean the audio is done playing
+                        self._response_done_event.set()
+                        logger.debug("Response done")
 
-                    # Cancel any pending partial emission
-                    if self.partial_transcript_task and not self.partial_transcript_task.done():
-                        self.partial_transcript_task.cancel()
-                        try:
-                            await self.partial_transcript_task
-                        except asyncio.CancelledError:
-                            pass
+                        response = getattr(event, "response", None)
+                        usage = getattr(response, "usage", None) if response else None
+                        if usage:
+                            cost = _compute_response_cost(usage)
+                            self.cumulative_cost += cost
+                            logger.debug("Cost: $%.4f | Cumulative: $%.4f", cost, self.cumulative_cost)
+                        else:
+                            logger.warning("No usage data available for cost tracking")
 
-                    await self.output_queue.put(AdditionalOutputs({"role": "user", "content": event.transcript}))
+                    # Handle partial transcription (user speaking in real-time)
+                    if event.type == "conversation.item.input_audio_transcription.partial":
+                        logger.debug(f"User partial transcript: {event.transcript}")
 
-                # Handle assistant transcription
-                if event.type in ("response.audio_transcript.done", "response.output_audio_transcript.done"):
-                    logger.debug(f"Assistant transcript: {event.transcript}")
-                    await self.output_queue.put(AdditionalOutputs({"role": "assistant", "content": event.transcript}))
+                        # Increment sequence
+                        self.partial_transcript_sequence += 1
+                        current_sequence = self.partial_transcript_sequence
 
-                # Handle audio delta
-                if event.type in ("response.audio.delta", "response.output_audio.delta"):
-                    if self.deps.head_wobbler is not None:
-                        self.deps.head_wobbler.feed(event.delta)
-                    self.last_activity_time = asyncio.get_event_loop().time()
-                    logger.debug("last activity time updated to %s", self.last_activity_time)
-                    await self.output_queue.put(
-                        (
-                            self.output_sample_rate,
-                            np.frombuffer(base64.b64decode(event.delta), dtype=np.int16).reshape(1, -1),
-                        ),
-                    )
+                        # Cancel previous debounce task if it exists
+                        if self.partial_transcript_task and not self.partial_transcript_task.done():
+                            self.partial_transcript_task.cancel()
+                            try:
+                                await self.partial_transcript_task
+                            except asyncio.CancelledError:
+                                pass
 
-                # ---- tool-calling plumbing ----
-                if event.type == "response.function_call_arguments.done":
-                    tool_name = getattr(event, "name", None)
-                    args_json_str = getattr(event, "arguments", None)
-                    call_id = getattr(event, "call_id", None)
-
-                    if not isinstance(tool_name, str) or not isinstance(args_json_str, str):
-                        logger.error("Invalid tool call: tool_name=%s, args=%s", tool_name, args_json_str)
-                        continue
-
-                    try:
-                        tool_result = await dispatch_tool_call(tool_name, args_json_str, self.deps)
-                        logger.debug("Tool '%s' executed successfully", tool_name)
-                        logger.debug("Tool result: %s", tool_result)
-                    except Exception as e:
-                        logger.error("Tool '%s' failed", tool_name)
-                        tool_result = {"error": str(e)}
-
-                    # send the tool result back
-                    if isinstance(call_id, str):
-                        await self.connection.conversation.item.create(
-                            item={
-                                "type": "function_call_output",
-                                "call_id": call_id,
-                                "output": json.dumps(tool_result),
-                            },
+                        # Start new debounce timer with sequence number
+                        self.partial_transcript_task = asyncio.create_task(
+                            self._emit_debounced_partial(event.transcript, current_sequence)
                         )
 
-                    await self.output_queue.put(
-                        AdditionalOutputs(
-                            {
-                                "role": "assistant",
-                                "content": json.dumps(tool_result),
-                                "metadata": {"title": f"🛠️ Used tool {tool_name}", "status": "done"},
-                            },
-                        ),
-                    )
+                    # Handle completed transcription (user finished speaking)
+                    if event.type == "conversation.item.input_audio_transcription.completed":
+                        logger.debug(f"User transcript: {event.transcript}")
 
-                    if tool_name == "camera" and "b64_im" in tool_result:
-                        # use raw base64, don't json.dumps (which adds quotes)
-                        b64_im = tool_result["b64_im"]
-                        if not isinstance(b64_im, str):
-                            logger.warning("Unexpected type for b64_im: %s", type(b64_im))
-                            b64_im = str(b64_im)
-                        await self.connection.conversation.item.create(
-                            item={
-                                "type": "message",
-                                "role": "user",
-                                "content": [
-                                    {
-                                        "type": "input_image",
-                                        "image_url": f"data:image/jpeg;base64,{b64_im}",
-                                    },
-                                ],
-                            },
+                        # Cancel any pending partial emission
+                        if self.partial_transcript_task and not self.partial_transcript_task.done():
+                            self.partial_transcript_task.cancel()
+                            try:
+                                await self.partial_transcript_task
+                            except asyncio.CancelledError:
+                                pass
+
+                        await self.output_queue.put(AdditionalOutputs({"role": "user", "content": event.transcript}))
+
+                    # Handle assistant transcription
+                    if event.type in ("response.audio_transcript.done", "response.output_audio_transcript.done"):
+                        logger.debug(f"Assistant transcript: {event.transcript}")
+                        await self.output_queue.put(AdditionalOutputs({"role": "assistant", "content": event.transcript}))
+
+                    # Handle audio delta
+                    if event.type in ("response.audio.delta", "response.output_audio.delta"):
+                        if self.deps.head_wobbler is not None:
+                            self.deps.head_wobbler.feed(event.delta)
+                        self.last_activity_time = asyncio.get_event_loop().time()
+                        logger.debug("last activity time updated to %s", self.last_activity_time)
+                        await self.output_queue.put(
+                            (
+                                self.output_sample_rate,
+                                np.frombuffer(base64.b64decode(event.delta), dtype=np.int16).reshape(1, -1),
+                            ),
                         )
-                        logger.info("Added camera image to conversation")
 
-                        if self.deps.camera_worker is not None:
-                            np_img = self.deps.camera_worker.get_latest_frame()
-                            if np_img is not None:
-                                # Camera frames are BGR from OpenCV; convert so Gradio displays correct colors.
-                                rgb_frame = cv2.cvtColor(np_img, cv2.COLOR_BGR2RGB)
-                            else:
-                                rgb_frame = None
-                            img = gr.Image(value=rgb_frame)
+                    # ---- tool-calling plumbing ----
+                    if event.type == "response.function_call_arguments.done":
+                        tool_name = getattr(event, "name", None)
+                        args_json_str = getattr(event, "arguments", None)
+                        call_id: str = str(getattr(event, "call_id", uuid.uuid4()))
 
-                            await self.output_queue.put(
-                                AdditionalOutputs(
-                                    {
-                                        "role": "assistant",
-                                        "content": img,
-                                    },
-                                ),
+                        logger.info(
+                            "Tool call received — tool_name=%r, call_id=%s, is_idle=%s, args=%s",
+                            tool_name, call_id, self.is_idle_tool_call, args_json_str,
+                        )
+
+                        if not isinstance(tool_name, str) or not isinstance(args_json_str, str):
+                            logger.error(
+                                "Invalid tool call: tool_name=%s (type=%s), args=%s (type=%s), call_id=%s",
+                                tool_name, type(tool_name).__name__,
+                                args_json_str, type(args_json_str).__name__,
+                                call_id,
+                            )
+                            continue
+
+                        bg_tool = await self.tool_manager.start_tool(
+                            call_id=call_id,
+                            tool_call_routine=ToolCallRoutine(
+                                tool_name=tool_name,
+                                args_json_str=args_json_str,
+                                deps=self.deps,
+                            ),
+                            is_idle_tool_call=self.is_idle_tool_call,
+                        )
+
+                        await self.output_queue.put(
+                            AdditionalOutputs(
+                                {
+                                    "role": "assistant",
+                                    "content": f"🛠️ Used tool {tool_name} with args {args_json_str}. The tool is now running. Tool ID: {bg_tool.tool_id}",
+                                },
+                            ),
+                        )
+
+                        if self.is_idle_tool_call:
+                            self.is_idle_tool_call = False
+                        else:
+                            await self._safe_response_create(
+                                response={
+                                    "instructions": "Notify what the tool has been running giving meaningful information about the task",
+                                },
                             )
 
-                    # if this tool call was triggered by an idle signal, don't make the robot speak
-                    # for other tool calls, let the robot reply out loud
-                    if self.is_idle_tool_call:
-                        self.is_idle_tool_call = False
-                    else:
-                        await self.connection.response.create(
-                            response={
-                                "instructions": "Use the tool result just returned and answer concisely in speech.",
-                            },
-                        )
+                        logger.info("Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id)
 
-                    # re synchronize the head wobble after a tool call that may have taken some time
-                    if self.deps.head_wobbler is not None:
-                        self.deps.head_wobbler.reset()
+                    # server error
+                    if event.type == "error":
+                        err = getattr(event, "error", None)
+                        msg = getattr(err, "message", str(err) if err else "unknown error")
+                        code = getattr(err, "code", "")
 
-                # server error
-                if event.type == "error":
-                    err = getattr(event, "error", None)
-                    msg = getattr(err, "message", str(err) if err else "unknown error")
-                    code = getattr(err, "code", "")
+                        if code == "conversation_already_has_active_response":
+                            # response.create was rejected.  The sender worker
+                            # is waiting on _response_done_event; when the active
+                            # response finishes it will wake up and see this flag.
+                            self._last_response_rejected = True
+                            logger.debug("response.create rejected; worker will retry after active response finishes")
+                        else:
+                            logger.error("Realtime error [%s]: %s (raw=%s)", code, msg, err)
 
-                    logger.error("Realtime error [%s]: %s (raw=%s)", code, msg, err)
+                        # Only show user-facing errors, not internal state errors
+                        if code not in ("input_audio_buffer_commit_empty",):
+                            await self.output_queue.put(
+                                AdditionalOutputs({"role": "assistant", "content": f"[error] {msg}"})
+                            )
+            finally:
+                # Stop the response sender worker.
+                if response_sender_task is not None:
+                    response_sender_task.cancel()
+                    try:
+                        await response_sender_task
+                    except asyncio.CancelledError:
+                        pass
 
-                    # Only show user-facing errors, not internal state errors
-                    if code not in ("input_audio_buffer_commit_empty", "conversation_already_has_active_response"):
-                        await self.output_queue.put(
-                            AdditionalOutputs({"role": "assistant", "content": f"[error] {msg}"})
-                        )
+                # Stop background tool manager tasks (listener + cleanup) in all patus.
+                await self.tool_manager.shutdown()
 
     # Microphone receive
     async def receive(self, frame: Tuple[int, NDArray[np.int16]]) -> None:
@@ -566,6 +739,13 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
     async def shutdown(self) -> None:
         """Shutdown the handler."""
         self._shutdown_requested = True
+
+        # Unblock the response sender worker so it can exit
+        self._response_done_event.set()
+
+        # Stop background tool manager tasks (listener + cleanup)
+        await self.tool_manager.shutdown()
+
         # Cancel any pending debounce task
         if self.partial_transcript_task and not self.partial_transcript_task.done():
             self.partial_transcript_task.cancel()
@@ -680,7 +860,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 "content": [{"type": "input_text", "text": timestamp_msg}],
             },
         )
-        await self.connection.response.create(
+        await self._safe_response_create(
             response={
                 "instructions": "You MUST respond with function calls only - no speech or text. Choose appropriate actions for idle behavior.",
                 "tool_choice": "required",

--- a/src/reachy_mini_conversation_app/tools/background_tool_manager.py
+++ b/src/reachy_mini_conversation_app/tools/background_tool_manager.py
@@ -1,0 +1,406 @@
+"""Background tool orchestrator for non-blocking tool execution.
+
+Allows tools to run long operations asynchronously while the robot
+continues conversing. Tools can be tracked, cancelled, and their
+completion is announced vocally via a silent notification queue.
+"""
+
+from __future__ import annotations
+import time
+import asyncio
+import logging
+from typing import Any, Dict, Callable, Optional, Coroutine
+
+from pydantic import Field, BaseModel, PrivateAttr
+
+from reachy_mini_conversation_app.tools.core_tools import (
+    ToolDependencies,
+    dispatch_tool_call,
+)
+from reachy_mini_conversation_app.tools.tool_constants import ToolState
+
+
+logger = logging.getLogger(__name__)
+
+class ToolProgress(BaseModel):
+    """Progress of a background tool."""
+
+    """the progress of the tool"""
+    progress: float = Field(..., ge=0.0, le=1.0)
+
+    """the message of the tool"""
+    message: Optional[str] = None
+
+
+class ToolCallRoutine(BaseModel):
+    """Encapsulates an async callable with its arguments for deferred execution."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    """the name of the tool"""
+    tool_name: str
+
+    """the JSON arguments for the tool call"""
+    args_json_str: str
+
+    """the dependencies for the tool call"""
+    deps: "ToolDependencies"
+
+    async def __call__(self, tool_manager: BackgroundToolManager) -> Any:
+        """Execute the stored callable with its arguments."""
+        return await dispatch_tool_call(tool_name=self.tool_name, args_json=self.args_json_str, deps=self.deps)
+
+
+class ToolNotification(BaseModel):
+    """Notification payload for completed tools."""
+
+    """the ID of the tool"""
+    id: str
+
+    """the name of the tool"""
+    tool_name: str
+
+    """whether the tool call was triggered by an idle signal"""
+    is_idle_tool_call: bool
+
+    """the status of the tool"""
+    status: ToolState
+
+    """the result of the tool"""
+    result: Optional[Dict[str, Any]] = None
+
+    """the error of the tool"""
+    error: Optional[str] = None
+
+
+class BackgroundTool(ToolNotification):
+    """Represents a background tool."""
+
+    """the progress of the tool"""
+    progress: Optional[ToolProgress] = None
+
+    """the start time of the tool"""
+    started_at: float = Field(default_factory=time.monotonic)
+
+    """the completion time of the tool"""
+    completed_at: Optional[float] = None
+
+    """the async tool execution task"""
+    _task: Optional[asyncio.Task[None]] = PrivateAttr(default=None)
+
+    @property
+    def tool_id(self) -> str:
+        """Get the name of the tool."""
+        return f"{self.tool_name}-{self.id}-{self.started_at}"
+
+    def get_notification(self) -> ToolNotification:
+        """Get the notification for the tool."""
+        return ToolNotification(
+            id=self.id,
+            tool_name=self.tool_name,
+            is_idle_tool_call=self.is_idle_tool_call,
+            status=self.status,
+            result=self.result,
+            error=self.error,
+        )
+
+
+class BackgroundToolManager(BaseModel):
+    """Manages background tools for non-blocking tool execution.
+
+    Features:
+    - Start async tools without blocking the conversation
+    - Track tool status and progress
+    - Cancel running tools
+
+    """
+
+    """the dictionary of tools"""
+    _tools: Dict[str, BackgroundTool] = PrivateAttr(default_factory=dict)
+
+    """the async queue for notifications"""
+    _notification_queue: asyncio.Queue[ToolNotification] = PrivateAttr(default_factory=asyncio.Queue)
+
+    """the event loop"""
+    _loop: Optional[asyncio.AbstractEventLoop] = PrivateAttr(default=None)
+
+    """internal lifecycle tasks (notification listener, periodic cleanup)"""
+    _lifecycle_tasks: list[asyncio.Task[None]] = PrivateAttr(default_factory=list)
+
+    """the maximum duration of a tool execution in seconds (default: 1 hour)"""
+    _max_tool_duration_seconds: float = PrivateAttr(default=3600)
+
+    """the maximum time to keep a completed/failed/cancelled tool in memory (default: 1 day)"""
+    _max_tool_memory_seconds: float = PrivateAttr(default=86400)
+
+    def set_loop(
+        self,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        """Set the event loop.
+
+        Args:
+            loop: The event loop (defaults to current running loop)
+
+        """
+        if loop is not None:
+            self._loop = loop
+        else:
+            try:
+                self._loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self._loop = asyncio.new_event_loop()
+        logger.debug("BackgroundToolManager: event loop set")
+
+
+    async def start_tool(
+        self,
+        call_id: str,
+        tool_call_routine: ToolCallRoutine,
+        is_idle_tool_call: bool,
+        with_progress: bool = False,
+    ) -> BackgroundTool:
+        """Start a new background tool.
+
+        Args:
+            call_id: The ID of the tool
+            tool_call_routine: The ToolCallRoutine containing the callable and its arguments
+            with_progress: Whether to track progress (0.0-1.0)
+            is_idle_tool_call: Whether the tool call was triggered by an idle signal
+
+        Returns:
+            BackgroundTool object with tool ID
+
+        """
+        tool_name = tool_call_routine.tool_name
+        id = call_id
+        bg_tool = BackgroundTool(
+            id=id,
+            tool_name=tool_name,
+            is_idle_tool_call=is_idle_tool_call,
+            progress=ToolProgress(progress=0.0) if with_progress else None,
+            status=ToolState.RUNNING,
+        )
+        self._tools[bg_tool.tool_id] = bg_tool
+
+        async_task = asyncio.create_task(
+            self._run_tool(bg_tool, tool_call_routine),
+            name=f"bg-{tool_name}-{id}",
+        )
+        bg_tool._task = async_task
+
+        logger.info(f"Started background tool: {bg_tool.tool_name} (id={id})")
+
+        return bg_tool
+
+    async def _run_tool(
+        self,
+        bg_tool: BackgroundTool,
+        tool_call_routine: ToolCallRoutine,
+    ) -> None:
+        """Execute the tool and handle completion."""
+        result: dict[str, Any] = await tool_call_routine(self)
+        bg_tool.completed_at = time.monotonic()
+        error = result.get("error")
+
+        if error is not None:
+            if error == "Tool cancelled":
+                bg_tool.status = ToolState.CANCELLED
+                logger.debug(f"Background tool cancelled: {bg_tool.tool_name} (id={bg_tool.id})")
+            else:
+                bg_tool.status = ToolState.FAILED
+                logger.debug(f"Background tool failed: {bg_tool.tool_name} (id={bg_tool.id}): {bg_tool.error}")
+            bg_tool.error = result["error"]
+
+        else:
+            bg_tool.result = result
+            bg_tool.status = ToolState.COMPLETED
+            logger.debug(f"Background tool completed: {bg_tool.tool_name} (id={bg_tool.id})")
+
+        await self._notification_queue.put(bg_tool.get_notification())
+        logger.debug(f"Queued notification for tool: {bg_tool.tool_name} (id={bg_tool.id})")
+
+    async def update_progress(
+        self,
+        tool_id: str,
+        progress: float,
+        message: Optional[str] = None,
+    ) -> bool:
+        """Update progress for a tool (for tools with with_progress=True).
+
+        Args:
+            tool_id: The tool ID
+            progress: Progress value between 0.0 and 1.0
+            message: Optional progress message (e.g., "50% downloaded")
+
+        Returns:
+            True if updated successfully, False if tool not found or not tracking progress
+
+        """
+        tool = self._tools.get(tool_id)
+        if tool is None:
+            return False
+
+        if tool.progress is None:
+            # Tool not tracking progress
+            return False
+
+        tool.progress = ToolProgress(progress=max(0.0, min(1.0, progress)), message=message)
+        logger.debug(f"Tool {tool_id} progress: {progress:.1%} - {message or ''}")
+        return True
+
+    async def cancel_tool(self, tool_id: str, log: bool = True) -> bool:
+        """Cancel a running tool by ID.
+
+        Args:
+            tool_id: The tool ID to cancel
+            log: Whether to log the cancellation
+
+        Returns:
+            True if cancelled, False if tool not found or not running
+
+        """
+        tool = self._tools.get(tool_id)
+        if tool is None:
+            if log:
+                logger.warning(f"Cannot cancel tool {tool_id}: not found")
+            return False
+
+        if tool.status != ToolState.RUNNING:
+            if log:
+                logger.warning(f"Cannot cancel tool {tool_id}: status is {tool.status.value}")
+            return True
+
+        if tool._task:
+            tool._task.cancel()
+            if log:
+                logger.info(f"Cancelled tool: {tool.tool_name} (id={tool_id})")
+            return True
+
+        return False
+
+    def start_up(self, tool_callbacks: list[Callable[[ToolNotification], Coroutine[Any, Any, None]]]) -> None:
+        """Start the background tool manager.
+
+        This method starts two concurrent tasks:
+        - _listener: Listens for completed BackgroundTool notifications and calls the callbacks.
+        - _cleanup: Cleans up completed/failed/cancelled tools that have been in memory for too long and times out tools that have been running too long.
+
+        Args:
+            tool_callbacks: A list of async or sync callables that receive the completed BackgroundTool notifications.
+
+        """
+        self.set_loop()
+
+        async def _listener() -> None:
+            while True:
+                bg_tool = await self._notification_queue.get()
+                for callback in tool_callbacks:
+                    await callback(bg_tool)
+
+        async def _cleanup(interval_seconds: float = 5 * 60) -> None:
+            while True:
+                await asyncio.sleep(interval_seconds)
+                await self.cleanup_tools()
+                await self.timeout_tools()
+
+        self._lifecycle_tasks = [
+            asyncio.create_task(_cleanup(), name="bg-tool-cleanup"),
+            asyncio.create_task(_listener(), name="bg-tool-listener-callback"),
+        ]
+
+        logger.info(
+            "BackgroundToolManager started. "
+            "Max tool execution duration: %s seconds (tools running longer will be auto-cancelled). "
+            "Max tool memory retention: %s seconds (completed/failed/cancelled tools older than this are purged).",
+            self._max_tool_duration_seconds, self._max_tool_memory_seconds,
+        )
+
+    async def shutdown(self) -> None:
+        """Cancel all background tasks (listener, cleanup) and running tools."""
+        for task in self._lifecycle_tasks:
+            task.cancel()
+        for task in self._lifecycle_tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._lifecycle_tasks.clear()
+
+        for tool_id in list(self._tools):
+            await self.cancel_tool(tool_id, log=False)
+
+        logger.info("BackgroundToolManager shut down")
+
+    async def timeout_tools(self) -> int:
+        """Cancel tools that have been running too long.
+
+        Returns:
+            Number of tools cancelled
+
+        """
+        now = time.monotonic()
+        to_cancel = []
+
+        for tool_id, tool in self._tools.items():
+            if tool.status == ToolState.RUNNING:
+                if tool.started_at and (now - tool.started_at) > self._max_tool_duration_seconds:
+                    to_cancel.append(tool_id)
+
+        for tool_id in to_cancel:
+            await self.cancel_tool(tool_id)
+
+        if to_cancel:
+            logger.debug(f"Timed out {len(to_cancel)} tools")
+
+        return len(to_cancel)
+
+    async def cleanup_tools(self) -> int:
+        """Remove completed/failed/cancelled tools that have been in memory for too long.
+
+        Returns:
+            Number of tools removed
+
+        """
+        now = time.monotonic()
+        to_remove = []
+
+        for tool_id, tool in self._tools.items():
+            if tool.status in (ToolState.COMPLETED, ToolState.FAILED, ToolState.CANCELLED):
+                if tool.completed_at and (now - tool.completed_at) > self._max_tool_memory_seconds:
+                    to_remove.append(tool_id)
+
+        for tool_id in to_remove:
+            del self._tools[tool_id]
+
+        if to_remove:
+            logger.debug(f"Cleaned up {len(to_remove)} old tools")
+
+        return len(to_remove)
+
+    def get_tool(self, tool_id: str) -> Optional[BackgroundTool]:
+        """Get a tool by ID."""
+        return self._tools.get(tool_id)
+
+    def get_running_tools(self) -> list[BackgroundTool]:
+        """Get all currently running tools."""
+        return [t for t in self._tools.values() if t.status == ToolState.RUNNING]
+
+    def get_all_tools(self, limit: Optional[int] = None) -> list[BackgroundTool]:
+        """Get recent tools (most recent first).
+
+        Args:
+            limit: Maximum number of tools to return (None means all)
+
+        Returns:
+            List of tools sorted by start time (most recent first)
+
+        """
+        sorted_tools = sorted(
+            self._tools.values(),
+            key=lambda t: t.started_at,
+            reverse=True,
+        )
+        if limit is not None:
+            return sorted_tools[:limit]
+        return sorted_tools

--- a/src/reachy_mini_conversation_app/tools/tool_constants.py
+++ b/src/reachy_mini_conversation_app/tools/tool_constants.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ToolState(Enum):
+    """Status of a background tool."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -50,9 +50,6 @@ async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -
     monkeypatch.setattr(rt_mod, "ConnectionClosedError", FakeCCE)
 
     # Make asyncio.sleep return immediately (for backoff)
-    # but still yield to the event loop via sleep(0).
-    # A plain `return None` would never yield, starving concurrent tasks
-    # like _response_sender_loop and preventing them from making progress.
     _real_sleep = asyncio.sleep
     async def _mock_sleep(*_a: Any, **_kw: Any) -> None: await _real_sleep(0)
     monkeypatch.setattr(asyncio, "sleep", _mock_sleep, raising=False)

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -1,3 +1,4 @@
+import random
 import asyncio
 import logging
 from typing import Any
@@ -7,8 +8,10 @@ from unittest.mock import MagicMock
 import pytest
 
 import reachy_mini_conversation_app.openai_realtime as rt_mod
+import reachy_mini_conversation_app.tools.background_tool_manager as btm_mod
 from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler, _compute_response_cost
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.background_tool_manager import ToolCallRoutine
 
 
 def _build_handler(loop: asyncio.AbstractEventLoop) -> OpenaiRealtimeHandler:
@@ -47,8 +50,12 @@ async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -
     monkeypatch.setattr(rt_mod, "ConnectionClosedError", FakeCCE)
 
     # Make asyncio.sleep return immediately (for backoff)
-    async def _fast_sleep(*_a: Any, **_kw: Any) -> None: return None
-    monkeypatch.setattr(asyncio, "sleep", _fast_sleep, raising=False)
+    # but still yield to the event loop via sleep(0).
+    # A plain `return None` would never yield, starving concurrent tasks
+    # like _response_sender_loop and preventing them from making progress.
+    _real_sleep = asyncio.sleep
+    async def _mock_sleep(*_a: Any, **_kw: Any) -> None: await _real_sleep(0)
+    monkeypatch.setattr(asyncio, "sleep", _mock_sleep, raising=False)
 
     attempt_counter = {"n": 0}
 
@@ -116,7 +123,6 @@ async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -
     warnings = [r for r in caplog.records if r.levelname == "WARNING" and "closed unexpectedly" in r.msg]
     assert len(warnings) == 1
 
-
 # ---- Cost calculation tests ----
 
 
@@ -171,3 +177,371 @@ def test_compute_response_cost(usage_kwargs: dict[str, Any], expect_positive: bo
         assert cost > 0
     else:
         assert cost == 0.0
+
+
+# ---- Stress test: response.create rejection + retry ----
+
+
+@pytest.mark.asyncio
+async def test_response_sender_retries_on_active_response_rejection(monkeypatch: Any, caplog: Any) -> None:
+    """Stress test: response.create rejection + retry via real event processing.
+
+    Tool results (is_idle_tool_call=False) queue response.create calls via
+    _safe_response_create.  When the server rejects some with
+    ``conversation_already_has_active_response``, the error event flows through
+    the event handler and _response_sender_loop retries the rejected request.
+
+    The full _run_realtime_session event loop runs so that the error-handling
+    code path (setting _last_response_rejected) is exercised by real event
+    processing, not mocked out.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    FakeCCE = type("FakeCCE", (Exception,), {})
+    monkeypatch.setattr(rt_mod, "ConnectionClosedError", FakeCCE)
+    monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
+    monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
+    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda: [])
+
+    N_TOOL_RESULTS = 400
+    REJECT_CALL_NUMBERS = {1, 3, 5, 10, 25, 50, 75, 100, 150, 200, 300, 399}
+    EXPECTED_TOTAL_CALLS = N_TOOL_RESULTS + len(REJECT_CALL_NUMBERS)
+
+    event_queue: asyncio.Queue[Any] = asyncio.Queue()
+    response_create_log: list[tuple[int, dict[str, Any]]] = []
+    handler_ref: list[Any] = []
+
+    # ---- Fake event / error objects mirroring the OpenAI SDK shapes ----
+
+    class FakeError:
+        def __init__(self, message: str, code: str) -> None:
+            self.message = message
+            self.code = code
+            self.type = "invalid_request_error"
+            self.event_id = None
+            self.param = None
+
+        def __repr__(self) -> str:
+            return (
+                f"RealtimeError(message='{self.message}', type='{self.type}', "
+                f"code='{self.code}', event_id=None, param=None)"
+            )
+
+    class FakeEvent:
+        def __init__(self, etype: str, **kwargs: Any) -> None:
+            self.type = etype
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    # ---- Fake connection components ----
+
+    class FakeResponseAPI:
+        """Mimics connection.response.
+
+        Pushes server events into the shared event_queue so they flow
+        through the real event-handling code.  Also guards the serialization
+        invariant: every create() must arrive when no response is active.
+        """
+
+        def __init__(self) -> None:
+            self._call_count = 0
+            self._serialization_violations: list[int] = []
+
+        async def create(self, **kwargs: Any) -> None:
+            self._call_count += 1
+            n = self._call_count
+            response_create_log.append((n, kwargs))
+
+            h = handler_ref[0]
+
+            # Real backend rejects when a response is already active.
+            if not h._response_done_event.is_set():
+                self._serialization_violations.append(n)
+                await event_queue.put(
+                    FakeEvent(
+                        "error",
+                        error=FakeError(
+                            message=(
+                                f"Conversation already has an active response in "
+                                f"progress: resp_fake{n}. Wait until the response "
+                                f"is finished before creating a new one."
+                            ),
+                            code="conversation_already_has_active_response",
+                        ),
+                    )
+                )
+                await asyncio.sleep(0)
+                await event_queue.put(
+                    FakeEvent("response.done", response=MagicMock())
+                )
+                return
+
+            # Intentional rejections (simulating a race where another
+            # response sneaks in right after our check).
+            if n in REJECT_CALL_NUMBERS:
+                await event_queue.put(
+                    FakeEvent(
+                        "error",
+                        error=FakeError(
+                            message=(
+                                f"Conversation already has an active response in "
+                                f"progress: resp_fake{n}. Wait until the response "
+                                f"is finished before creating a new one."
+                            ),
+                            code="conversation_already_has_active_response",
+                        ),
+                    )
+                )
+                await asyncio.sleep(0)
+            else:
+                await event_queue.put(FakeEvent("response.created"))
+
+            await event_queue.put(
+                FakeEvent("response.done", response=MagicMock())
+            )
+
+
+        async def cancel(self, **_kw: Any) -> None:
+            pass
+
+    fake_response_api = FakeResponseAPI()
+
+    class FakeSession:
+        async def update(self, **_kw: Any) -> None:
+            pass
+
+    class FakeInputAudioBuffer:
+        async def append(self, **_kw: Any) -> None:
+            pass
+
+    class FakeItem:
+        async def create(self, **_kw: Any) -> None:
+            pass
+
+    class FakeConversation:
+        item = FakeItem()
+
+    class FakeConn:
+        session = FakeSession()
+        input_audio_buffer = FakeInputAudioBuffer()
+        conversation = FakeConversation()
+        response = fake_response_api
+
+        async def __aenter__(self) -> "FakeConn":
+            return self
+
+        async def __aexit__(self, *_a: Any) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+        def __aiter__(self) -> "FakeConn":
+            return self
+
+        async def __anext__(self) -> FakeEvent:
+            event: FakeEvent = await event_queue.get()
+            if event is None:  # sentinel → end iteration
+                raise StopAsyncIteration
+            return event
+
+    class FakeRealtime:
+        def connect(self, **_kw: Any) -> FakeConn:
+            return FakeConn()
+
+    class FakeClient:
+        def __init__(self, **_kw: Any) -> None:
+            self.realtime = FakeRealtime()
+
+    monkeypatch.setattr(rt_mod, "AsyncOpenAI", FakeClient)
+
+    # Patch dispatch_tool_call so tools complete with a result.
+    async def _fake_dispatch(
+        tool_name: str, args_json: str, deps: Any, **_kw: Any
+    ) -> dict[str, Any]:
+        await asyncio.sleep(random.uniform(0.3, 0.5))
+        return {"ok": True, "tool": tool_name}
+
+    monkeypatch.setattr(btm_mod, "dispatch_tool_call", _fake_dispatch)
+
+    # ---- Build handler and start the full realtime session ----
+
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = rt_mod.OpenaiRealtimeHandler(deps)
+    handler_ref.append(handler)
+
+    asyncio.create_task(handler.start_up())
+
+    # ---- Start tools via the real BackgroundToolManager pipeline ----
+    # start_tool → _run_tool → notification queue → listener → _handle_tool_result
+
+    for i in range(N_TOOL_RESULTS):
+        await handler.tool_manager.start_tool(
+            call_id=f"call_{i}",
+            tool_call_routine=ToolCallRoutine(
+                tool_name="test_tool",
+                args_json_str=f'{{"index": {i}}}',
+                deps=deps,
+            ),
+            is_idle_tool_call=False,
+        )
+
+    # Yield so spawned tool tasks, the listener, and the sender can drain.
+    await asyncio.sleep(5)
+
+    # ---- Tear down ----
+
+    await event_queue.put(None)  # sentinel stops event iteration
+
+    await handler.shutdown()
+
+
+    # ---- Assertions ----
+
+    # Serialization: every response.create() must have been called only when
+    # no response was in-flight (_response_done_event was set).  Any violation
+    # means the sender fired a new request before the previous one finished.
+    assert fake_response_api._serialization_violations == [], (
+        f"response.create() was called while a response was still active on "
+        f"call(s) {fake_response_api._serialization_violations}"
+    )
+
+    # Total response.create() calls = tool results + retries for rejected ones
+    assert fake_response_api._call_count == EXPECTED_TOTAL_CALLS, (
+        f"Expected {EXPECTED_TOTAL_CALLS} response.create calls "
+        f"({N_TOOL_RESULTS} results + {len(REJECT_CALL_NUMBERS)} retries), "
+        f"got {fake_response_api._call_count}"
+    )
+
+    # The error event handler must have set _last_response_rejected for each
+    # rejection (the log message comes from the event handler code path).
+    rejection_logs = [
+        r for r in caplog.records
+        if "worker will retry" in getattr(r, "msg", "")
+    ]
+    assert len(rejection_logs) == len(REJECT_CALL_NUMBERS), (
+        f"Expected {len(REJECT_CALL_NUMBERS)} rejection entries from error handler, "
+        f"got {len(rejection_logs)}"
+    )
+
+    # The sender loop must have retried after each rejection.
+    retry_logs = [
+        r for r in caplog.records
+        if "response.create was rejected; retrying" in getattr(r, "msg", "")
+    ]
+    assert len(retry_logs) == len(REJECT_CALL_NUMBERS), (
+        f"Expected {len(REJECT_CALL_NUMBERS)} retry entries from sender loop, "
+        f"got {len(retry_logs)}"
+    )
+
+
+# ---- Response creation timeout guard tests ----
+
+
+@pytest.mark.asyncio
+async def test_response_sender_loop_times_out_waiting_for_response_done(
+    monkeypatch: Any, caplog: Any,
+) -> None:
+    """If response.done is never received the sender loop should time out.
+
+    Rather than hang forever, it force-sets the event and moves on.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    monkeypatch.setattr(rt_mod, "_RESPONSE_DONE_TIMEOUT", 0.3)
+
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = rt_mod.OpenaiRealtimeHandler(deps)
+
+    create_count = 0
+
+    class FakeResponse:
+        async def create(self, **_kw: Any) -> None:
+            nonlocal create_count
+            create_count += 1
+            # Simulate response.created clearing the event, but never
+            # send response.done (so the event stays cleared forever).
+            handler._response_done_event.clear()
+
+        async def cancel(self, **_kw: Any) -> None:
+            pass
+
+    fake_conn = MagicMock()
+    fake_conn.response = FakeResponse()
+    handler.connection = fake_conn
+
+    # Queue two requests
+    await handler._safe_response_create(instructions="req1")
+    await handler._safe_response_create(instructions="req2")
+
+    sender_task = asyncio.create_task(handler._response_sender_loop())
+
+    # Give enough time for both requests to time out (0.3s each + margin)
+    await asyncio.sleep(1.5)
+
+    handler.connection = None  # signal the loop to exit
+    handler._response_done_event.set()
+    await asyncio.wait_for(sender_task, timeout=2.0)
+
+    assert create_count == 2, f"Expected 2 response.create calls, got {create_count}"
+
+    timeout_logs = [
+        r for r in caplog.records
+        if "Timed out waiting for response.done" in r.getMessage()
+    ]
+    assert len(timeout_logs) == 2, (
+        f"Expected 2 timeout warnings, got {len(timeout_logs)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_sender_loop_times_out_waiting_for_previous_response(
+    monkeypatch: Any, caplog: Any,
+) -> None:
+    """If a previous response never completes, the pre-condition wait times out.
+
+    It should force-set the event and proceed to send.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    monkeypatch.setattr(rt_mod, "_RESPONSE_DONE_TIMEOUT", 0.3)
+
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = rt_mod.OpenaiRealtimeHandler(deps)
+
+    # Pretend a response is already in-flight (event cleared)
+    handler._response_done_event.clear()
+
+    created = asyncio.Event()
+
+    class FakeResponse:
+        async def create(self, **_kw: Any) -> None:
+            # Immediately complete the response cycle so the loop can finish
+            handler._response_done_event.set()
+            created.set()
+
+        async def cancel(self, **_kw: Any) -> None:
+            pass
+
+    fake_conn = MagicMock()
+    fake_conn.response = FakeResponse()
+    handler.connection = fake_conn
+
+    await handler._safe_response_create(instructions="waiting_req")
+
+    sender_task = asyncio.create_task(handler._response_sender_loop())
+
+    # Wait for the request to be sent (after timing out on the pre-condition)
+    await asyncio.wait_for(created.wait(), timeout=2.0)
+
+    handler.connection = None
+    handler._response_done_event.set()
+    await asyncio.wait_for(sender_task, timeout=2.0)
+
+    timeout_logs = [
+        r for r in caplog.records
+        if "Timed out waiting for previous response" in r.getMessage()
+    ]
+    assert len(timeout_logs) == 1, (
+        f"Expected 1 pre-condition timeout warning, got {len(timeout_logs)}"
+    )

--- a/tests/tools/test_background_tool_manager.py
+++ b/tests/tools/test_background_tool_manager.py
@@ -1,0 +1,545 @@
+"""Tests for BackgroundToolManager."""
+
+from __future__ import annotations
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools.tool_constants import ToolState
+from reachy_mini_conversation_app.tools.background_tool_manager import (
+    ToolProgress,
+    BackgroundTool,
+    ToolCallRoutine,
+    ToolNotification,
+    BackgroundToolManager,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_routine(
+    tool_name: str = "test_tool",
+    result: dict[str, Any] | None = None,
+    error: Exception | None = None,
+    delay: float = 0.0,
+) -> ToolCallRoutine:
+    """Create a mock ToolCallRoutine that returns *result* or raises *error*.
+
+    If *delay* > 0, the routine will sleep for that many seconds before
+    returning / raising so we can test cancellation and progress.
+
+    Mirrors the contract of ``_dispatch_tool_call`` in core_tools: exceptions
+    (including ``CancelledError``) are caught and returned as
+    ``{"error": "..."}`` dicts so that ``_run_tool`` never sees a raw raise.
+    """
+    routine = MagicMock(spec=ToolCallRoutine)
+    routine.tool_name = tool_name
+    routine.args_json_str = "{}"
+
+    async def _call(manager: BackgroundToolManager) -> dict[str, Any]:
+        try:
+            if delay:
+                await asyncio.sleep(delay)
+            if error is not None:
+                raise error
+            return result or {"ok": True}
+        except asyncio.CancelledError:
+            return {"error": "Tool cancelled"}
+        except Exception as e:
+            return {"error": f"{type(e).__name__}: {e}"}
+
+    routine.__call__ = _call  # type: ignore[method-assign]
+    routine.side_effect = _call
+    return routine
+
+
+# ---------------------------------------------------------------------------
+# Model / data-class sanity checks
+# ---------------------------------------------------------------------------
+
+
+class TestToolProgress:
+    """Validate ToolProgress construction and bounds."""
+
+    def test_valid_progress(self) -> None:
+        """Accept valid progress values and messages."""
+        p = ToolProgress(progress=0.5, message="halfway")
+        assert p.progress == 0.5
+        assert p.message == "halfway"
+
+    def test_bounds(self) -> None:
+        """Allow 0.0 and 1.0 as boundary values."""
+        assert ToolProgress(progress=0.0).progress == 0.0
+        assert ToolProgress(progress=1.0).progress == 1.0
+
+    def test_out_of_bounds_raises(self) -> None:
+        """Reject progress values outside [0, 1]."""
+        with pytest.raises(Exception):
+            ToolProgress(progress=-0.1)
+        with pytest.raises(Exception):
+            ToolProgress(progress=1.1)
+
+
+class TestToolNotification:
+    """Validate ToolNotification construction."""
+
+    def test_creation(self) -> None:
+        """Create a notification and verify its fields."""
+        n = ToolNotification(
+            id="abc",
+            tool_name="my_tool",
+            is_idle_tool_call=False,
+            status=ToolState.COMPLETED,
+            result={"data": 1},
+        )
+        assert n.id == "abc"
+        assert n.status == ToolState.COMPLETED
+        assert n.result == {"data": 1}
+        assert n.error is None
+
+
+class TestBackgroundTool:
+    """Validate BackgroundTool helpers."""
+
+    def test_tool_id(self) -> None:
+        """Verify the composite tool_id property includes started_at."""
+        t = BackgroundTool(
+            id="123",
+            tool_name="weather",
+            is_idle_tool_call=False,
+            status=ToolState.RUNNING,
+        )
+        assert t.tool_id == f"weather-123-{t.started_at}"
+
+    def test_get_notification(self) -> None:
+        """Convert a BackgroundTool to a ToolNotification."""
+        t = BackgroundTool(
+            id="1",
+            tool_name="t",
+            is_idle_tool_call=True,
+            status=ToolState.COMPLETED,
+            result={"x": 1},
+            error=None,
+        )
+        n = t.get_notification()
+        assert isinstance(n, ToolNotification)
+        assert n.id == "1"
+        assert n.tool_name == "t"
+        assert n.is_idle_tool_call is True
+        assert n.status == ToolState.COMPLETED
+        assert n.result == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# BackgroundToolManager
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager() -> BackgroundToolManager:
+    """Return a fresh BackgroundToolManager for each test."""
+    return BackgroundToolManager()
+
+
+class TestSetLoop:
+    """Verify event-loop assignment via set_loop."""
+
+    @pytest.mark.asyncio
+    async def test_set_loop_uses_running_loop(self, manager: BackgroundToolManager) -> None:
+        """Default to the current running loop."""
+        manager.set_loop()
+        assert manager._loop is asyncio.get_running_loop()
+
+    def test_set_loop_explicit(self, manager: BackgroundToolManager) -> None:
+        """Accept an explicitly provided loop."""
+        loop = asyncio.new_event_loop()
+        try:
+            manager.set_loop(loop)
+            assert manager._loop is loop
+        finally:
+            loop.close()
+
+    def test_set_loop_creates_new_when_no_running(self, manager: BackgroundToolManager) -> None:
+        """When called outside an async context it falls back to a new loop."""
+        manager.set_loop()
+        assert manager._loop is not None
+
+
+class TestStartTool:
+    """Verify tool registration via start_tool."""
+
+    @pytest.mark.asyncio
+    async def test_start_registers_tool(self, manager: BackgroundToolManager) -> None:
+        """Register a tool and verify its initial state."""
+        routine = _make_routine("greet")
+        bg = await manager.start_tool(
+            call_id="c1",
+            tool_call_routine=routine,
+            is_idle_tool_call=False,
+        )
+        assert bg.tool_name == "greet"
+        assert bg.id == "c1"
+        assert bg.status == ToolState.RUNNING
+        assert manager.get_tool(bg.tool_id) is bg
+
+        # Let the task finish
+        await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_start_with_progress(self, manager: BackgroundToolManager) -> None:
+        """Initialize progress tracking when requested."""
+        routine = _make_routine("slow", delay=0.1)
+        bg = await manager.start_tool(
+            call_id="c2",
+            tool_call_routine=routine,
+            is_idle_tool_call=True,
+            with_progress=True,
+        )
+        assert bg.progress is not None
+        assert bg.progress.progress == 0.0
+        await asyncio.sleep(0.15)
+
+
+class TestRunToolLifecycle:
+    """Test _run_tool via start_tool (the public entry point)."""
+
+    @pytest.mark.asyncio
+    async def test_successful_completion(self, manager: BackgroundToolManager) -> None:
+        """Complete a tool and verify result, status, and notification."""
+        routine = _make_routine("ok_tool", result={"answer": 42})
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False)
+
+        # Wait for the task to finish
+        await asyncio.sleep(0.05)
+
+        assert bg.status == ToolState.COMPLETED
+        assert bg.result == {"answer": 42}
+        assert bg.completed_at is not None
+        assert bg.error is None
+
+        # Notification should be queued
+        notification = manager._notification_queue.get_nowait()
+        assert notification.status == ToolState.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_tool_failure(self, manager: BackgroundToolManager) -> None:
+        """Mark a tool as FAILED when it raises an exception."""
+        routine = _make_routine("bad_tool", error=ValueError("boom"))
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False)
+
+        await asyncio.sleep(0.05)
+
+        assert bg.status == ToolState.FAILED
+        assert "ValueError: boom" in (bg.error or "")
+        assert bg.completed_at is not None
+
+        notification = manager._notification_queue.get_nowait()
+        assert notification.status == ToolState.FAILED
+
+    @pytest.mark.asyncio
+    async def test_tool_cancellation(self, manager: BackgroundToolManager) -> None:
+        """Cancel a running tool and verify CANCELLED status."""
+        routine = _make_routine("long_tool", delay=10.0)
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False)
+
+        # Give the task a moment to start, then cancel
+        await asyncio.sleep(0.02)
+        cancelled = await manager.cancel_tool(bg.tool_id)
+        assert cancelled is True
+
+        # Let cancellation propagate
+        await asyncio.sleep(0.05)
+
+        assert bg.status == ToolState.CANCELLED
+        assert bg.error == "Tool cancelled"
+        assert bg.completed_at is not None
+
+
+class TestUpdateProgress:
+    """Verify progress updates on running tools."""
+
+    @pytest.mark.asyncio
+    async def test_update_progress_success(self, manager: BackgroundToolManager) -> None:
+        """Update progress value and message on a tracked tool."""
+        routine = _make_routine("prog", delay=0.5)
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False, with_progress=True)
+
+        ok = await manager.update_progress(bg.tool_id, 0.5, "half done")
+        assert ok is True
+        assert bg.progress is not None
+        assert bg.progress.progress == 0.5
+        assert bg.progress.message == "half done"
+
+        # Cancel to clean up
+        await manager.cancel_tool(bg.tool_id)
+        await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_update_progress_clamps(self, manager: BackgroundToolManager) -> None:
+        """Clamp out-of-range progress values to [0, 1]."""
+        routine = _make_routine("prog", delay=0.5)
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False, with_progress=True)
+
+        await manager.update_progress(bg.tool_id, 1.5)
+        assert bg.progress is not None
+        assert bg.progress.progress == 1.0
+
+        await manager.update_progress(bg.tool_id, -0.5)
+        assert bg.progress.progress == 0.0
+
+        await manager.cancel_tool(bg.tool_id)
+        await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_update_progress_unknown_tool(self, manager: BackgroundToolManager) -> None:
+        """Return False for an unknown tool_id."""
+        ok = await manager.update_progress("nonexistent", 0.5)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_update_progress_no_tracking(self, manager: BackgroundToolManager) -> None:
+        """Return False when progress tracking is disabled."""
+        routine = _make_routine("fast", delay=0.5)
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False, with_progress=False)
+
+        ok = await manager.update_progress(bg.tool_id, 0.5)
+        assert ok is False
+
+        await manager.cancel_tool(bg.tool_id)
+        await asyncio.sleep(0.05)
+
+
+class TestCancelTool:
+    """Verify tool cancellation behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_nonexistent(self, manager: BackgroundToolManager) -> None:
+        """Return False when the tool_id does not exist."""
+        result = await manager.cancel_tool("does-not-exist")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_already_completed(self, manager: BackgroundToolManager) -> None:
+        """Return True when cancelling an already-completed tool."""
+        routine = _make_routine("done")
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False)
+        await asyncio.sleep(0.05)  # let it finish
+        assert bg.status == ToolState.COMPLETED
+
+        # Cancelling a completed tool should return True (not running, no-op)
+        result = await manager.cancel_tool(bg.tool_id)
+        assert result is True
+
+
+class TestTimeoutTools:
+    """Verify automatic timeout of long-running tools."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_cancels_old_tools(self, manager: BackgroundToolManager) -> None:
+        """Cancel tools exceeding max duration."""
+        # Use a very short max duration
+        manager._max_tool_duration_seconds = 0.01
+
+        routine = _make_routine("slow", delay=10.0)
+        await manager.start_tool("c1", routine, is_idle_tool_call=False)
+
+        # Wait longer than the timeout
+        await asyncio.sleep(0.05)
+
+        count = await manager.timeout_tools()
+        assert count == 1
+
+        await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_timeout_ignores_recent_tools(self, manager: BackgroundToolManager) -> None:
+        """Leave recent tools untouched."""
+        manager._max_tool_duration_seconds = 9999
+
+        routine = _make_routine("fast", delay=10.0)
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False)
+
+        count = await manager.timeout_tools()
+        assert count == 0
+
+        await manager.cancel_tool(bg.tool_id)
+        await asyncio.sleep(0.05)
+
+
+class TestCleanupTools:
+    """Verify cleanup of completed tools from memory."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_old_completed(self, manager: BackgroundToolManager) -> None:
+        """Remove completed tools past the retention window."""
+        manager._max_tool_memory_seconds = 0.01
+
+        routine = _make_routine("old")
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False)
+        await asyncio.sleep(0.05)
+        assert bg.status == ToolState.COMPLETED
+
+        # Wait for the memory retention to expire
+        await asyncio.sleep(0.05)
+
+        removed = await manager.cleanup_tools()
+        assert removed == 1
+        assert manager.get_tool(bg.tool_id) is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_keeps_recent_completed(self, manager: BackgroundToolManager) -> None:
+        """Keep recently completed tools."""
+        manager._max_tool_memory_seconds = 9999
+
+        routine = _make_routine("recent")
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False)
+        await asyncio.sleep(0.05)
+
+        removed = await manager.cleanup_tools()
+        assert removed == 0
+        assert manager.get_tool(bg.tool_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_ignores_running(self, manager: BackgroundToolManager) -> None:
+        """Never remove still-running tools."""
+        manager._max_tool_memory_seconds = 0.0  # immediate expiry
+
+        routine = _make_routine("still_going", delay=10.0)
+        bg = await manager.start_tool("c1", routine, is_idle_tool_call=False)
+
+        removed = await manager.cleanup_tools()
+        assert removed == 0
+
+        await manager.cancel_tool(bg.tool_id)
+        await asyncio.sleep(0.05)
+
+
+class TestGetters:
+    """Verify tool retrieval helpers."""
+
+    @pytest.mark.asyncio
+    async def test_get_tool(self, manager: BackgroundToolManager) -> None:
+        """Return None for missing tools and the instance for known ones."""
+        assert manager.get_tool("nope") is None
+
+        routine = _make_routine("x")
+        bg = await manager.start_tool("1", routine, is_idle_tool_call=False)
+        assert manager.get_tool(bg.tool_id) is bg
+        await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_get_running_tools(self, manager: BackgroundToolManager) -> None:
+        """Return only tools that are still running."""
+        r1 = _make_routine("a", delay=10.0)
+        r2 = _make_routine("b", delay=10.0)
+        r3 = _make_routine("c")  # finishes immediately
+
+        bg1 = await manager.start_tool("1", r1, is_idle_tool_call=False)
+        bg2 = await manager.start_tool("2", r2, is_idle_tool_call=False)
+        await manager.start_tool("3", r3, is_idle_tool_call=False)
+        await asyncio.sleep(0.05)  # let r3 finish
+
+        running = manager.get_running_tools()
+        assert len(running) == 2
+        names = {t.tool_name for t in running}
+        assert names == {"a", "b"}
+
+        # Clean up
+        await manager.cancel_tool(bg1.tool_id)
+        await manager.cancel_tool(bg2.tool_id)
+        await asyncio.sleep(0.05)
+
+    @pytest.mark.asyncio
+    async def test_get_all_tools_sorted(self, manager: BackgroundToolManager) -> None:
+        """Tools are returned most-recent-first."""
+        r1 = _make_routine("first")
+        r2 = _make_routine("second")
+
+        await manager.start_tool("1", r1, is_idle_tool_call=False)
+        await asyncio.sleep(0.02)  # ensure different started_at
+        await manager.start_tool("2", r2, is_idle_tool_call=False)
+
+        await asyncio.sleep(0.05)
+
+        all_tools = manager.get_all_tools()
+        assert len(all_tools) == 2
+        assert all_tools[0].tool_name == "second"
+        assert all_tools[1].tool_name == "first"
+
+    @pytest.mark.asyncio
+    async def test_get_all_tools_limit(self, manager: BackgroundToolManager) -> None:
+        """Respect the limit parameter on get_all_tools."""
+        for i in range(5):
+            r = _make_routine(f"t{i}")
+            await manager.start_tool(str(i), r, is_idle_tool_call=False)
+
+        await asyncio.sleep(0.05)
+
+        limited = manager.get_all_tools(limit=3)
+        assert len(limited) == 3
+
+
+class TestStartUp:
+    """Verify start_up bootstraps background tasks."""
+
+    @pytest.mark.asyncio
+    async def test_startup_creates_tasks(self, manager: BackgroundToolManager) -> None:
+        """start_up should create the listener and cleanup background tasks."""
+        callback = AsyncMock()
+        manager.start_up(tool_callbacks=[callback])
+
+        # Start a tool and let it complete — the listener should invoke the callback
+        routine = _make_routine("ping")
+        await manager.start_tool("c1", routine, is_idle_tool_call=False)
+        await asyncio.sleep(0.1)
+
+        assert callback.call_count == 1
+        notification = callback.call_args[0][0]
+        assert isinstance(notification, ToolNotification)
+        assert notification.status == ToolState.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_startup_multiple_callbacks(self, manager: BackgroundToolManager) -> None:
+        """Invoke all registered callbacks on completion."""
+        cb1 = AsyncMock()
+        cb2 = AsyncMock()
+        manager.start_up(tool_callbacks=[cb1, cb2])
+
+        routine = _make_routine("multi")
+        await manager.start_tool("c1", routine, is_idle_tool_call=False)
+        await asyncio.sleep(0.1)
+
+        assert cb1.call_count == 1
+        assert cb2.call_count == 1
+
+
+class TestNotificationQueue:
+    """Verify notifications are enqueued on tool completion or failure."""
+
+    @pytest.mark.asyncio
+    async def test_notifications_queued_on_completion(self, manager: BackgroundToolManager) -> None:
+        """Queue a COMPLETED notification with the tool result."""
+        routine = _make_routine("notif", result={"v": 1})
+        await manager.start_tool("c1", routine, is_idle_tool_call=False)
+        await asyncio.sleep(0.05)
+
+        n = manager._notification_queue.get_nowait()
+        assert n.tool_name == "notif"
+        assert n.status == ToolState.COMPLETED
+        assert n.result == {"v": 1}
+
+    @pytest.mark.asyncio
+    async def test_notifications_queued_on_failure(self, manager: BackgroundToolManager) -> None:
+        """Queue a FAILED notification with the error message."""
+        routine = _make_routine("fail", error=RuntimeError("oops"))
+        await manager.start_tool("c1", routine, is_idle_tool_call=False)
+        await asyncio.sleep(0.05)
+
+        n = manager._notification_queue.get_nowait()
+        assert n.status == ToolState.FAILED
+        assert "RuntimeError: oops" in (n.error or "")


### PR DESCRIPTION
## Summary

Split from PR [#205](https://github.com/pollen-robotics/reachy_mini_conversation_app/pull/205): this PR delivers part 1/3, introducing the non-blocking execution foundation with `BackgroundToolManager`, response serialization (`_response_sender_loop`/`_safe_response_create`), openai_realtime integration, and focused tests.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
<!-- Optional: context, caveats, migration notes -->
