### PR TITLE
244 add deploy script for faster development on wireless units

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,29 @@ reachy-mini-conversation-app --robot-name <name>
 
 </details>
 
+## Development on Wireless
+
+The `scripts/` folder contains helper scripts for faster iteration on a Wireless Reachy Mini:
+
+- **`deploy_wireless.sh`** — Rsyncs your local source to the robot's site-packages, stops any running app, starts the conversation app via the daemon API, and tails logs. This uses the same launch path as the dashboard, so it's representative of production behavior.
+- **`stop_app.sh`** — Stops whatever app is currently running (equivalent to the dashboard's "Stop" button).
+
+```bash
+./scripts/deploy_wireless.sh                  # default: reachy-mini.local
+./scripts/deploy_wireless.sh 192.168.1.42    # custom IP
+./scripts/stop_app.sh
+```
+
+Requires `bash`, `ssh`, and `rsync` (native on Linux/macOS, use Git Bash or WSL on Windows).
+
+> [!TIP]
+> Set up passwordless SSH to avoid typing the password multiple times per deploy:
+> ```bash
+> ssh-copy-id pollen@reachy-mini.local   # password: root
+> ```
+
+For more development workflows and tips, see the [Development Workflow for Wireless Reachy Mini](https://huggingface.co/docs/reachy_mini/platforms/reachy_mini/development_workflow#development-workflow-for-wireless-reachy-mini) documentation.
+
 ## Contributing
 
 We welcome bug fixes, features, profiles, and documentation improvements. Please review our

--- a/scripts/deploy_wireless.sh
+++ b/scripts/deploy_wireless.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────
+# Deploy conversation app to Reachy Mini Wireless and start it via the daemon.
+#
+# Rsyncs your local source code to the robot's site-packages, then
+# starts the app through the daemon API (same as clicking "Start"
+# on the dashboard). Logs stream live to your terminal.
+#
+# PREREQUISITES:
+#   1. Passwordless SSH access to the robot:
+#        ssh-copy-id pollen@reachy-mini.local    (password: root)
+#
+#   2. The reachy-mini-daemon must be running on the robot.
+#      It starts automatically on boot. If stopped:
+#        ssh pollen@reachy-mini.local 'systemctl restart reachy-mini-daemon.service'
+#
+#   3. The robot must be powered on and on the same network as your laptop.
+#      If reachy-mini.local doesn't resolve, pass the IP address instead.
+#
+# PLATFORM:
+#   Requires bash, ssh, rsync, and curl.
+#   Works on Linux and macOS natively. On Windows, use Git Bash or WSL.
+#
+# WIRELESS ONLY:
+#   This script targets the Wireless version's shared venv at
+#   /venvs/apps_venv/ with Python 3.12. The Lite version uses a
+#   different venv layout — this script will NOT work on Lite as-is.
+#
+# HOW IT WORKS:
+#   1. Checks the daemon is running (systemctl is-active)
+#   2. Rsyncs reachy_mini_conversation_app/ into site-packages (~1 second)
+#   3. Stops any currently running app (POST /api/apps/stop-current-app)
+#   4. Starts conversation app via daemon (POST /api/apps/start-app/reachy_mini_conversation_app)
+#   5. Tails journalctl for live log output
+#
+#   Ctrl+C detaches from logs — the app keeps running on the robot.
+#   You can also stop it from the dashboard, or with the daemon API.
+#
+# USAGE:
+#   ./deploy_wireless.sh                  # default: reachy-mini.local
+#   ./deploy_wireless.sh 192.168.1.42    # custom IP
+#   ./deploy_wireless.sh --sync-only     # sync without starting
+# ─────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+SYNC_ONLY=false
+HOST="reachy-mini.local"
+
+for arg in "$@"; do
+    case "$arg" in
+        --sync-only) SYNC_ONLY=true ;;
+        *)           HOST="$arg" ;;
+    esac
+done
+
+USER="pollen"
+SITE_PACKAGES="/venvs/apps_venv/lib/python3.12/site-packages"
+REMOTE="${USER}@${HOST}"
+TARGET="${REMOTE}:${SITE_PACKAGES}/reachy_mini_conversation_app/"
+DAEMON_API="http://127.0.0.1:8000/api/apps"
+
+# Resolve the project root (one level up from scripts/)
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE="${SCRIPT_DIR}/src/reachy_mini_conversation_app/"
+
+# ── 1. Check daemon is running ───────────────────────────────────────
+echo "==> Checking daemon on ${HOST}..."
+if ! ssh -o ConnectTimeout=5 "${REMOTE}" \
+    "systemctl is-active --quiet reachy-mini-daemon" 2>/dev/null; then
+    echo "    ERROR: reachy-mini-daemon is not running on ${HOST}."
+    echo "    Start it with: ssh ${REMOTE} 'sudo systemctl start reachy-mini-daemon'"
+    exit 1
+fi
+echo "    Daemon is running."
+
+# ── 2. Rsync source to site-packages ─────────────────────────────────
+# This overwrites the installed package with your local source.
+# The dashboard can still manage the app normally afterwards.
+echo "==> Syncing reachy_mini_conversation_app/ to ${HOST}..."
+rsync -az --delete \
+    --exclude '__pycache__' \
+    --exclude '*.pyc' \
+    --exclude 'profiles/' \
+    "$SOURCE" "$TARGET"
+echo "    Sync complete."
+
+if $SYNC_ONLY; then
+    echo "Done (sync only)."
+    exit 0
+fi
+
+# ── 3. Stop any currently running app ─────────────────────────────────
+# Uses the same daemon API as the dashboard's "Stop" button.
+echo "==> Stopping current app (if any)..."
+ssh "${REMOTE}" "curl -sf -X POST ${DAEMON_API}/stop-current-app >/dev/null 2>&1 || true"
+sleep 1
+
+# ── 4. Start conversation app via daemon API ──────────────────────────
+echo "==> Starting reachy_mini_conversation_app via daemon..."
+RESP=$(ssh "${REMOTE}" "curl -sf -X POST ${DAEMON_API}/start-app/reachy_mini_conversation_app 2>/dev/null")
+if [ $? -ne 0 ]; then
+    echo "    ERROR: Failed to start conversation app via daemon API."
+    echo "    Response: ${RESP}"
+    exit 1
+fi
+echo "    Started."
+
+echo ""
+echo "Web UI: http://${HOST}:8042"
+echo ""
+
+# ── 5. Tail logs live ─────────────────────────────────────────────────
+echo "==> Tailing logs (Ctrl+C to detach — app keeps running)..."
+echo ""
+ssh "${REMOTE}" "journalctl -u reachy-mini-daemon -f --no-hostname -o cat" 2>/dev/null || true

--- a/scripts/stop_app.sh
+++ b/scripts/stop_app.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────
+# Stop whatever app is currently running on the robot via the daemon API.
+#
+# This is equivalent to clicking "Stop" on the dashboard.
+#
+# USAGE:
+#   ./stop_app.sh                      # default: reachy-mini.local
+#   ./stop_app.sh 192.168.1.42        # custom IP
+# ─────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+HOST="${1:-reachy-mini.local}"
+REMOTE="pollen@${HOST}"
+DAEMON_API="http://127.0.0.1:8000/api/apps"
+
+echo "==> Stopping current app on ${HOST}..."
+RESP=$(ssh -o ConnectTimeout=5 "${REMOTE}" \
+    "curl -sf -X POST ${DAEMON_API}/stop-current-app 2>/dev/null" 2>/dev/null) || true
+
+# Check what's running now
+STATUS=$(ssh "${REMOTE}" \
+    "curl -sf ${DAEMON_API}/current-app-status 2>/dev/null" 2>/dev/null) || true
+
+if [ "$STATUS" = "null" ] || [ -z "$STATUS" ]; then
+    echo "    No app running."
+else
+    echo "    Status: ${STATUS}"
+fi


### PR DESCRIPTION
## Summary
Implementing this for the conv app:
https://discord.com/channels/519098054377340948/1451670882094284850/1474823046366761021

The `scripts/` folder contains helper scripts for faster iteration on a Wireless Reachy Mini:

- **`deploy_wireless.sh`** — Rsyncs your local source to the robot's site-packages, stops any running app, starts the conversation app via the daemon API, and tails logs. This uses the same launch path as the dashboard, so it's representative of production behavior.
- **`stop_app.sh`** — Stops whatever app is currently running (equivalent to the dashboard's "Stop" button).

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ x ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ x ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
<!-- Optional: context, caveats, migration notes -->
