### PR TITLE
fix(ci): install system deps for PyGObject in test and typecheck work…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,12 @@ jobs:
       HF_HUB_DOWNLOAD_TIMEOUT: "120"
 
     steps:
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libcairo2-dev libgirepository1.0-dev
+          version: 1.0
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -26,6 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Install system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libcairo2-dev libgirepository1.0-dev
+          version: 1.0
+
       - uses: actions/checkout@v6
 
       - name: Install uv


### PR DESCRIPTION
…flows

reachy-mini 1.5.0 transitively depends on PyGObject on Linux, which requires libcairo2-dev and libgirepository1.0-dev to build from source.

## Summary
<!-- What does this PR change and why? -->

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [X] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
<!-- Optional: context, caveats, migration notes -->
