### PR TITLE
Update deprecated/non-existent OpenAI Realtime events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "python-dotenv",
 
     #OpenAI
-    "openai==2.24.0",
+    "openai==2.28.0",
 
     #Reachy mini
     "reachy_mini_dances_library",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "python-dotenv",
 
     #OpenAI
-    "openai>=2.1",
+    "openai==2.24.0",
 
     #Reachy mini
     "reachy_mini_dances_library",

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -16,16 +16,18 @@ from fastrtc import AdditionalOutputs, AsyncStreamHandler, wait_for_item, audio_
 from pydantic import Field, BaseModel
 from numpy.typing import NDArray
 from scipy.signal import resample
-from openai.types.realtime import RealtimeSessionCreateRequestParam
+from openai.types.realtime import (
+    ConversationItemParam,
+    AudioTranscriptionParam,
+    RealtimeAudioConfigParam,
+    RealtimeAudioConfigInputParam,
+    RealtimeAudioConfigOutputParam,
+    RealtimeResponseCreateParamsParam,
+    RealtimeSessionCreateRequestParam,
+)
 from websockets.exceptions import ConnectionClosedError
 from openai.resources.realtime.realtime import AsyncRealtimeConnection
-from openai.types.realtime.conversation_item_param import ConversationItemParam
-from openai.types.realtime.audio_transcription_param import AudioTranscriptionParam
-from openai.types.realtime.realtime_audio_config_param import RealtimeAudioConfigParam
 from openai.types.realtime.realtime_audio_formats_param import AudioPCM
-from openai.types.realtime.realtime_audio_config_input_param import RealtimeAudioConfigInputParam
-from openai.types.realtime.realtime_audio_config_output_param import RealtimeAudioConfigOutputParam
-from openai.types.realtime.realtime_response_create_params_param import RealtimeResponseCreateParamsParam
 from openai.types.realtime.realtime_audio_input_turn_detection_param import ServerVad
 
 from reachy_mini_conversation_app.config import AVAILABLE_VOICES, config
@@ -568,10 +570,6 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             input_transcript.deltas.append(delta)
 
                         sequence_counter = len(input_transcript.deltas) - 1
-
-                        logger.info(f"Input transcript: {input_transcript.deltas}")
-                        logger.info(f"Item ID: {item_id}")
-                        logger.info(f"Sequence counter: {sequence_counter}")
 
                         # Cancel previous debounce task if it exists
                         if self.partial_transcript_task and not self.partial_transcript_task.done():

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -22,7 +22,6 @@ from openai.resources.realtime.realtime import AsyncRealtimeConnection
 from openai.types.realtime.conversation_item_param import ConversationItemParam
 from openai.types.realtime.audio_transcription_param import AudioTranscriptionParam
 from openai.types.realtime.realtime_audio_config_param import RealtimeAudioConfigParam
-from openai.types.realtime.realtime_tools_config_param import RealtimeToolsConfigParam
 from openai.types.realtime.realtime_audio_formats_param import AudioPCM
 from openai.types.realtime.realtime_audio_config_input_param import RealtimeAudioConfigInputParam
 from openai.types.realtime.realtime_audio_config_output_param import RealtimeAudioConfigOutputParam
@@ -481,7 +480,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             voice=get_session_voice(),
                         ),
                     ),
-                    tools=cast(RealtimeToolsConfigParam, get_tool_specs()),
+                    tools=get_tool_specs(), # type: ignore[typeddict-item]
                     tool_choice="auto",
                 )
                 await conn.session.update(session=session_config)

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -3,20 +3,28 @@ import base64
 import random
 import asyncio
 import logging
-from typing import Any, Final, Tuple, Literal, Optional
+from typing import Any, Final, Tuple, Literal, Optional, cast
 from pathlib import Path
 from datetime import datetime
 
 import cv2
 import numpy as np
 import gradio as gr
-from openai import AsyncOpenAI
 from fastrtc import AdditionalOutputs, AsyncStreamHandler, wait_for_item, audio_to_int16
-from openai.resources.realtime.realtime import AsyncRealtimeConnection
 from numpy.typing import NDArray
 from scipy.signal import resample
 from websockets.exceptions import ConnectionClosedError
 
+from openai import AsyncOpenAI
+from openai.types.realtime import RealtimeSessionCreateRequestParam
+from openai.resources.realtime.realtime import AsyncRealtimeConnection
+from openai.types.realtime.audio_transcription_param import AudioTranscriptionParam
+from openai.types.realtime.realtime_audio_config_param import RealtimeAudioConfigParam
+from openai.types.realtime.realtime_tools_config_param import RealtimeToolsConfigParam
+from openai.types.realtime.realtime_audio_formats_param import AudioPCM
+from openai.types.realtime.realtime_audio_config_input_param import RealtimeAudioConfigInputParam
+from openai.types.realtime.realtime_audio_config_output_param import RealtimeAudioConfigOutputParam
+from openai.types.realtime.realtime_audio_input_turn_detection_param import ServerVad
 from reachy_mini_conversation_app.config import config
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
 from reachy_mini_conversation_app.tools.core_tools import (
@@ -133,11 +141,15 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             if self.connection is not None:
                 try:
                     await self.connection.session.update(
-                        session={
-                            "type": "realtime",
-                            "instructions": instructions,
-                            "audio": {"output": {"voice": voice}},
-                        },
+                        session=RealtimeSessionCreateRequestParam(
+                            type="realtime",
+                            instructions=instructions,
+                            audio=RealtimeAudioConfigParam(
+                                output=RealtimeAudioConfigOutputParam(
+                                    voice=voice,
+                                ),
+                            ),
+                        ),
                     )
                     logger.info("Applied personality via live update: %s", profile or "built-in default")
                 except Exception as e:
@@ -259,34 +271,24 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         """Establish and manage a single realtime session."""
         async with self.client.realtime.connect(model=config.MODEL_NAME) as conn:
             try:
-                await conn.session.update(
-                    session={
-                        "type": "realtime",
-                        "instructions": get_session_instructions(),
-                        "audio": {
-                            "input": {
-                                "format": {
-                                    "type": "audio/pcm",
-                                    "rate": self.input_sample_rate,
-                                },
-                                "transcription": {"model": "gpt-4o-transcribe", "language": "en"},
-                                "turn_detection": {
-                                    "type": "server_vad",
-                                    "interrupt_response": True,
-                                },
-                            },
-                            "output": {
-                                "format": {
-                                    "type": "audio/pcm",
-                                    "rate": self.output_sample_rate,
-                                },
-                                "voice": get_session_voice(),
-                            },
-                        },
-                        "tools": get_tool_specs(),  # type: ignore[typeddict-item]
-                        "tool_choice": "auto",
-                    },
+                session_config = RealtimeSessionCreateRequestParam(
+                    type="realtime",
+                    instructions=get_session_instructions(),
+                    audio=RealtimeAudioConfigParam(
+                        input=RealtimeAudioConfigInputParam(
+                            format=AudioPCM(type="audio/pcm", rate=self.input_sample_rate),
+                            transcription=AudioTranscriptionParam(model="gpt-4o-transcribe", language="en"),
+                            turn_detection=ServerVad(type="server_vad", interrupt_response=True),
+                        ),
+                        output=RealtimeAudioConfigOutputParam(
+                            format=AudioPCM(type="audio/pcm", rate=self.output_sample_rate),
+                            voice=get_session_voice(),
+                        ),
+                    ),
+                    tools=cast(RealtimeToolsConfigParam, get_tool_specs()),
+                    tool_choice="auto",
                 )
+                await conn.session.update(session=session_config)
                 logger.info(
                     "Realtime session initialized with profile=%r voice=%r",
                     getattr(config, "REACHY_MINI_CUSTOM_PROFILE", None),

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -11,13 +11,12 @@ from datetime import datetime
 import cv2
 import numpy as np
 import gradio as gr
+from openai import AsyncOpenAI
 from fastrtc import AdditionalOutputs, AsyncStreamHandler, wait_for_item, audio_to_int16
 from numpy.typing import NDArray
 from scipy.signal import resample
-from websockets.exceptions import ConnectionClosedError
-
-from openai import AsyncOpenAI
 from openai.types.realtime import RealtimeSessionCreateRequestParam
+from websockets.exceptions import ConnectionClosedError
 from openai.resources.realtime.realtime import AsyncRealtimeConnection
 from openai.types.realtime.conversation_item_param import ConversationItemParam
 from openai.types.realtime.audio_transcription_param import AudioTranscriptionParam
@@ -28,6 +27,7 @@ from openai.types.realtime.realtime_audio_config_input_param import RealtimeAudi
 from openai.types.realtime.realtime_audio_config_output_param import RealtimeAudioConfigOutputParam
 from openai.types.realtime.realtime_response_create_params_param import RealtimeResponseCreateParamsParam
 from openai.types.realtime.realtime_audio_input_turn_detection_param import ServerVad
+
 from reachy_mini_conversation_app.config import AVAILABLE_VOICES, config
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
 from reachy_mini_conversation_app.tools.core_tools import (
@@ -525,10 +525,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                         self.deps.movement_manager.set_listening(False)
                         logger.debug("User speech stopped - server will auto-commit with VAD")
 
-                    if event.type in (
-                        "response.output_audio.done",  # GA
-                        "response.completed",  # text-only completion
-                    ):
+                    if event.type == "response.output_audio.done":
                         logger.debug("response completed")
 
                     if event.type == "response.created":

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -19,14 +19,14 @@ from websockets.exceptions import ConnectionClosedError
 from openai import AsyncOpenAI
 from openai.types.realtime import RealtimeSessionCreateRequestParam
 from openai.resources.realtime.realtime import AsyncRealtimeConnection
+from openai.types.realtime.conversation_item_param import ConversationItemParam
 from openai.types.realtime.audio_transcription_param import AudioTranscriptionParam
 from openai.types.realtime.realtime_audio_config_param import RealtimeAudioConfigParam
-from openai.types.realtime.conversation_item_param import ConversationItemParam
-from openai.types.realtime.realtime_response_create_params_param import RealtimeResponseCreateParamsParam
 from openai.types.realtime.realtime_tools_config_param import RealtimeToolsConfigParam
 from openai.types.realtime.realtime_audio_formats_param import AudioPCM
 from openai.types.realtime.realtime_audio_config_input_param import RealtimeAudioConfigInputParam
 from openai.types.realtime.realtime_audio_config_output_param import RealtimeAudioConfigOutputParam
+from openai.types.realtime.realtime_response_create_params_param import RealtimeResponseCreateParamsParam
 from openai.types.realtime.realtime_audio_input_turn_detection_param import ServerVad
 from reachy_mini_conversation_app.config import config
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
@@ -490,7 +490,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             logger.info("Realtime session updated successfully")
 
             # Reset the partial-transcript accumulator for each new session
-            self.input_transcript_acc: dict[str, str] = {}
+            self.input_transcript_acc.clear()
 
             # Manage event received from the openai server
             self.connection = conn

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -569,9 +569,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
                         sequence_counter = len(input_transcript.deltas) - 1
 
-                        logger.debug(f"Input transcript: {input_transcript.deltas}")
-                        logger.debug(f"Item ID: {item_id}")
-                        logger.debug(f"Sequence counter: {sequence_counter}")
+                        logger.info(f"Input transcript: {input_transcript.deltas}")
+                        logger.info(f"Item ID: {item_id}")
+                        logger.info(f"Sequence counter: {sequence_counter}")
 
                         # Cancel previous debounce task if it exists
                         if self.partial_transcript_task and not self.partial_transcript_task.done():

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -4,7 +4,7 @@ import base64
 import random
 import asyncio
 import logging
-from typing import Any, Final, Tuple, Literal, Optional, cast
+from typing import Any, Final, Tuple, Literal, Optional
 from pathlib import Path
 from datetime import datetime
 
@@ -17,7 +17,6 @@ from pydantic import Field, BaseModel
 from numpy.typing import NDArray
 from scipy.signal import resample
 from openai.types.realtime import (
-    ConversationItemParam,
     AudioTranscriptionParam,
     RealtimeAudioConfigParam,
     RealtimeAudioConfigInputParam,
@@ -120,7 +119,6 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         self.input_transcript_chunks_by_item = InputTranscriptChunksByItem()
 
         # Internal lifecycle flags
-        self._shutdown_requested: bool = False
         self._connected_event: asyncio.Event = asyncio.Event()
 
         # Background tool manager
@@ -387,11 +385,11 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             # TODO: refactor this since it's repeated here, in the camera branch below, and in send_idle_signal
             if isinstance(bg_tool.id, str):
                 await self.connection.conversation.item.create(
-                    item=cast(ConversationItemParam, {
+                    item={
                         "type": "function_call_output",
                         "call_id": bg_tool.id,
                         "output": json.dumps(tool_result),
-                    }),
+                    },
                 )
 
             await self.output_queue.put(
@@ -415,7 +413,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     logger.warning("Unexpected type for b64_im: %s", type(b64_im))
                     b64_im = str(b64_im)
                 await self.connection.conversation.item.create(
-                    item=cast(ConversationItemParam, {
+                    item={
                         "type": "message",
                         "role": "user",
                         "content": [
@@ -424,7 +422,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                                 "image_url": f"data:image/jpeg;base64,{b64_im}",
                             },
                         ],
-                    }),
+                    },
                 )
                 logger.info("Added camera image to conversation")
 
@@ -587,8 +585,6 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     # Handle completed transcription (user finished speaking)
                     if event.type == "conversation.item.input_audio_transcription.completed":
                         logger.debug(f"User transcript: {event.transcript}")
-
-                        item_id = event.item_id
 
                         # Cancel any pending partial emission
                         if self.partial_transcript_task and not self.partial_transcript_task.done():
@@ -761,8 +757,6 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
     async def shutdown(self) -> None:
         """Shutdown the handler."""
-        self._shutdown_requested = True
-
         # Unblock the response sender worker so it can exit
         self._response_done_event.set()
 
@@ -868,11 +862,11 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             logger.debug("No connection, cannot send idle signal")
             return
         await self.connection.conversation.item.create(
-            item=cast(ConversationItemParam, {
+            item={
                 "type": "message",
                 "role": "user",
                 "content": [{"type": "input_text", "text": timestamp_msg}],
-            }),
+            },
         )
         await self._safe_response_create(
             response=RealtimeResponseCreateParamsParam(

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -4,9 +4,10 @@ import base64
 import random
 import asyncio
 import logging
-from typing import Any, Final, Tuple, Literal, Optional, cast
-from pathlib import Path
+from pydantic import BaseModel, Field
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Final, Literal, Optional, Tuple, cast
 
 import cv2
 import numpy as np
@@ -54,6 +55,14 @@ TEXT_OUTPUT_COST_PER_1M = 16.0
 IMAGE_INPUT_COST_PER_1M = 5.0
 
 _RESPONSE_DONE_TIMEOUT: Final[float] = 30.0
+
+
+
+class InputTranscriptChunksByItem(BaseModel):
+    """Current item_id and its accumulated deltas. Only one item at a time."""
+
+    item_id: str | None = None
+    deltas: list[str] = Field(default_factory=list)
 
 
 def _compute_response_cost(usage: Any) -> float:
@@ -107,7 +116,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         # Debouncing for partial transcripts
         self.partial_transcript_task: asyncio.Task[None] | None = None
         self.partial_debounce_delay = 0.5  # seconds
-        self.input_transcript_acc: dict[str, list[str]] = {} # list of delta transcripts by item_id
+        self.input_transcript_chunks_by_item = InputTranscriptChunksByItem()
 
         # Internal lifecycle flags
         self._shutdown_requested: bool = False
@@ -197,8 +206,8 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         try:
             await asyncio.sleep(self.partial_debounce_delay)
 
-            # Only emit if this is still the latest partial (by sequence number)
-            if item_id in self.input_transcript_acc and len(self.input_transcript_acc[item_id]) - 1 == sequence_counter:
+            input_transcript = self.input_transcript_chunks_by_item
+            if input_transcript.item_id == item_id and len(input_transcript.deltas) - 1 == sequence_counter:
                 await self.output_queue.put(AdditionalOutputs({"role": "user_partial", "content": transcript}))
                 logger.debug(f"Debounced partial emitted: {transcript}")
         except asyncio.CancelledError:
@@ -491,7 +500,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             logger.info("Realtime session updated successfully")
 
             # Reset the partial-transcript accumulator for each new session
-            self.input_transcript_acc.clear()
+            self.input_transcript_chunks_by_item = InputTranscriptChunksByItem()
 
             # Manage event received from the openai server
             self.connection = conn
@@ -552,13 +561,14 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                         item_id = event.item_id
                         delta = event.delta or ""
 
-                        if item_id not in self.input_transcript_acc:
-                            self.input_transcript_acc[item_id] = [delta]
+                        input_transcript = self.input_transcript_chunks_by_item
+                        if input_transcript.item_id != item_id:
+                            input_transcript.item_id = item_id
+                            input_transcript.deltas = [delta]
                         else:
-                            self.input_transcript_acc[item_id].append(delta)
+                            input_transcript.deltas.append(delta)
 
-                        chunks = self.input_transcript_acc[item_id]
-                        sequence_counter = len(chunks) - 1
+                        sequence_counter = len(input_transcript.deltas) - 1
 
                         # Cancel previous debounce task if it exists
                         if self.partial_transcript_task and not self.partial_transcript_task.done():
@@ -570,7 +580,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
                         # Start new debounce timer with the last delta
                         self.partial_transcript_task = asyncio.create_task(
-                            self._emit_debounced_partial(chunks[-1], item_id, sequence_counter)
+                            self._emit_debounced_partial("".join(input_transcript.deltas), item_id, sequence_counter)
                         )
 
                     # Handle completed transcription (user finished speaking)
@@ -586,9 +596,6 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                                 await self.partial_transcript_task
                             except asyncio.CancelledError:
                                 pass
-
-                        # Clear the accumulator entry for this item
-                        self.input_transcript_acc.pop(item_id, None)
 
                         await self.output_queue.put(AdditionalOutputs({"role": "user", "content": event.transcript}))
 

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -28,7 +28,6 @@ from openai.types.realtime.realtime_audio_config_input_param import RealtimeAudi
 from openai.types.realtime.realtime_audio_config_output_param import RealtimeAudioConfigOutputParam
 from openai.types.realtime.realtime_response_create_params_param import RealtimeResponseCreateParamsParam
 from openai.types.realtime.realtime_audio_input_turn_detection_param import ServerVad
-from reachy_mini_conversation_app.config import config
 from reachy_mini_conversation_app.config import AVAILABLE_VOICES, config
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
 from reachy_mini_conversation_app.tools.core_tools import (

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -192,12 +192,13 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             logger.error("Error applying personality '%s': %s", profile, e)
             return f"Failed to apply personality: {e}"
 
-    async def _emit_debounced_partial(self, transcript: str, content_index: int, sequence_counter: int) -> None:
+    async def _emit_debounced_partial(self, transcript: str, item_id: str, sequence_counter: int) -> None:
         """Emit partial transcript after debounce delay."""
         try:
             await asyncio.sleep(self.partial_debounce_delay)
+
             # Only emit if this is still the latest partial (by sequence number)
-            if content_index == sequence_counter:
+            if item_id in self.input_transcript_acc and len(self.input_transcript_acc[item_id]) - 1 == sequence_counter:
                 await self.output_queue.put(AdditionalOutputs({"role": "user_partial", "content": transcript}))
                 logger.debug(f"Debounced partial emitted: {transcript}")
         except asyncio.CancelledError:
@@ -553,15 +554,14 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
                         item_id = event.item_id
                         delta = event.delta or ""
-                        content_index = event.content_index or 0
 
-                        # Accumulate deltas by item_id
-                        try:
-                            chunks = self.input_transcript_acc[item_id]
-                        except KeyError:
+                        if item_id not in self.input_transcript_acc:
                             self.input_transcript_acc[item_id] = [delta]
                         else:
                             self.input_transcript_acc[item_id].append(delta)
+
+                        chunks = self.input_transcript_acc[item_id]
+                        sequence_counter = len(chunks) - 1
 
                         # Cancel previous debounce task if it exists
                         if self.partial_transcript_task and not self.partial_transcript_task.done():
@@ -573,7 +573,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
                         # Start new debounce timer with the full accumulated transcript
                         self.partial_transcript_task = asyncio.create_task(
-                            self._emit_debounced_partial(chunks[-1], content_index, len(chunks) - 1)
+                            self._emit_debounced_partial(chunks[-1], item_id, sequence_counter)
                         )
 
                     # Handle completed transcription (user finished speaking)

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -21,6 +21,8 @@ from openai.types.realtime import RealtimeSessionCreateRequestParam
 from openai.resources.realtime.realtime import AsyncRealtimeConnection
 from openai.types.realtime.audio_transcription_param import AudioTranscriptionParam
 from openai.types.realtime.realtime_audio_config_param import RealtimeAudioConfigParam
+from openai.types.realtime.conversation_item_param import ConversationItemParam
+from openai.types.realtime.realtime_response_create_params_param import RealtimeResponseCreateParamsParam
 from openai.types.realtime.realtime_tools_config_param import RealtimeToolsConfigParam
 from openai.types.realtime.realtime_audio_formats_param import AudioPCM
 from openai.types.realtime.realtime_audio_config_input_param import RealtimeAudioConfigInputParam
@@ -104,8 +106,8 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
         # Debouncing for partial transcripts
         self.partial_transcript_task: asyncio.Task[None] | None = None
-        self.partial_transcript_sequence: int = 0  # sequence counter to prevent stale emissions
         self.partial_debounce_delay = 0.5  # seconds
+        self.input_transcript_acc: dict[str, list[str]] = {} # list of delta transcripts by item_id
 
         # Internal lifecycle flags
         self._shutdown_requested: bool = False
@@ -190,12 +192,12 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             logger.error("Error applying personality '%s': %s", profile, e)
             return f"Failed to apply personality: {e}"
 
-    async def _emit_debounced_partial(self, transcript: str, sequence: int) -> None:
+    async def _emit_debounced_partial(self, transcript: str, content_index: int, sequence_counter: int) -> None:
         """Emit partial transcript after debounce delay."""
         try:
             await asyncio.sleep(self.partial_debounce_delay)
             # Only emit if this is still the latest partial (by sequence number)
-            if self.partial_transcript_sequence == sequence:
+            if content_index == sequence_counter:
                 await self.output_queue.put(AdditionalOutputs({"role": "user_partial", "content": transcript}))
                 logger.debug(f"Debounced partial emitted: {transcript}")
         except asyncio.CancelledError:
@@ -374,11 +376,11 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             # Send the tool result back
             if isinstance(bg_tool.id, str):
                 await self.connection.conversation.item.create(
-                    item={
+                    item=cast(ConversationItemParam, {
                         "type": "function_call_output",
                         "call_id": bg_tool.id,
                         "output": json.dumps(tool_result),
-                    },
+                    }),
                 )
 
             await self.output_queue.put(
@@ -402,7 +404,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     logger.warning("Unexpected type for b64_im: %s", type(b64_im))
                     b64_im = str(b64_im)
                 await self.connection.conversation.item.create(
-                    item={
+                    item=cast(ConversationItemParam, {
                         "type": "message",
                         "role": "user",
                         "content": [
@@ -411,7 +413,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                                 "image_url": f"data:image/jpeg;base64,{b64_im}",
                             },
                         ],
-                    },
+                    }),
                 )
                 logger.info("Added camera image to conversation")
 
@@ -437,9 +439,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             # For other tool calls, let the robot reply out loud.
             if not bg_tool.is_idle_tool_call:
                 await self._safe_response_create(
-                    response={
-                        "instructions": "Use the tool result just returned and answer concisely in speech.",
-                    },
+                    response=RealtimeResponseCreateParamsParam(
+                        instructions="Use the tool result just returned and answer concisely in speech.",
+                    ),
                 )
 
             # Re-synchronize the head wobble after a tool call that may have taken some time
@@ -486,6 +488,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 return
 
             logger.info("Realtime session updated successfully")
+
+            # Reset the partial-transcript accumulator for each new session
+            self.input_transcript_acc: dict[str, str] = {}
 
             # Manage event received from the openai server
             self.connection = conn
@@ -544,30 +549,38 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             logger.warning("No usage data available for cost tracking")
 
                     if event.type == "conversation.item.input_audio_transcription.delta":
-                         logger.debug(f"User partial transcript: {event.delta}")
+                        logger.debug(f"User partial transcript: {event.delta}")
 
-                         if event.delta is not None:
+                        item_id = event.item_id
+                        delta = event.delta or ""
+                        content_index = event.content_index or 0
 
-                             # Increment sequence
-                             self.partial_transcript_sequence += 1
-                             current_sequence = self.partial_transcript_sequence
+                        # Accumulate deltas by item_id
+                        try:
+                            chunks = self.input_transcript_acc[item_id]
+                        except KeyError:
+                            self.input_transcript_acc[item_id] = [delta]
+                        else:
+                            self.input_transcript_acc[item_id].append(delta)
 
-                             # Cancel previous debounce task if it exists
-                             if self.partial_transcript_task and not self.partial_transcript_task.done():
-                                 self.partial_transcript_task.cancel()
-                                 try:
-                                     await self.partial_transcript_task
-                                 except asyncio.CancelledError:
-                                     pass
+                        # Cancel previous debounce task if it exists
+                        if self.partial_transcript_task and not self.partial_transcript_task.done():
+                            self.partial_transcript_task.cancel()
+                            try:
+                                await self.partial_transcript_task
+                            except asyncio.CancelledError:
+                                pass
 
-                             # Start new debounce timer with sequence number
-                             self.partial_transcript_task = asyncio.create_task(
-                                 self._emit_debounced_partial(event.delta, current_sequence)
-                             )
+                        # Start new debounce timer with the full accumulated transcript
+                        self.partial_transcript_task = asyncio.create_task(
+                            self._emit_debounced_partial(chunks[-1], content_index, len(chunks) - 1)
+                        )
 
                     # Handle completed transcription (user finished speaking)
                     if event.type == "conversation.item.input_audio_transcription.completed":
                         logger.debug(f"User transcript: {event.transcript}")
+
+                        item_id = event.item_id
 
                         # Cancel any pending partial emission
                         if self.partial_transcript_task and not self.partial_transcript_task.done():
@@ -576,6 +589,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                                 await self.partial_transcript_task
                             except asyncio.CancelledError:
                                 pass
+
+                        # Clear the accumulator entry for this item
+                        self.input_transcript_acc.pop(item_id, None)
 
                         await self.output_queue.put(AdditionalOutputs({"role": "user", "content": event.transcript}))
 
@@ -640,9 +656,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             self.is_idle_tool_call = False
                         else:
                             await self._safe_response_create(
-                                response={
-                                    "instructions": "Notify what the tool has been running giving meaningful information about the task",
-                                },
+                                response=RealtimeResponseCreateParamsParam(
+                                    instructions="Notify what the tool has been running giving meaningful information about the task",
+                                ),
                             )
 
                         logger.info("Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id)
@@ -856,17 +872,17 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             logger.debug("No connection, cannot send idle signal")
             return
         await self.connection.conversation.item.create(
-            item={
+            item=cast(ConversationItemParam, {
                 "type": "message",
                 "role": "user",
                 "content": [{"type": "input_text", "text": timestamp_msg}],
-            },
+            }),
         )
         await self._safe_response_create(
-            response={
-                "instructions": "You MUST respond with function calls only - no speech or text. Choose appropriate actions for idle behavior.",
-                "tool_choice": "required",
-            },
+            response=RealtimeResponseCreateParamsParam(
+                instructions="You MUST respond with function calls only - no speech or text. Choose appropriate actions for idle behavior.",
+                tool_choice="required",
+            ),
         )
 
     def _persist_api_key_if_needed(self) -> None:

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -571,7 +571,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             except asyncio.CancelledError:
                                 pass
 
-                        # Start new debounce timer with the full accumulated transcript
+                        # Start new debounce timer with the last delta
                         self.partial_transcript_task = asyncio.create_task(
                             self._emit_debounced_partial(chunks[-1], item_id, sequence_counter)
                         )

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -12,6 +12,7 @@ import numpy as np
 import gradio as gr
 from openai import AsyncOpenAI
 from fastrtc import AdditionalOutputs, AsyncStreamHandler, wait_for_item, audio_to_int16
+from openai.resources.realtime.realtime import AsyncRealtimeConnection
 from numpy.typing import NDArray
 from scipy.signal import resample
 from websockets.exceptions import ConnectionClosedError
@@ -74,7 +75,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         self.output_sample_rate = OPEN_AI_OUTPUT_SAMPLE_RATE
         self.input_sample_rate = OPEN_AI_INPUT_SAMPLE_RATE
 
-        self.connection: Any = None
+        self.connection: AsyncRealtimeConnection | None = None
         self.output_queue: "asyncio.Queue[Tuple[int, NDArray[np.int16]] | AdditionalOutputs]" = asyncio.Queue()
 
         self.last_activity_time = asyncio.get_event_loop().time()
@@ -321,9 +322,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     logger.debug("User speech stopped - server will auto-commit with VAD")
 
                 if event.type in (
-                    "response.audio.done",  # GA
-                    "response.output_audio.done",  # GA alias
-                    "response.audio.completed",  # legacy (for safety)
+                    "response.output_audio.done",  # GA
                     "response.completed",  # text-only completion
                 ):
                     logger.debug("response completed")
@@ -347,25 +346,27 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                         logger.warning("No usage data available for cost tracking")
 
                 # Handle partial transcription (user speaking in real-time)
-                if event.type == "conversation.item.input_audio_transcription.partial":
-                    logger.debug(f"User partial transcript: {event.transcript}")
+                if event.type == "conversation.item.input_audio_transcription.delta":
+                    logger.debug(f"User partial transcript: {event.delta}")
 
-                    # Increment sequence
-                    self.partial_transcript_sequence += 1
-                    current_sequence = self.partial_transcript_sequence
+                    if event.delta is not None:
 
-                    # Cancel previous debounce task if it exists
-                    if self.partial_transcript_task and not self.partial_transcript_task.done():
-                        self.partial_transcript_task.cancel()
-                        try:
-                            await self.partial_transcript_task
-                        except asyncio.CancelledError:
-                            pass
+                        # Increment sequence
+                        self.partial_transcript_sequence += 1
+                        current_sequence = self.partial_transcript_sequence
 
-                    # Start new debounce timer with sequence number
-                    self.partial_transcript_task = asyncio.create_task(
-                        self._emit_debounced_partial(event.transcript, current_sequence)
-                    )
+                        # Cancel previous debounce task if it exists
+                        if self.partial_transcript_task and not self.partial_transcript_task.done():
+                            self.partial_transcript_task.cancel()
+                            try:
+                                await self.partial_transcript_task
+                            except asyncio.CancelledError:
+                                pass
+
+                        # Start new debounce timer with sequence number
+                        self.partial_transcript_task = asyncio.create_task(
+                            self._emit_debounced_partial(event.delta, current_sequence)
+                        )
 
                 # Handle completed transcription (user finished speaking)
                 if event.type == "conversation.item.input_audio_transcription.completed":
@@ -382,12 +383,12 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     await self.output_queue.put(AdditionalOutputs({"role": "user", "content": event.transcript}))
 
                 # Handle assistant transcription
-                if event.type in ("response.audio_transcript.done", "response.output_audio_transcript.done"):
+                if event.type == "response.output_audio_transcript.done":
                     logger.debug(f"Assistant transcript: {event.transcript}")
                     await self.output_queue.put(AdditionalOutputs({"role": "assistant", "content": event.transcript}))
 
                 # Handle audio delta
-                if event.type in ("response.audio.delta", "response.output_audio.delta"):
+                if event.type == "response.output_audio.delta":
                     if self.deps.head_wobbler is not None:
                         self.deps.head_wobbler.feed(event.delta)
                     self.last_activity_time = asyncio.get_event_loop().time()

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -4,16 +4,16 @@ import base64
 import random
 import asyncio
 import logging
-from pydantic import BaseModel, Field
-from datetime import datetime
+from typing import Any, Final, Tuple, Literal, Optional, cast
 from pathlib import Path
-from typing import Any, Final, Literal, Optional, Tuple, cast
+from datetime import datetime
 
 import cv2
 import numpy as np
 import gradio as gr
 from openai import AsyncOpenAI
 from fastrtc import AdditionalOutputs, AsyncStreamHandler, wait_for_item, audio_to_int16
+from pydantic import Field, BaseModel
 from numpy.typing import NDArray
 from scipy.signal import resample
 from openai.types.realtime import RealtimeSessionCreateRequestParam
@@ -383,7 +383,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             return
 
         try:
-            # Send the tool result back
+            # TODO: refactor this since it's repeated here, in the camera branch below, and in send_idle_signal
             if isinstance(bg_tool.id, str):
                 await self.connection.conversation.item.create(
                     item=cast(ConversationItemParam, {
@@ -569,6 +569,10 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             input_transcript.deltas.append(delta)
 
                         sequence_counter = len(input_transcript.deltas) - 1
+
+                        logger.debug(f"Input transcript: {input_transcript.deltas}")
+                        logger.debug(f"Item ID: {item_id}")
+                        logger.debug(f"Sequence counter: {sequence_counter}")
 
                         # Cancel previous debounce task if it exists
                         if self.partial_transcript_task and not self.partial_transcript_task.done():

--- a/uv.lock
+++ b/uv.lock
@@ -906,7 +906,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
@@ -1044,7 +1044,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2797,7 +2797,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2808,7 +2808,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2835,9 +2835,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2848,7 +2848,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -2896,7 +2896,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.21.0"
+version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2908,9 +2908,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
 ]
 
 [[package]]
@@ -3894,6 +3894,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/bb/93a3e83bdf9322c7e21cafd092e56a4a17c4d8ef4277b6eb01af1a540a6f/python_discovery-1.1.0.tar.gz", hash = "sha256:447941ba1aed8cc2ab7ee3cb91be5fc137c5bdbb05b7e6ea62fbdcb66e50b268", size = 55674, upload-time = "2026-02-26T09:42:49.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/54/82a6e2ef37f0f23dccac604b9585bdcbd0698604feb64807dcb72853693e/python_discovery-1.1.0-py3-none-any.whl", hash = "sha256:a162893b8809727f54594a99ad2179d2ede4bf953e12d4c7abc3cc9cdbd1437b", size = 30687, upload-time = "2026-02-26T09:42:48.548Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4151,7 +4164,7 @@ requires-dist = [
     { name = "mediapipe", marker = "extra == 'mediapipe-vision'", specifier = "==0.10.14" },
     { name = "num2words", marker = "extra == 'all-vision'" },
     { name = "num2words", marker = "extra == 'local-vision'" },
-    { name = "openai", specifier = ">=2.1" },
+    { name = "openai", specifier = "==2.24.0" },
     { name = "opencv-python", specifier = ">=4.12.0.88" },
     { name = "pygobject", marker = "extra == 'reachy-mini-wireless'", specifier = ">=3.42.2,<=3.46.0" },
     { name = "python-dotenv" },
@@ -5534,17 +5547,18 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.37.0"
+version = "21.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ef/d9d4ce633df789bf3430bd81fb0d8b9d9465dfc1d1f0deb3fb62cd80f5c2/virtualenv-20.37.0.tar.gz", hash = "sha256:6f7e2064ed470aa7418874e70b6369d53b66bcd9e9fd5389763e96b6c94ccb7c", size = 5864710, upload-time = "2026-02-16T16:17:59.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/4b/6cf85b485be7ec29db837ec2a1d8cd68bc1147b1abf23d8636c5bd65b3cc/virtualenv-20.37.0-py3-none-any.whl", hash = "sha256:5d3951c32d57232ae3569d4de4cc256c439e045135ebf43518131175d9be435d", size = 5837480, upload-time = "2026-02-16T16:17:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3088,7 +3088,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.24.0"
+version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3100,9 +3100,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/87/eb0abb4ef88ddb95b3c13149384c4c288f584f3be17d6a4f63f8c3e3c226/openai-2.28.0.tar.gz", hash = "sha256:bb7fdff384d2a787fa82e8822d1dd3c02e8cf901d60f1df523b7da03cbb6d48d", size = 670334, upload-time = "2026-03-13T19:56:27.306Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/5a/df122348638885526e53140e9c6b0d844af7312682b3bde9587eebc28b47/openai-2.28.0-py3-none-any.whl", hash = "sha256:79aa5c45dba7fef84085701c235cf13ba88485e1ef4f8dfcedc44fc2a698fc1d", size = 1141218, upload-time = "2026-03-13T19:56:25.46Z" },
 ]
 
 [[package]]
@@ -4356,7 +4356,7 @@ requires-dist = [
     { name = "mediapipe", marker = "extra == 'mediapipe-vision'", specifier = "==0.10.14" },
     { name = "num2words", marker = "extra == 'all-vision'" },
     { name = "num2words", marker = "extra == 'local-vision'" },
-    { name = "openai", specifier = "==2.24.0" },
+    { name = "openai", specifier = "==2.28.0" },
     { name = "opencv-python", specifier = ">=4.12.0.88" },
     { name = "python-dotenv" },
     { name = "reachy-mini", specifier = ">=1.5.1" },
@@ -5434,6 +5434,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },


### PR DESCRIPTION
## Summary

Resolve issue https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/228 (and sub-issue https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/229):

- Upgrade `openai` package to 2.24.0. (`uv.lock` and `pyproject.py` updated).
- Migrate or remove deprecated/nonexistent events.
- Strong typing for event models.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added

## Notes
<!-- Optional: context, caveats, migration notes -->
