### PR TITLE
fix: increase head wobbler test timeout for macOS

### DIFF
--- a/tests/audio/test_head_wobbler.py
+++ b/tests/audio/test_head_wobbler.py
@@ -22,7 +22,7 @@ def _make_audio_chunk(duration_s: float = 0.3, frequency_hz: float = 220.0) -> s
     return base64.b64encode(pcm.tobytes()).decode("ascii")
 
 
-def _wait_for(predicate: Callable[[], bool], timeout: float = 0.6) -> bool:
+def _wait_for(predicate: Callable[[], bool], timeout: float = 2.0) -> bool:
     """Poll `predicate` until true or timeout."""
     end_time = time.time() + timeout
     while time.time() < end_time:


### PR DESCRIPTION
## Summary
Bump `_wait_for` timeout from 0.6s to 2.0s to fix flaky wobbler tests on macOS runners

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>