### PR TITLE
fix: support DaemonStatus object in simulation status check

### DIFF
--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -90,9 +90,16 @@ def run(
             logger.error("Please check your configuration and try again.")
             sys.exit(1)
 
-    # Auto-enable Gradio in simulation mode (both MuJoCo for deamon and mockup-sim for desktop app)
+    # Auto-enable Gradio in simulation mode (both MuJoCo for daemon and mockup-sim for desktop app)
     status = robot.client.get_status()
-    is_simulation = status.get("simulation_enabled", False) or status.get("mockup_sim_enabled", False)
+    if isinstance(status, dict):
+        simulation_enabled = status.get("simulation_enabled", False)
+        mockup_sim_enabled = status.get("mockup_sim_enabled", False)
+    else:
+        simulation_enabled = getattr(status, "simulation_enabled", False)
+        mockup_sim_enabled = getattr(status, "mockup_sim_enabled", False)
+
+    is_simulation = simulation_enabled or mockup_sim_enabled
 
     if is_simulation and not args.gradio:
         logger.info("Simulation mode detected. Automatically enabling gradio flag.")


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
<!-- Optional: context, caveats, migration notes -->
