### PR TITLE
docs: add privacy notice to static web UI

### DIFF
--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -19,6 +19,45 @@
         <p class="subtitle">Configure your OpenAI key and tweak personalities without the full UI.</p>
       </header>
 
+      <aside class="privacy-notice" role="note" aria-label="Privacy notice">
+        <p>
+          <strong>Privacy notice:</strong>
+          By default, speech and camera data is sent to OpenAI's Realtime API for inference.
+          OpenAI does <strong>not</strong> use API data to train models, but retains it up to 30 days
+          for abuse monitoring. Clone the
+          <a href="https://github.com/pollen-robotics/reachy_mini_conversation_app" target="_blank" rel="noopener">
+            project from GitHub
+          </a>
+          and use <code>--local-vision</code> to keep image processing on-device.
+        </p>
+
+        <details>
+          <summary>Learn more</summary>
+
+          <p>
+            Audio streams are transmitted to OpenAI for realtime speech processing. 
+            Robot-captured images may also be sent when the assistant uses the camera tool for vision analysis. Per OpenAI's
+            <a href="https://platform.openai.com/docs/guides/your-data" target="_blank" rel="noopener">
+              data usage policy
+            </a>:
+          </p>
+
+          <ul>
+            <li>API inputs and outputs are <strong>not</strong> used for model training (since March 2023).</li>
+            <li>Data may be retained up to <strong>30 days</strong> for abuse monitoring.</li>
+            <li>Audio outputs are cached for <strong>~1 hour</strong> to support multi-turn conversations.</li>
+          </ul>
+
+          <p>
+            In privacy-sensitive environments, use <code>--local-vision</code> to process images on-device. See the
+            <a href="https://github.com/pollen-robotics/reachy_mini_conversation_app/blob/main/README.md" target="_blank" rel="noopener">
+              project README
+            </a>
+            for full setup instructions.
+          </p>
+        </details>
+      </aside>
+
       <div id="configured" class="panel hidden">
         <div class="panel-heading">
           <div>

--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -22,38 +22,22 @@
       <aside class="privacy-notice" role="note" aria-label="Privacy notice">
         <p>
           <strong>Privacy notice:</strong>
-          By default, speech and camera data is sent to OpenAI's Realtime API for inference.
-          OpenAI does <strong>not</strong> use API data to train models, but retains it up to 30 days
-          for abuse monitoring. Clone the
-          <a href="https://github.com/pollen-robotics/reachy_mini_conversation_app" target="_blank" rel="noopener">
-            project from GitHub
+          By default, speech and camera data are sent to OpenAI's Realtime API for inference. See OpenAI's
+          <a href="https://platform.openai.com/docs/guides/your-data" target="_blank" rel="noopener">
+            data usage policy
           </a>
-          and use <code>--local-vision</code> to keep image processing on-device.
+          for details.
         </p>
 
         <details>
           <summary>Learn more</summary>
 
           <p>
-            Audio streams are transmitted to OpenAI for realtime speech processing. 
-            Robot-captured images may also be sent when the assistant uses the camera tool for vision analysis. Per OpenAI's
-            <a href="https://platform.openai.com/docs/guides/your-data" target="_blank" rel="noopener">
-              data usage policy
-            </a>:
-          </p>
-
-          <ul>
-            <li>API inputs and outputs are <strong>not</strong> used for model training (since March 2023).</li>
-            <li>Data may be retained up to <strong>30 days</strong> for abuse monitoring.</li>
-            <li>Audio outputs are cached for <strong>~1 hour</strong> to support multi-turn conversations.</li>
-          </ul>
-
-          <p>
             In privacy-sensitive environments, use <code>--local-vision</code> to process images on-device. See the
             <a href="https://github.com/pollen-robotics/reachy_mini_conversation_app/blob/main/README.md" target="_blank" rel="noopener">
               project README
             </a>
-            for full setup instructions.
+            for full setup instructions. An open-source approach is in the works – stay tuned for its release.
           </p>
         </details>
       </aside>

--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -92,6 +92,96 @@ body {
   border: 1px solid rgba(94, 240, 193, 0.25);
 }
 
+.privacy-notice {
+  margin: 0 0 18px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 181, 71, 0.35);
+  background: linear-gradient(135deg, rgba(255, 181, 71, 0.12), rgba(255, 255, 255, 0.02));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.privacy-notice p {
+  margin: 0;
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.privacy-notice p + p,
+.privacy-notice p + ul,
+.privacy-notice ul + p {
+  margin-top: 8px;
+}
+
+.privacy-notice strong {
+  color: var(--warn);
+  font-weight: 700;
+}
+
+.privacy-notice a {
+  color: #7c3aed;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.privacy-notice code {
+  padding: 2px 6px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--text);
+  font-family: "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+
+.privacy-notice details {
+  margin-top: 8px;
+}
+
+.privacy-notice summary {
+  cursor: pointer;
+  color: var(--accent);
+  font-size: 12px;
+}
+
+.privacy-notice summary:focus-visible {
+  outline: 2px solid rgba(69, 196, 255, 0.6);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.privacy-notice details[open] summary {
+  margin-bottom: 6px;
+}
+
+.privacy-notice details > p,
+.privacy-notice details > ul {
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.privacy-notice ul {
+  margin: 8px 0;
+  padding-left: 1.25em;
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.privacy-notice li {
+  margin: 0 0 4px;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.privacy-notice li:last-child {
+  margin-bottom: 0;
+}
+
 .panel {
   background: var(--panel);
   border: 1px solid var(--border);
@@ -310,6 +400,7 @@ button.ghost:hover { border-color: rgba(94, 240, 193, 0.4); }
 
 @media (max-width: 760px) {
   .hero h1 { font-size: 26px; }
+  .privacy-notice { padding: 10px 12px; }
   .row { grid-template-columns: 1fr; }
   #personality-panel .row:first-of-type { grid-template-columns: 1fr; }
   button { width: 100%; justify-content: center; }


### PR DESCRIPTION
## Summary
Solves https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/241. Adds a privacy notice to the static web UI to clarify how audio and camera data are handled by the application.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added