### PR TITLE
docs: simplify PR template with collapsible sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->
+
 ## Summary
 <!-- What does this PR change and why? -->
 
@@ -9,26 +11,29 @@
 - [ ] CI/CD
 - [ ] Other
 
-## Check before merging
-### Basic
-- [ ] CI green (Ruff, Tests, Mypy)
-- [ ] Code update is clear (types, docs, comments)
+## Pre-merge checklist
+- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
+- [ ] Code is clear (types, docs, comments where needed)
+- [ ] `.env.example` updated (if new config vars were added)
 
-### Run modes
+<details>
+<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>
+
 - [ ] Headless mode (default)
 - [ ] Gradio UI (`--gradio`)
-- [ ] Everything is tested in simulation as well (`--gradio` required)
+- [ ] Simulation (`--gradio` required)
+</details>
 
-### Vision / motion
+<details>
+<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>
+
 - [ ] Local vision (`--local-vision`)
-- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
+- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
 - [ ] Camera pipeline (with/without `--no-camera`)
 - [ ] Movement manager (dances, emotions, head motion)
 - [ ] Head wobble
 - [ ] Profiles or custom tools
-
-### Dependencies & config
-- [ ] Updated `.env.example` if new config vars added
+</details>
 
 ## Notes
 <!-- Optional: context, caveats, migration notes -->


### PR DESCRIPTION
## Summary
Shorten the PR checklist by removing items already covered by CI (platform testing, linting, type checks). 
Move vision/motion and UI/run-mode checks into collapsible sections so contributors only see what's relevant to their change.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Check before merging
### Basic
- [ ] CI green (Ruff, Tests, Mypy)
- [ ] Code update is clear (types, docs, comments)

### Run modes
- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Everything is tested in simulation as well (`--gradio` required)

### Vision / motion
- [ ] Local vision (`--local-vision`)
- [ ] YOLO or MediaPipe head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools

### Dependencies & config
- [ ] Updated `.env.example` if new config vars added
