### PR TITLE
docs: align mypy command with typecheck workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We welcome all contributions: bug fixes, new features, documentation, testing, a
    ```bash
    uv run ruff check . --fix
    uv run ruff format .
-   uv run mypy --pretty --show-error-codes .
+   uv run mypy --pretty --show-error-codes
    uv run pytest tests/ -v
    ```
 
@@ -125,7 +125,7 @@ Releases are explicit and tag-based.
 ## Before Opening a PR
 
 - All tests pass locally (`uv run pytest tests/ -v`)
-- Code is formatted (`uv run ruff format .`) and type-checked (`uv run mypy .`)
+- Code is formatted (`uv run ruff format .`) and type-checked (`uv run mypy`)
 - Added tests for bug fixes or new features
 - Updated docs if needed
 - No secrets or `.env` files committed
@@ -143,7 +143,7 @@ uv run ruff format .            # Format code
 
 ### Type Checking
 ```bash
-uv run mypy --pretty --show-error-codes .
+uv run mypy --pretty --show-error-codes
 ```
 
 ### Testing
@@ -154,7 +154,7 @@ uv run pytest tests/ -v --cov  # With coverage
 
 ### All at Once
 ```bash
-uv run mypy --pretty --show-error-codes . && uv run ruff check . --fix && uv run pytest tests/ -v
+uv run mypy --pretty --show-error-codes && uv run ruff check . --fix && uv run pytest tests/ -v
 ```
 
 </details>


### PR DESCRIPTION
## Summary
Update `CONTRIBUTING.md` so the documented mypy command matches the CI typecheck workflow and the repo mypy configuration.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>