### PR TITLE
247 the control loop doesnt have a stable enough frequency on the wireless unit

### DIFF
--- a/src/reachy_mini_conversation_app/moves.py
+++ b/src/reachy_mini_conversation_app/moves.py
@@ -643,7 +643,7 @@ class MovementManager:
     def _issue_control_command(self, head: NDArray[np.float32], antennas: Tuple[float, float], body_yaw: float) -> None:
         """Send the fused pose to the robot with throttled error logging."""
         try:
-            self.current_robot.set_target_full(head=head, antennas=antennas, body_yaw=body_yaw)
+            self.current_robot.set_target(head=head, antennas=antennas, body_yaw=body_yaw)
         except Exception as e:
             now = self._now()
             if now - self._last_set_target_err >= self._set_target_err_interval:


### PR DESCRIPTION
## Summary

The control loop in `moves.py` couldn't sustain a stable frequency on the Wireless unit (Pi CM4). Profiling revealed three bottlenecks (the forth is minor):

1. **100Hz target was unreachable** — the Pi CM4 averaged ~77Hz with high variance (std 26.2)
2. **`set_target()` sent 3 separate WebSocket messages per tick** — Pydantic serialization + WS send x3 cost 6.7ms mean (p99: 43ms)
3. **`compose_world_offset(reorthonormalize=True)` ran SVD every tick** — unnecessary since poses are freshly composed each tick (no drift accumulation)
4. **`create_head_pose()` called unconditionally** even when secondary offsets (speech wobble + face tracking) hadn't changed

## Changes

Four commits, one per fix:

- **Lower target from 100Hz to 60Hz** — low-level runs at 50Hz, so 60Hz ensures a fresh target per hardware tick without wasting CPU headroom
- **Remove per-tick SVD reorthonormalization** — `reorthonormalize=False` in `combine_full_body()`, saves ~2ms/tick on Pi CM4
- **Cache secondary pose** — skip `create_head_pose()` (scipy `R.from_euler` + `np.eye(4)`) when offsets haven't changed since last tick
- **Use batched `set_target_full()`** — single WS message instead of 3 (requires pollen-robotics/reachy_mini#962)

## Performance evolution

### Step 1: Baseline at 100Hz

avg 77.1Hz, std 26.2, min 1.2Hz, max 99.5Hz
<img width="1836" height="647" alt="image" src="https://github.com/user-attachments/assets/75dd4a57-ceed-40c3-bebc-f30131a715e3" />


### Step 2: Lower target to 60Hz

avg 55.7Hz, std 7.2, min 5.7Hz, max 59.7Hz
<img width="1836" height="647" alt="image" src="https://github.com/user-attachments/assets/5c104203-10a5-4be2-9cce-26fbd95f1cae" />

### Step 3: Per-tick timing breakdown (before optimizations)

Instrumented each phase of the control loop at 60Hz:

| Phase | mean | p50 | p95 | p99 | max |
|-------|-----:|----:|----:|----:|----:|
| signals (poll) | 0.12ms | 0.09ms | 0.25ms | 0.54ms | 3.1ms |
| motion+tracking | 0.07ms | 0.04ms | 0.13ms | 0.48ms | 6.1ms |
| compose+blend | 4.5ms | 3.0ms | 12.1ms | 19.1ms | 52.7ms |
| **WS send** | **6.7ms** | **4.6ms** | **17.3ms** | **43.5ms** | **149.6ms** |
| lock wait | 0.01ms | 0.005ms | 0.015ms | 0.04ms | 0.9ms |
| clone | 0.07ms | 0.04ms | 0.13ms | 0.43ms | 4.4ms |

16.4% of ticks exceeded the 16.7ms budget.

### Step 4: All optimizations applied (no SVD + cached secondary + batched WS)

| Metric | Before | After | Change |
|--------|-------:|------:|-------:|
| `ws_send_ms` mean | 6.73ms | **3.63ms** | **-46%** |
| `compose_ms` mean | 4.49ms | **2.53ms** | **-44%** |
| Total compute mean | 11.47ms | **6.40ms** | **-44%** |
| Ticks over budget | 16.4% | **4.6%** | **-72%** |
| Frequency avg | 55.7Hz | **56.8Hz** | +1.1Hz |
| Frequency std | 7.2 | **5.3** | -26% jitter |

<img width="1836" height="647" alt="image" src="https://github.com/user-attachments/assets/5bd7962d-01d6-41c6-ba8f-663e4615ee54" />

## Dependencies

- reachy_mini#962 (adds `set_target_full()` to the SDK)
/!\ Don't merge before this is merged on the core!

## Tests
I did a bunch of benchmark runs and some conversations with the robot. More testing is welcome.