### PR TITLE
Add private Hugging Face preview Spaces for pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@
 - [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
 - [ ] Code is clear (types, docs, comments where needed)
 - [ ] `.env.example` updated (if new config vars were added)
+- [ ] Installation from the desktop app tested (if applicable)
 
 <details>
 <summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

--- a/.github/workflows/pr-hf-space-preview.yml
+++ b/.github/workflows/pr-hf-space-preview.yml
@@ -44,6 +44,8 @@ jobs:
           lfs: true
 
       - name: Sync preview space
+        id: sync
+        continue-on-error: true
         uses: huggingface/hub-sync@v0.1.0
         with:
           github_repo_id: ${{ github.repository }}
@@ -54,12 +56,14 @@ jobs:
           private: true
 
       - name: Ensure preview space stays private
+        if: steps.sync.outcome == 'success'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: ${{ steps.preview.outputs.space_id }}
         run: uvx hf repos settings "${HF_SPACE_ID}" --repo-type space --private
 
       - name: Create or update preview comment
+        if: steps.sync.outcome == 'success'
         uses: actions/github-script@v8
         env:
           HF_PREVIEW_COMMENT_MARKER: ${{ env.HF_PREVIEW_COMMENT_MARKER }}
@@ -67,7 +71,18 @@ jobs:
         with:
           script: |
             const marker = process.env.HF_PREVIEW_COMMENT_MARKER;
-            const body = `${marker}\nYour test space is pushed and available here: ${process.env.HF_SPACE_URL}`;
+            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const body = [
+              marker,
+              `🤗 **Preview space ready!**`,
+              ``,
+              `| | |`,
+              `|---|---|`,
+              `| **Space** | ${process.env.HF_SPACE_URL} |`,
+              `| **Commit** | \`${sha}\` |`,
+              ``,
+              `> This space will be automatically deleted when the PR is closed or merged.`,
+            ].join("\n");
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -96,6 +111,54 @@ jobs:
               });
             }
 
+      - name: Comment sync failure
+        if: steps.sync.outcome == 'failure'
+        uses: actions/github-script@v8
+        env:
+          HF_PREVIEW_COMMENT_MARKER: ${{ env.HF_PREVIEW_COMMENT_MARKER }}
+        with:
+          script: |
+            const marker = process.env.HF_PREVIEW_COMMENT_MARKER;
+            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              `❌ **Preview space sync failed** for commit \`${sha}\`.`,
+              ``,
+              `See the [workflow run](${run}) for details.`,
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.login === "github-actions[bot]" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail job if sync failed
+        if: steps.sync.outcome == 'failure'
+        run: exit 1
+
   delete-preview:
     if: ${{ github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
@@ -112,3 +175,36 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: ${{ steps.preview.outputs.space_id }}
         run: uvx hf repos delete "${HF_SPACE_ID}" --repo-type space --missing-ok
+
+      - name: Update comment to reflect deletion
+        uses: actions/github-script@v8
+        env:
+          HF_PREVIEW_COMMENT_MARKER: ${{ env.HF_PREVIEW_COMMENT_MARKER }}
+        with:
+          script: |
+            const marker = process.env.HF_PREVIEW_COMMENT_MARKER;
+            const action = context.payload.pull_request.merged ? "merged" : "closed";
+            const body = [
+              marker,
+              `🗑️ **Preview space removed** — PR was ${action}.`,
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.login === "github-actions[bot]" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            }

--- a/.github/workflows/pr-hf-space-preview.yml
+++ b/.github/workflows/pr-hf-space-preview.yml
@@ -1,0 +1,118 @@
+name: Sync PR Preview to Hugging Face Space
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hf-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  HF_SPACE_NAMESPACE: pollen-robotics
+  HF_SPACE_BASE_NAME: reachy_mini_conversation_app
+  HF_SPACE_SDK: static
+  HF_PREVIEW_COMMENT_MARKER: "<!-- hf-pr-preview-space -->"
+
+jobs:
+  sync-preview:
+    if: ${{ github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Compute preview space metadata
+        id: preview
+        run: |
+          echo "space_id=${HF_SPACE_NAMESPACE}/${HF_SPACE_BASE_NAME}_PR${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          echo "space_url=https://huggingface.co/spaces/${HF_SPACE_NAMESPACE}/${HF_SPACE_BASE_NAME}_PR${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pull request branch
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          lfs: true
+
+      - name: Sync preview space
+        uses: huggingface/hub-sync@v0.1.0
+        with:
+          github_repo_id: ${{ github.repository }}
+          huggingface_repo_id: ${{ steps.preview.outputs.space_id }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          repo_type: space
+          space_sdk: ${{ env.HF_SPACE_SDK }}
+          private: true
+
+      - name: Ensure preview space stays private
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: ${{ steps.preview.outputs.space_id }}
+        run: uvx hf repos settings "${HF_SPACE_ID}" --repo-type space --private
+
+      - name: Create or update preview comment
+        uses: actions/github-script@v8
+        env:
+          HF_PREVIEW_COMMENT_MARKER: ${{ env.HF_PREVIEW_COMMENT_MARKER }}
+          HF_SPACE_URL: ${{ steps.preview.outputs.space_url }}
+        with:
+          script: |
+            const marker = process.env.HF_PREVIEW_COMMENT_MARKER;
+            const body = `${marker}\nYour test space is pushed and available here: ${process.env.HF_SPACE_URL}`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.login === "github-actions[bot]" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  delete-preview:
+    if: ${{ github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Compute preview space metadata
+        id: preview
+        run: |
+          echo "space_id=${HF_SPACE_NAMESPACE}/${HF_SPACE_BASE_NAME}_PR${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Delete preview space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: ${{ steps.preview.outputs.space_id }}
+        run: uvx hf repos delete "${HF_SPACE_ID}" --repo-type space --missing-ok

--- a/.github/workflows/pr-hf-space-preview.yml
+++ b/.github/workflows/pr-hf-space-preview.yml
@@ -106,11 +106,6 @@ jobs:
         run: |
           echo "space_id=${HF_SPACE_NAMESPACE}/${HF_SPACE_BASE_NAME}_PR${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.12"
-
       - name: Delete preview space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/pr-hf-space-preview.yml
+++ b/.github/workflows/pr-hf-space-preview.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 concurrency:
   group: hf-pr-preview-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-hf-space-preview.yml
+++ b/.github/workflows/pr-hf-space-preview.yml
@@ -55,6 +55,10 @@ jobs:
           space_sdk: ${{ env.HF_SPACE_SDK }}
           private: true
 
+      - name: Set up uv
+        if: steps.sync.outcome == 'success'
+        uses: astral-sh/setup-uv@v8
+
       - name: Ensure preview space stays private
         if: steps.sync.outcome == 'success'
         env:
@@ -169,6 +173,9 @@ jobs:
         id: preview
         run: |
           echo "space_id=${HF_SPACE_NAMESPACE}/${HF_SPACE_BASE_NAME}_PR${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Delete preview space
         env:

--- a/.github/workflows/pr-hf-space-preview.yml
+++ b/.github/workflows/pr-hf-space-preview.yml
@@ -55,10 +55,6 @@ jobs:
           space_sdk: ${{ env.HF_SPACE_SDK }}
           private: true
 
-      - name: Set up uv
-        if: steps.sync.outcome == 'success'
-        uses: astral-sh/setup-uv@v8
-
       - name: Ensure preview space stays private
         if: steps.sync.outcome == 'success'
         env:

--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -27,4 +27,4 @@ jobs:
           huggingface_repo_id: pollen-robotics/reachy_mini_conversation_app
           hf_token: ${{ secrets.HF_TOKEN }}
           repo_type: space
-          space_sdk: gradio
+          space_sdk: static

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,10 @@ We welcome all contributions: bug fixes, new features, documentation, testing, a
 
 This project is mirrored to a Hugging Face Space.
 
-- Every push to the `main` branch is automatically synchronized to [pollen-robotics/reachy_mini_conversation_app](https://huggingface.co/spaces/pollen-robotics/reachy_mini_conversation_app)
-- This sync is handled by a GitHub Action and requires no manual steps.
+- Tagged releases are automatically synchronized to [pollen-robotics/reachy_mini_conversation_app](https://huggingface.co/spaces/pollen-robotics/reachy_mini_conversation_app)
+- Pull requests opened from branches in this repository automatically get a private preview Space named `reachy_mini_conversation_app_PR<PR number>`
+- Preview Spaces are refreshed on each push to the PR branch and removed automatically when the PR closes
+- This sync is handled by GitHub Actions and requires no manual steps.
 - Contributors do not need to interact with the Space on Hugging Face hub directly.
 
 ### 1. Create an Issue


### PR DESCRIPTION
## Summary
Solves https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/272. This adds a PR workflow that creates a private preview Space named `reachy_mini_conversation_app_PR<PR number>`, resyncs it on each commit, posts a single comment with the preview URL, and deletes it when the PR closes. It also aligns the release Space sync with the static sdk and updates the contributing docs.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
Related PRs:
- https://github.com/pollen-robotics/reachy-mini-desktop-app/pull/202
- https://github.com/pollen-robotics/reachy_mini/pull/992
⚠️ To merge them first to make this work useful