### PR TITLE
Feat/local vision from app

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -24,8 +24,8 @@ from reachy_mini import ReachyMini
 from reachy_mini.media.media_manager import MediaBackend
 from reachy_mini_conversation_app.config import LOCKED_PROFILE, config
 from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
-from reachy_mini_conversation_app.headless_personality_ui import mount_personality_routes
 from reachy_mini_conversation_app.vision_settings import mount_vision_routes
+from reachy_mini_conversation_app.headless_personality_ui import mount_personality_routes
 
 
 try:

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -14,7 +14,7 @@ import sys
 import time
 import asyncio
 import logging
-from typing import List, Optional
+from typing import Any, List, Optional
 from pathlib import Path
 
 from fastrtc import AdditionalOutputs, audio_to_float32
@@ -25,6 +25,7 @@ from reachy_mini.media.media_manager import MediaBackend
 from reachy_mini_conversation_app.config import LOCKED_PROFILE, config
 from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
 from reachy_mini_conversation_app.headless_personality_ui import mount_personality_routes
+from reachy_mini_conversation_app.vision_settings import mount_vision_routes
 
 
 try:
@@ -54,11 +55,15 @@ class LocalStream:
         *,
         settings_app: Optional[FastAPI] = None,
         instance_path: Optional[str] = None,
+        deps: Optional[Any] = None,
+        camera_worker: Optional[Any] = None,
     ):
         """Initialize the stream with an OpenAI realtime handler and pipelines.
 
         - ``settings_app``: the Reachy Mini Apps FastAPI to attach settings endpoints.
         - ``instance_path``: directory where per-instance ``.env`` should be stored.
+        - ``deps``: ToolDependencies for runtime vision toggling.
+        - ``camera_worker``: CameraWorker for runtime head tracker switching.
         """
         self.handler = handler
         self._robot = robot
@@ -68,6 +73,8 @@ class LocalStream:
         self.handler._clear_queue = self.clear_audio_queue
         self._settings_app: Optional[FastAPI] = settings_app
         self._instance_path: Optional[str] = instance_path
+        self._deps = deps
+        self._camera_worker = camera_worker
         self._settings_initialized = False
         self._asyncio_loop = None
 
@@ -302,6 +309,13 @@ class LocalStream:
             except Exception as e:
                 logger.warning(f"API key validation failed: {e}")
                 return JSONResponse({"valid": False, "error": "validation_error"}, status_code=500)
+
+        # Mount vision settings routes (head tracker + local vision toggling)
+        if self._deps is not None:
+            try:
+                mount_vision_routes(self._settings_app, self._deps, self._camera_worker)
+            except Exception:
+                logger.debug("Failed to mount vision routes", exc_info=True)
 
         self._settings_initialized = True
 

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -54,10 +54,7 @@ def run(
     logger.info("Starting Reachy Mini Conversation App")
 
     if args.no_camera and args.head_tracker is not None:
-        logger.warning(
-            "Head tracking disabled: --no-camera flag is set. "
-            "Remove --no-camera to enable head tracking."
-        )
+        logger.warning("Head tracking disabled: --no-camera flag is set. Remove --no-camera to enable head tracking.")
 
     if robot is None:
         try:
@@ -69,25 +66,17 @@ def run(
             robot = ReachyMini(**robot_kwargs)
 
         except TimeoutError as e:
-            logger.error(
-                "Connection timeout: Failed to connect to Reachy Mini daemon. "
-                f"Details: {e}"
-            )
+            logger.error(f"Connection timeout: Failed to connect to Reachy Mini daemon. Details: {e}")
             log_connection_troubleshooting(logger, args.robot_name)
             sys.exit(1)
 
         except ConnectionError as e:
-            logger.error(
-                "Connection failed: Unable to establish connection to Reachy Mini. "
-                f"Details: {e}"
-            )
+            logger.error(f"Connection failed: Unable to establish connection to Reachy Mini. Details: {e}")
             log_connection_troubleshooting(logger, args.robot_name)
             sys.exit(1)
 
         except Exception as e:
-            logger.error(
-                f"Unexpected error during robot initialization: {type(e).__name__}: {e}"
-            )
+            logger.error(f"Unexpected error during robot initialization: {type(e).__name__}: {e}")
             logger.error("Please check your configuration and try again.")
             sys.exit(1)
 

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -183,6 +183,8 @@ def run(
             robot,
             settings_app=settings_app,
             instance_path=instance_path,
+            deps=deps,
+            camera_worker=camera_worker,
         )
 
     # Each async service → its own thread/loop

--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -132,6 +132,53 @@
         </div>
         <p id="personality-status" class="status"></p>
       </div>
+
+      <div id="vision-panel" class="panel hidden">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Hardware</p>
+            <h2>Vision settings</h2>
+          </div>
+          <span id="vision-chip" class="chip">Live</span>
+        </div>
+        <p class="muted">Configure head tracking and local vision processing. Changes apply immediately.</p>
+
+        <div class="section">
+          <div class="section-heading">
+            <h3>Head tracking</h3>
+            <p class="muted small">Follow faces with the robot's head.</p>
+          </div>
+          <div class="row vision-row">
+            <label for="head-tracker-select">Backend</label>
+            <div class="vision-controls">
+              <select id="head-tracker-select">
+                <option value="">Disabled</option>
+                <option value="yolo">YOLO (face detection)</option>
+                <option value="mediapipe">MediaPipe (landmarks)</option>
+              </select>
+              <button id="apply-tracker" class="ghost">Apply</button>
+            </div>
+          </div>
+          <p id="tracker-status" class="status"></p>
+        </div>
+
+        <div class="section">
+          <div class="section-heading">
+            <h3>Local vision</h3>
+            <p class="muted small">Process images on-device with SmolVLM2.</p>
+          </div>
+          <div class="row vision-row">
+            <label for="local-vision-toggle">On-device inference</label>
+            <div class="vision-controls">
+              <label class="toggle-label">
+                <input type="checkbox" id="local-vision-toggle" />
+                <span id="local-vision-label">Disabled</span>
+              </label>
+            </div>
+          </div>
+          <p id="vision-status" class="status"></p>
+        </div>
+      </div>
     </div>
 
     <script src="/static/main.js"></script>

--- a/src/reachy_mini_conversation_app/static/main.js
+++ b/src/reachy_mini_conversation_app/static/main.js
@@ -163,6 +163,149 @@ async function applyPersonality(name, { persist = false } = {}) {
   return await resp.json();
 }
 
+// ---------- Vision API ----------
+async function getVisionStatus() {
+  try {
+    const url = new URL("/vision/status", window.location.origin);
+    url.searchParams.set("_", Date.now().toString());
+    const resp = await fetchWithTimeout(url, {}, 2000);
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch (e) {
+    return null;
+  }
+}
+
+async function waitForVisionStatus(timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const vs = await getVisionStatus();
+    if (vs !== null) return vs;
+    if (Date.now() >= deadline) return null;
+    await sleep(2000);
+  }
+}
+
+async function setHeadTracker(tracker) {
+  const resp = await fetch("/vision/head-tracker", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tracker: tracker || null }),
+  });
+  return await resp.json();
+}
+
+async function setLocalVision(enabled) {
+  const resp = await fetch("/vision/local-vision", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  return await resp.json();
+}
+
+async function initVisionPanel() {
+  const visionPanel = document.getElementById("vision-panel");
+  const trackerSelect = document.getElementById("head-tracker-select");
+  const applyTracker = document.getElementById("apply-tracker");
+  const trackerStatus = document.getElementById("tracker-status");
+  const localVisionToggle = document.getElementById("local-vision-toggle");
+  const localVisionLabel = document.getElementById("local-vision-label");
+  const visionStatus = document.getElementById("vision-status");
+
+  const vs = await waitForVisionStatus();
+  if (vs === null) return; // Vision endpoints not available
+
+  show(visionPanel, true);
+
+  trackerSelect.value = vs.head_tracker || "";
+  localVisionToggle.checked = vs.local_vision;
+  localVisionLabel.textContent = vs.local_vision ? "Enabled" : "Disabled";
+
+  if (!vs.camera_enabled) {
+    trackerStatus.textContent = "Camera is disabled. Head tracking unavailable.";
+    trackerStatus.className = "status warn";
+    trackerSelect.disabled = true;
+    applyTracker.disabled = true;
+  }
+
+  applyTracker.addEventListener("click", async () => {
+    trackerStatus.textContent = "Applying...";
+    trackerStatus.className = "status";
+    try {
+      const res = await setHeadTracker(trackerSelect.value);
+      if (res.ok) {
+        trackerStatus.textContent = res.head_tracker
+          ? `Switched to ${res.head_tracker}.`
+          : "Head tracking disabled.";
+        trackerStatus.className = "status ok";
+      } else {
+        const msg = typeof res.detail === "string" ? res.detail : res.error || "Failed.";
+        trackerStatus.textContent = msg;
+        trackerStatus.className = "status error";
+      }
+    } catch (e) {
+      trackerStatus.textContent = "Request failed.";
+      trackerStatus.className = "status error";
+    }
+  });
+
+  localVisionToggle.addEventListener("change", async () => {
+    const enabled = localVisionToggle.checked;
+    visionStatus.textContent = enabled ? "Enabling..." : "Disabling...";
+    visionStatus.className = "status";
+    localVisionLabel.textContent = enabled ? "Enabling..." : "Disabled";
+
+    try {
+      const res = await setLocalVision(enabled);
+      if (!res.ok) {
+        localVisionToggle.checked = false;
+        localVisionLabel.textContent = "Disabled";
+        const msg = typeof res.detail === "string" ? res.detail : res.error || "Failed.";
+        visionStatus.textContent = msg;
+        visionStatus.className = "status error";
+        return;
+      }
+
+      if (res.local_vision) {
+        localVisionLabel.textContent = "Enabled";
+        visionStatus.textContent = "Local vision enabled.";
+        visionStatus.className = "status ok";
+      } else if (res.initializing) {
+        localVisionLabel.textContent = "Initializing...";
+        visionStatus.textContent = "Downloading and loading model (this may take a few minutes)...";
+        visionStatus.className = "status";
+        const pollInterval = setInterval(async () => {
+          const status = await getVisionStatus();
+          if (status === null) return;
+          if (status.local_vision) {
+            clearInterval(pollInterval);
+            localVisionToggle.checked = true;
+            localVisionLabel.textContent = "Enabled";
+            visionStatus.textContent = "Local vision enabled.";
+            visionStatus.className = "status ok";
+          } else if (!status.local_vision_initializing) {
+            clearInterval(pollInterval);
+            localVisionToggle.checked = false;
+            localVisionLabel.textContent = "Disabled";
+            visionStatus.textContent = status.local_vision_error || "Initialization failed.";
+            visionStatus.className = "status error";
+          }
+        }, 2000);
+      } else if (!enabled) {
+        localVisionLabel.textContent = "Disabled";
+        visionStatus.textContent = "Local vision disabled.";
+        visionStatus.className = "status ok";
+      }
+    } catch (e) {
+      localVisionToggle.checked = false;
+      localVisionLabel.textContent = "Disabled";
+      visionStatus.textContent = "Request failed.";
+      visionStatus.className = "status error";
+    }
+  });
+}
+
 // Full list from https://developers.openai.com/api/docs/guides/text-to-speech/#voice-options
 // "marin" and "cedar" are recommended for gpt-realtime.
 const VOICE_FALLBACK = ["alloy", "ash", "ballad", "cedar", "coral", "echo", "marin", "sage", "shimmer", "verse"];
@@ -276,6 +419,9 @@ async function init() {
       statusEl.className = "status error";
     }
   });
+
+  // Start vision panel init in background (doesn't depend on API key)
+  initVisionPanel();
 
   if (!st.has_key) {
     statusEl.textContent = "";

--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -398,6 +398,38 @@ button.ghost:hover { border-color: rgba(94, 240, 193, 0.4); }
   margin: 0; font-size: 13px; color: var(--text);
 }
 
+/* Vision settings */
+.vision-row {
+  grid-template-columns: 160px 1fr;
+}
+.vision-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.vision-controls select {
+  flex: 1;
+}
+.vision-controls button {
+  margin: 0;
+  flex-shrink: 0;
+}
+.toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  margin: 0;
+  font-size: 13px;
+  color: var(--text);
+}
+.toggle-label input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
 @media (max-width: 760px) {
   .hero h1 { font-size: 26px; }
   .privacy-notice { padding: 10px 12px; }

--- a/src/reachy_mini_conversation_app/vision_settings.py
+++ b/src/reachy_mini_conversation_app/vision_settings.py
@@ -64,13 +64,15 @@ def mount_vision_routes(
     # ------------------------------------------------------------------
     @app.get("/vision/status")  # type: ignore[misc]
     def _vision_status() -> dict:  # type: ignore
-        return JSONResponse({  # type: ignore
-            "head_tracker": _get_head_tracker_name(camera_worker),
-            "local_vision": deps.vision_processor is not None,
-            "local_vision_initializing": _vision_initializing,
-            "local_vision_error": _vision_init_error,
-            "camera_enabled": camera_worker is not None,
-        })
+        return JSONResponse(
+            {  # type: ignore
+                "head_tracker": _get_head_tracker_name(camera_worker),
+                "local_vision": deps.vision_processor is not None,
+                "local_vision_initializing": _vision_initializing,
+                "local_vision_error": _vision_init_error,
+                "camera_enabled": camera_worker is not None,
+            }
+        )
 
     # ------------------------------------------------------------------
     # POST /vision/head-tracker
@@ -81,7 +83,11 @@ def mount_vision_routes(
 
         if camera_worker is None:
             return JSONResponse(  # type: ignore
-                {"ok": False, "error": "camera_disabled", "detail": "Camera is not enabled. Start with camera support."},
+                {
+                    "ok": False,
+                    "error": "camera_disabled",
+                    "detail": "Camera is not enabled. Start with camera support.",
+                },
                 status_code=400,
             )
 

--- a/src/reachy_mini_conversation_app/vision_settings.py
+++ b/src/reachy_mini_conversation_app/vision_settings.py
@@ -111,13 +111,17 @@ def mount_vision_routes(
 
         try:
             if tracker_name == "yolo":
-                from reachy_mini_conversation_app.vision.yolo_head_tracker import HeadTracker
+                from reachy_mini_conversation_app.vision.head_tracking.yolo_process import (
+                    YoloHeadTrackerProcess,
+                )
 
-                new_tracker = HeadTracker()
+                new_tracker: Any = YoloHeadTrackerProcess()
             else:
-                from reachy_mini_toolbox.vision import HeadTracker  # type: ignore[no-redef]
+                from reachy_mini_conversation_app.vision.head_tracking.mediapipe import (
+                    MediapipeHeadTracker,
+                )
 
-                new_tracker = HeadTracker()
+                new_tracker = MediapipeHeadTracker()
 
             camera_worker.head_tracker = new_tracker
             _active_head_tracker = tracker_name

--- a/src/reachy_mini_conversation_app/vision_settings.py
+++ b/src/reachy_mini_conversation_app/vision_settings.py
@@ -1,0 +1,202 @@
+"""FastAPI routes for runtime vision settings (head tracker + local vision).
+
+Mounted on the headless settings app so users can toggle vision features
+from the embedded web UI without restarting the daemon.
+"""
+
+import logging
+import threading
+from typing import Any, Optional
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.camera_worker import CameraWorker
+
+logger = logging.getLogger(__name__)
+
+# Module-level cache so the vision processor survives disable/re-enable cycles.
+_cached_vision_processor: Any = None
+_vision_initializing = False
+_vision_init_error: Optional[str] = None
+
+# Track which head tracker backend is active (for status reporting).
+_active_head_tracker: Optional[str] = None
+
+
+def _get_head_tracker_name(camera_worker: Optional[CameraWorker]) -> Optional[str]:
+    """Return the active head tracker backend name, or None."""
+    global _active_head_tracker
+    if camera_worker is None or camera_worker.head_tracker is None:
+        _active_head_tracker = None
+        return None
+    return _active_head_tracker
+
+
+def mount_vision_routes(
+    app: Any,
+    deps: ToolDependencies,
+    camera_worker: Optional[CameraWorker],
+) -> None:
+    """Register vision settings endpoints on a FastAPI app."""
+    try:
+        from fastapi import Request
+        from fastapi.responses import JSONResponse
+    except Exception:
+        return
+
+    global _cached_vision_processor, _vision_initializing, _vision_init_error, _active_head_tracker
+
+    # Seed tracker name from whatever was set at startup
+    if camera_worker is not None and camera_worker.head_tracker is not None:
+        tracker = camera_worker.head_tracker
+        cls_name = type(tracker).__module__
+        if "yolo" in cls_name:
+            _active_head_tracker = "yolo"
+        else:
+            _active_head_tracker = "mediapipe"
+
+    # Seed cached processor from startup
+    if deps.vision_processor is not None:
+        _cached_vision_processor = deps.vision_processor
+
+    # ------------------------------------------------------------------
+    # GET /vision/status
+    # ------------------------------------------------------------------
+    @app.get("/vision/status")
+    def _vision_status() -> JSONResponse:
+        return JSONResponse({
+            "head_tracker": _get_head_tracker_name(camera_worker),
+            "local_vision": deps.vision_processor is not None,
+            "local_vision_initializing": _vision_initializing,
+            "local_vision_error": _vision_init_error,
+            "camera_enabled": camera_worker is not None,
+        })
+
+    # ------------------------------------------------------------------
+    # POST /vision/head-tracker
+    # ------------------------------------------------------------------
+    @app.post("/vision/head-tracker")
+    async def _set_head_tracker(request: Request) -> JSONResponse:
+        global _active_head_tracker
+
+        if camera_worker is None:
+            return JSONResponse(
+                {"ok": False, "error": "camera_disabled", "detail": "Camera is not enabled. Start with camera support."},
+                status_code=400,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        tracker_name = body.get("tracker")  # "yolo", "mediapipe", or null/empty
+
+        if not tracker_name:
+            camera_worker.head_tracker = None
+            _active_head_tracker = None
+            logger.info("Head tracker disabled via settings UI")
+            return JSONResponse({"ok": True, "head_tracker": None})
+
+        if tracker_name not in ("yolo", "mediapipe"):
+            return JSONResponse(
+                {"ok": False, "error": "invalid_tracker", "detail": f"Unknown tracker: {tracker_name}"},
+                status_code=400,
+            )
+
+        try:
+            if tracker_name == "yolo":
+                from reachy_mini_conversation_app.vision.yolo_head_tracker import HeadTracker
+                new_tracker = HeadTracker()
+            else:
+                from reachy_mini_toolbox.vision import HeadTracker  # type: ignore[no-redef]
+                new_tracker = HeadTracker()
+
+            camera_worker.head_tracker = new_tracker
+            _active_head_tracker = tracker_name
+            logger.info("Head tracker switched to %s via settings UI", tracker_name)
+            return JSONResponse({"ok": True, "head_tracker": tracker_name})
+
+        except ImportError:
+            extra = "yolo_vision" if tracker_name == "yolo" else "mediapipe_vision"
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": "missing_dependency",
+                    "detail": f"Install the required extra: pip install '.[{extra}]'",
+                },
+                status_code=400,
+            )
+        except Exception as e:
+            logger.exception("Failed to initialize %s head tracker", tracker_name)
+            return JSONResponse(
+                {"ok": False, "error": "init_failed", "detail": str(e)},
+                status_code=500,
+            )
+
+    # ------------------------------------------------------------------
+    # POST /vision/local-vision
+    # ------------------------------------------------------------------
+    @app.post("/vision/local-vision")
+    async def _set_local_vision(request: Request) -> JSONResponse:
+        global _cached_vision_processor, _vision_initializing, _vision_init_error
+
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        enabled = body.get("enabled", False)
+
+        if not enabled:
+            # Disable: clear from deps but keep cached
+            if deps.vision_processor is not None:
+                _cached_vision_processor = deps.vision_processor
+            deps.vision_processor = None
+            logger.info("Local vision disabled via settings UI")
+            return JSONResponse({"ok": True, "local_vision": False})
+
+        # Enable: use cached processor if available
+        if _cached_vision_processor is not None:
+            deps.vision_processor = _cached_vision_processor
+            logger.info("Local vision re-enabled from cache via settings UI")
+            return JSONResponse({"ok": True, "local_vision": True})
+
+        # Need to initialize — check if already in progress
+        if _vision_initializing:
+            return JSONResponse({"ok": True, "local_vision": False, "initializing": True})
+
+        # Check that the extra is installed before spawning a thread
+        try:
+            import importlib
+            importlib.import_module("torch")
+            importlib.import_module("transformers")
+        except ImportError:
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": "missing_dependency",
+                    "detail": "Install the required extra: pip install '.[local_vision]'",
+                },
+                status_code=400,
+            )
+
+        # Start background initialization
+        _vision_initializing = True
+        _vision_init_error = None
+
+        def _init_vision() -> None:
+            global _cached_vision_processor, _vision_initializing, _vision_init_error
+            try:
+                from reachy_mini_conversation_app.vision.processors import initialize_vision_processor
+                processor = initialize_vision_processor()
+                _cached_vision_processor = processor
+                deps.vision_processor = processor
+                logger.info("Local vision initialized in background via settings UI")
+            except Exception as e:
+                logger.exception("Background vision initialization failed")
+                _vision_init_error = str(e)
+            finally:
+                _vision_initializing = False
+
+        thread = threading.Thread(target=_init_vision, daemon=True, name="vision-init")
+        thread.start()
+
+        return JSONResponse({"ok": True, "local_vision": False, "initializing": True})

--- a/src/reachy_mini_conversation_app/vision_settings.py
+++ b/src/reachy_mini_conversation_app/vision_settings.py
@@ -8,8 +8,9 @@ import logging
 import threading
 from typing import Any, Optional
 
-from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.camera_worker import CameraWorker
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+
 
 logger = logging.getLogger(__name__)
 
@@ -61,9 +62,9 @@ def mount_vision_routes(
     # ------------------------------------------------------------------
     # GET /vision/status
     # ------------------------------------------------------------------
-    @app.get("/vision/status")
-    def _vision_status() -> JSONResponse:
-        return JSONResponse({
+    @app.get("/vision/status")  # type: ignore[misc]
+    def _vision_status() -> dict:  # type: ignore
+        return JSONResponse({  # type: ignore
             "head_tracker": _get_head_tracker_name(camera_worker),
             "local_vision": deps.vision_processor is not None,
             "local_vision_initializing": _vision_initializing,
@@ -74,12 +75,12 @@ def mount_vision_routes(
     # ------------------------------------------------------------------
     # POST /vision/head-tracker
     # ------------------------------------------------------------------
-    @app.post("/vision/head-tracker")
-    async def _set_head_tracker(request: Request) -> JSONResponse:
+    @app.post("/vision/head-tracker")  # type: ignore[misc]
+    async def _set_head_tracker(request: Request) -> dict:  # type: ignore
         global _active_head_tracker
 
         if camera_worker is None:
-            return JSONResponse(
+            return JSONResponse(  # type: ignore
                 {"ok": False, "error": "camera_disabled", "detail": "Camera is not enabled. Start with camera support."},
                 status_code=400,
             )
@@ -94,10 +95,10 @@ def mount_vision_routes(
             camera_worker.head_tracker = None
             _active_head_tracker = None
             logger.info("Head tracker disabled via settings UI")
-            return JSONResponse({"ok": True, "head_tracker": None})
+            return JSONResponse({"ok": True, "head_tracker": None})  # type: ignore
 
         if tracker_name not in ("yolo", "mediapipe"):
-            return JSONResponse(
+            return JSONResponse(  # type: ignore
                 {"ok": False, "error": "invalid_tracker", "detail": f"Unknown tracker: {tracker_name}"},
                 status_code=400,
             )
@@ -105,19 +106,21 @@ def mount_vision_routes(
         try:
             if tracker_name == "yolo":
                 from reachy_mini_conversation_app.vision.yolo_head_tracker import HeadTracker
+
                 new_tracker = HeadTracker()
             else:
                 from reachy_mini_toolbox.vision import HeadTracker  # type: ignore[no-redef]
+
                 new_tracker = HeadTracker()
 
             camera_worker.head_tracker = new_tracker
             _active_head_tracker = tracker_name
             logger.info("Head tracker switched to %s via settings UI", tracker_name)
-            return JSONResponse({"ok": True, "head_tracker": tracker_name})
+            return JSONResponse({"ok": True, "head_tracker": tracker_name})  # type: ignore
 
         except ImportError:
             extra = "yolo_vision" if tracker_name == "yolo" else "mediapipe_vision"
-            return JSONResponse(
+            return JSONResponse(  # type: ignore
                 {
                     "ok": False,
                     "error": "missing_dependency",
@@ -127,7 +130,7 @@ def mount_vision_routes(
             )
         except Exception as e:
             logger.exception("Failed to initialize %s head tracker", tracker_name)
-            return JSONResponse(
+            return JSONResponse(  # type: ignore
                 {"ok": False, "error": "init_failed", "detail": str(e)},
                 status_code=500,
             )
@@ -135,8 +138,8 @@ def mount_vision_routes(
     # ------------------------------------------------------------------
     # POST /vision/local-vision
     # ------------------------------------------------------------------
-    @app.post("/vision/local-vision")
-    async def _set_local_vision(request: Request) -> JSONResponse:
+    @app.post("/vision/local-vision")  # type: ignore[misc]
+    async def _set_local_vision(request: Request) -> dict:  # type: ignore
         global _cached_vision_processor, _vision_initializing, _vision_init_error
 
         try:
@@ -151,25 +154,26 @@ def mount_vision_routes(
                 _cached_vision_processor = deps.vision_processor
             deps.vision_processor = None
             logger.info("Local vision disabled via settings UI")
-            return JSONResponse({"ok": True, "local_vision": False})
+            return JSONResponse({"ok": True, "local_vision": False})  # type: ignore
 
         # Enable: use cached processor if available
         if _cached_vision_processor is not None:
             deps.vision_processor = _cached_vision_processor
             logger.info("Local vision re-enabled from cache via settings UI")
-            return JSONResponse({"ok": True, "local_vision": True})
+            return JSONResponse({"ok": True, "local_vision": True})  # type: ignore
 
         # Need to initialize — check if already in progress
         if _vision_initializing:
-            return JSONResponse({"ok": True, "local_vision": False, "initializing": True})
+            return JSONResponse({"ok": True, "local_vision": False, "initializing": True})  # type: ignore
 
         # Check that the extra is installed before spawning a thread
         try:
             import importlib
+
             importlib.import_module("torch")
             importlib.import_module("transformers")
         except ImportError:
-            return JSONResponse(
+            return JSONResponse(  # type: ignore
                 {
                     "ok": False,
                     "error": "missing_dependency",
@@ -186,6 +190,7 @@ def mount_vision_routes(
             global _cached_vision_processor, _vision_initializing, _vision_init_error
             try:
                 from reachy_mini_conversation_app.vision.processors import initialize_vision_processor
+
                 processor = initialize_vision_processor()
                 _cached_vision_processor = processor
                 deps.vision_processor = processor
@@ -199,4 +204,4 @@ def mount_vision_routes(
         thread = threading.Thread(target=_init_vision, daemon=True, name="vision-init")
         thread.start()
 
-        return JSONResponse({"ok": True, "local_vision": False, "initializing": True})
+        return JSONResponse({"ok": True, "local_vision": False, "initializing": True})  # type: ignore

--- a/tests/vision/test_vision_settings.py
+++ b/tests/vision/test_vision_settings.py
@@ -1,0 +1,246 @@
+"""Tests for the runtime vision settings endpoints."""
+
+from types import SimpleNamespace
+from typing import Any
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reachy_mini_conversation_app import vision_settings
+from reachy_mini_conversation_app.vision_settings import (
+    mount_vision_routes,
+    _get_head_tracker_name,
+)
+
+
+@dataclass
+class FakeDeps:
+    """Minimal stand-in for ToolDependencies used by vision settings."""
+
+    vision_processor: Any = None
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Any:
+    """Reset module-level globals between tests."""
+    vision_settings._cached_vision_processor = None
+    vision_settings._vision_initializing = False
+    vision_settings._vision_init_error = None
+    vision_settings._active_head_tracker = None
+    yield
+    vision_settings._cached_vision_processor = None
+    vision_settings._vision_initializing = False
+    vision_settings._vision_init_error = None
+    vision_settings._active_head_tracker = None
+
+
+# ---------- _get_head_tracker_name ----------
+
+
+def test_get_head_tracker_name_no_camera() -> None:
+    """Returns None when camera_worker is None."""
+    assert _get_head_tracker_name(None) is None
+
+
+def test_get_head_tracker_name_no_tracker() -> None:
+    """Returns None when head_tracker is not set."""
+    cw = SimpleNamespace(head_tracker=None)
+    assert _get_head_tracker_name(cw) is None  # type: ignore[arg-type]
+
+
+def test_get_head_tracker_name_returns_cached_name() -> None:
+    """Returns the cached tracker name when tracker is active."""
+    vision_settings._active_head_tracker = "yolo"
+    cw = SimpleNamespace(head_tracker=MagicMock())
+    assert _get_head_tracker_name(cw) == "yolo"  # type: ignore[arg-type]
+
+
+# ---------- mount_vision_routes / GET /vision/status ----------
+
+
+@pytest.fixture
+def app_and_deps() -> tuple[Any, FakeDeps, SimpleNamespace]:
+    """Create a test FastAPI app with vision routes mounted."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    deps = FakeDeps()
+    cw = SimpleNamespace(head_tracker=None)
+    app = FastAPI()
+    mount_vision_routes(app, deps, cw)  # type: ignore[arg-type]
+    return TestClient(app), deps, cw
+
+
+def test_status_endpoint_defaults(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """GET /vision/status returns default state."""
+    client, deps, cw = app_and_deps
+    resp = client.get("/vision/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["head_tracker"] is None
+    assert data["local_vision"] is False
+    assert data["local_vision_initializing"] is False
+    assert data["local_vision_error"] is None
+    assert data["camera_enabled"] is True
+
+
+def test_status_reflects_vision_processor(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """GET /vision/status shows local_vision=True when processor is set."""
+    client, deps, _ = app_and_deps
+    deps.vision_processor = MagicMock()
+    resp = client.get("/vision/status")
+    assert resp.json()["local_vision"] is True
+
+
+# ---------- POST /vision/head-tracker ----------
+
+
+def test_set_head_tracker_disable(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """Setting tracker to null disables head tracking."""
+    client, _, cw = app_and_deps
+    cw.head_tracker = MagicMock()
+    resp = client.post("/vision/head-tracker", json={"tracker": None})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["head_tracker"] is None
+    assert cw.head_tracker is None
+
+
+def test_set_head_tracker_invalid_name(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """Invalid tracker names are rejected."""
+    client, _, _ = app_and_deps
+    resp = client.post("/vision/head-tracker", json={"tracker": "invalid"})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_tracker"
+
+
+def test_set_head_tracker_init_failure(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """Tracker initialization failures return a 500 error."""
+    client, _, _ = app_and_deps
+    with patch(
+        "reachy_mini_conversation_app.vision.yolo_head_tracker.HeadTracker",
+        side_effect=RuntimeError("GPU init failed"),
+    ):
+        resp = client.post("/vision/head-tracker", json={"tracker": "yolo"})
+
+    assert resp.status_code == 500
+    assert resp.json()["error"] == "init_failed"
+
+
+def test_set_head_tracker_no_camera() -> None:
+    """Returns error when camera is not available."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    deps = FakeDeps()
+    app = FastAPI()
+    mount_vision_routes(app, deps, None)  # type: ignore[arg-type]
+    client = TestClient(app)
+
+    resp = client.post("/vision/head-tracker", json={"tracker": "yolo"})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "camera_disabled"
+
+
+# ---------- POST /vision/local-vision ----------
+
+
+def test_disable_local_vision(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """Disabling local vision clears deps but caches the processor."""
+    client, deps, _ = app_and_deps
+    fake_proc = MagicMock()
+    deps.vision_processor = fake_proc
+
+    resp = client.post("/vision/local-vision", json={"enabled": False})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["local_vision"] is False
+    assert deps.vision_processor is None
+    assert vision_settings._cached_vision_processor is fake_proc
+
+
+def test_enable_local_vision_from_cache(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """Re-enabling local vision uses the cached processor instantly."""
+    client, deps, _ = app_and_deps
+    fake_proc = MagicMock()
+    vision_settings._cached_vision_processor = fake_proc
+
+    resp = client.post("/vision/local-vision", json={"enabled": True})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["local_vision"] is True
+    assert deps.vision_processor is fake_proc
+
+
+def test_enable_local_vision_missing_dependency(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """Returns error when torch/transformers not installed."""
+    client, deps, _ = app_and_deps
+
+    with patch("importlib.import_module", side_effect=ImportError("No module")):
+        resp = client.post("/vision/local-vision", json={"enabled": True})
+
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "missing_dependency"
+
+
+def test_enable_local_vision_already_initializing(app_and_deps: tuple[Any, FakeDeps, SimpleNamespace]) -> None:
+    """Returns initializing status when init is already in progress."""
+    client, _, _ = app_and_deps
+    vision_settings._vision_initializing = True
+
+    resp = client.post("/vision/local-vision", json={"enabled": True})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["initializing"] is True
+
+
+# ---------- Seeding from startup state ----------
+
+
+def test_mount_seeds_tracker_name_from_yolo() -> None:
+    """mount_vision_routes detects yolo tracker from module name."""
+    from fastapi import FastAPI
+
+    deps = FakeDeps()
+    tracker = MagicMock()
+    type(tracker).__module__ = "reachy_mini_conversation_app.vision.yolo_head_tracker"
+    cw = SimpleNamespace(head_tracker=tracker)
+
+    app = FastAPI()
+    mount_vision_routes(app, deps, cw)  # type: ignore[arg-type]
+
+    assert vision_settings._active_head_tracker == "yolo"
+
+
+def test_mount_seeds_tracker_name_from_mediapipe() -> None:
+    """mount_vision_routes detects mediapipe tracker from module name."""
+    from fastapi import FastAPI
+
+    deps = FakeDeps()
+    tracker = MagicMock()
+    type(tracker).__module__ = "reachy_mini_toolbox.vision"
+    cw = SimpleNamespace(head_tracker=tracker)
+
+    app = FastAPI()
+    mount_vision_routes(app, deps, cw)  # type: ignore[arg-type]
+
+    assert vision_settings._active_head_tracker == "mediapipe"
+
+
+def test_mount_seeds_cached_processor() -> None:
+    """mount_vision_routes caches existing vision processor."""
+    from fastapi import FastAPI
+
+    fake_proc = MagicMock()
+    deps = FakeDeps(vision_processor=fake_proc)
+    cw = SimpleNamespace(head_tracker=None)
+
+    app = FastAPI()
+    mount_vision_routes(app, deps, cw)  # type: ignore[arg-type]
+
+    assert vision_settings._cached_vision_processor is fake_proc

--- a/tests/vision/test_vision_settings.py
+++ b/tests/vision/test_vision_settings.py
@@ -120,7 +120,7 @@ def test_set_head_tracker_init_failure(app_and_deps: tuple[Any, FakeDeps, Simple
     """Tracker initialization failures return a 500 error."""
     client, _, _ = app_and_deps
     with patch(
-        "reachy_mini_conversation_app.vision.yolo_head_tracker.HeadTracker",
+        "reachy_mini_conversation_app.vision.head_tracking.yolo_process.YoloHeadTrackerProcess",
         side_effect=RuntimeError("GPU init failed"),
     ):
         resp = client.post("/vision/head-tracker", json={"tracker": "yolo"})
@@ -208,7 +208,7 @@ def test_mount_seeds_tracker_name_from_yolo() -> None:
 
     deps = FakeDeps()
     tracker = MagicMock()
-    type(tracker).__module__ = "reachy_mini_conversation_app.vision.yolo_head_tracker"
+    type(tracker).__module__ = "reachy_mini_conversation_app.vision.head_tracking.yolo_process"
     cw = SimpleNamespace(head_tracker=tracker)
 
     app = FastAPI()
@@ -223,7 +223,7 @@ def test_mount_seeds_tracker_name_from_mediapipe() -> None:
 
     deps = FakeDeps()
     tracker = MagicMock()
-    type(tracker).__module__ = "reachy_mini_toolbox.vision"
+    type(tracker).__module__ = "reachy_mini_conversation_app.vision.head_tracking.mediapipe"
     cw = SimpleNamespace(head_tracker=tracker)
 
     app = FastAPI()


### PR DESCRIPTION
## Summary

Add a "Vision settings" panel to the headless settings page (embedded in the desktop app) that allows toggling head tracking (YOLO/MediaPipe) and local vision (SmolVLM2) at runtime without restarting the daemon.

- New vision_settings.py with FastAPI endpoints: `GET /vision/status`, `POST /vision/head-tracker`, `POST
  /vision/local-vision`
- Head tracker is swapped live on the `CameraWorker`
- Local vision processor initializes in a background thread with status polling; cached for instant re-enable after
  disable
- Wire deps and `camera_worker` into `LocalStream` for runtime access
- Frontend: vision panel with select, toggle, and async init feedback
- 16 new tests covering all endpoints
  
## Category
- [ ] Fix
- [X] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [X] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [X] Code is clear (types, docs, comments where needed)
- [X] `.env.example` updated (if new config vars were added)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [X] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [X] Local vision (`--local-vision`)
- [X] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
Vision features were previously only configurable via CLI flags at startup. 
This PR makes them toggle able at runtime from the headless settings page that the desktop app embeds via iframe. 

No changes to the desktop app are needed.

The VisionProcessor (SmolVLM2) is initialized lazily in a background thread on first enable, with the UI polling `/vision/status` until ready. 

Once initialized, the processor is cached at module level so disable/re-enable is instant.

Head tracker swapping works by assigning a new tracker instance to camera_worker.head_tracker, the working loop picks it up on the next iteration under the GIL.
