### PR TITLE
feat: add Home Assistant MCP tool and credentials support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 OPENAI_API_KEY=
 MODEL_NAME="gpt-realtime"
+HOME_ASSISTANT_ENABLED=0
+HOME_ASSISTANT_MCP_URL=
+HOME_ASSISTANT_TOKEN=
 
 # To use Gemini Live instead of OpenAI Realtime, set:
 # MODEL_NAME="gemini-3.1-flash-live-preview"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Some wheels (like PyTorch) are large and require compatible CUDA or CPU builds�
 |----------|-------------|
 | `OPENAI_API_KEY` | Required for OpenAI mode. Grants access to the OpenAI realtime endpoint. |
 | `GEMINI_API_KEY` | Required for Gemini mode. Also accepts `GOOGLE_API_KEY`. Get one at [aistudio.google.com](https://aistudio.google.com/apikey). |
+| `HOME_ASSISTANT_ENABLED` | Optional. Set to `1` to enable the built-in `home_assistant` MCP bridge tool. |
+| `HOME_ASSISTANT_MCP_URL` | Optional. Full Home Assistant MCP endpoint URL, for example `http://192.168.1.20:8123/api/mcp`. |
+| `HOME_ASSISTANT_TOKEN` | Optional. Home Assistant long-lived access token used for MCP authentication. |
 | `MODEL_NAME` | Which backend to use. `gpt-realtime` (default) for OpenAI, or `gemini-3.1-flash-live-preview` for Gemini Live. |
 | `HF_HOME` | Cache directory for local Hugging Face downloads (only used with `--local-vision` flag, defaults to `./cache`). |
 | `HF_TOKEN` | Optional token for Hugging Face access (for gated/private assets). |
@@ -204,6 +207,7 @@ reachy-mini-conversation-app --gradio
 | `play_emotion` | Play a recorded emotion clip via Hugging Face datasets. | Core install only. Uses the default open emotions dataset: [`pollen-robotics/reachy-mini-emotions-library`](https://huggingface.co/datasets/pollen-robotics/reachy-mini-emotions-library). |
 | `stop_emotion` | Clear queued emotions. | Core install only. |
 | `do_nothing` | Explicitly remain idle. | Core install only. |
+| `home_assistant` | Bridge to Home Assistant's MCP server for discovery, prompt lookup, and tool calls. | Requires `HOME_ASSISTANT_*` settings and a profile that enables the tool. |
 
 ## Advanced features
 
@@ -252,6 +256,8 @@ When running with `--gradio`, open the "Personality" accordion:
 - Select among available profiles (folders under `profiles/`) or the built‑in default.
 - Click "Apply" to update the current session instructions live.
 - Create a new personality by entering a name and instructions text. It stores files under `profiles/<name>/` and copies `tools.txt` from the `default` profile.
+
+When running in headless mode through the Reachy Mini Apps settings page, the `Credentials` section now has a separate `Home Assistant` card. Save the MCP URL and token there, then enable `home_assistant` in a profile. Tool list changes still require a restart because `tools.txt` is loaded at startup.
 
 Note: The "Personality" panel updates the conversation instructions. Tool sets are loaded at startup from `tools.txt` and are not hot‑reloaded.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-dotenv",
 
     #OpenAI
+    "mcp>=1.0.0",
     "openai>=2.30.0",
 
     #Gemini

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -53,6 +53,11 @@ except Exception:  # pragma: no cover - only loaded when settings_app is used
 logger = logging.getLogger(__name__)
 
 
+HOME_ASSISTANT_URL_ENV = "HOME_ASSISTANT_MCP_URL"
+HOME_ASSISTANT_TOKEN_ENV = "HOME_ASSISTANT_TOKEN"
+HOME_ASSISTANT_ENABLED_ENV = "HOME_ASSISTANT_ENABLED"
+
+
 class LocalStream:
     """LocalStream using Reachy Mini's recorder/player."""
 
@@ -169,6 +174,70 @@ class LocalStream:
         except Exception as e:
             logger.warning("Failed to persist OPENAI_API_KEY: %s", e)
 
+    def _persist_home_assistant_config(self, enabled: bool, url: str | None = None, token: str | None = None) -> None:
+        """Persist Home Assistant MCP configuration without touching OpenAI settings."""
+        url_value = (url or "").strip()
+        token_value = (token or "").strip()
+
+        try:
+            os.environ[HOME_ASSISTANT_ENABLED_ENV] = "1" if enabled else "0"
+            if url_value:
+                os.environ[HOME_ASSISTANT_URL_ENV] = url_value
+            if token_value:
+                os.environ[HOME_ASSISTANT_TOKEN_ENV] = token_value
+        except Exception:
+            pass
+
+        if not self._instance_path:
+            return
+
+        try:
+            env_path = Path(self._instance_path) / ".env"
+            lines = self._read_env_lines(env_path)
+            updates = {
+                HOME_ASSISTANT_ENABLED_ENV: "1" if enabled else "0",
+                HOME_ASSISTANT_URL_ENV: url_value or None,
+                HOME_ASSISTANT_TOKEN_ENV: token_value or None,
+            }
+
+            for key, value in updates.items():
+                if value is None:
+                    continue
+                replaced = False
+                for i, ln in enumerate(lines):
+                    if ln.strip().startswith(f"{key}="):
+                        lines[i] = f"{key}={value}"
+                        replaced = True
+                        break
+                if not replaced:
+                    lines.append(f"{key}={value}")
+
+            final_text = "\n".join(lines) + "\n"
+            env_path.write_text(final_text, encoding="utf-8")
+            logger.info("Persisted Home Assistant config to %s", env_path)
+
+            try:
+                from dotenv import load_dotenv
+
+                load_dotenv(dotenv_path=str(env_path), override=True)
+            except Exception:
+                pass
+        except Exception as e:
+            logger.warning("Failed to persist Home Assistant config: %s", e)
+
+    def _read_home_assistant_config(self) -> dict[str, object]:
+        """Read current Home Assistant MCP configuration from the live environment."""
+        enabled_raw = os.getenv(HOME_ASSISTANT_ENABLED_ENV, "0").strip().lower()
+        enabled = enabled_raw in {"1", "true", "yes", "on"}
+        url = os.getenv(HOME_ASSISTANT_URL_ENV, "").strip()
+        token = os.getenv(HOME_ASSISTANT_TOKEN_ENV, "").strip()
+        return {
+            "enabled": enabled,
+            "configured": bool(url and token),
+            "url": url,
+            "has_token": bool(token),
+        }
+
     def _persist_personality(self, profile: Optional[str]) -> None:
         """Persist the startup personality to the instance .env and config."""
         if LOCKED_PROFILE is not None:
@@ -251,6 +320,11 @@ class LocalStream:
         class ApiKeyPayload(BaseModel):
             openai_api_key: str
 
+        class HomeAssistantPayload(BaseModel):
+            enabled: bool = False
+            url: str | None = None
+            token: str | None = None
+
         # GET / -> index.html
         @self._settings_app.get("/")
         def _root() -> FileResponse:
@@ -285,6 +359,29 @@ class LocalStream:
                 return JSONResponse({"ok": False, "error": "empty_key"}, status_code=400)
             self._persist_api_key(key)
             return JSONResponse({"ok": True})
+
+        @self._settings_app.get("/home_assistant_config")
+        def _get_home_assistant_config() -> JSONResponse:
+            return JSONResponse(self._read_home_assistant_config())
+
+        @self._settings_app.post("/home_assistant_config")
+        def _set_home_assistant_config(payload: HomeAssistantPayload) -> JSONResponse:
+            existing = self._read_home_assistant_config()
+            url = (payload.url or "").strip()
+            token = (payload.token or "").strip()
+            saved_url = str(existing.get("url") or "").strip()
+            has_saved_token = bool(existing.get("has_token"))
+
+            if payload.enabled:
+                effective_url = url or saved_url
+                effective_has_token = bool(token) or has_saved_token
+                if not effective_url:
+                    return JSONResponse({"ok": False, "error": "missing_home_assistant_url"}, status_code=400)
+                if not effective_has_token:
+                    return JSONResponse({"ok": False, "error": "missing_home_assistant_token"}, status_code=400)
+
+            self._persist_home_assistant_config(payload.enabled, url or None, token or None)
+            return JSONResponse({"ok": True, **self._read_home_assistant_config()})
 
         # POST /validate_api_key -> validate key without persisting it
         @self._settings_app.post("/validate_api_key")

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -33,6 +33,7 @@ from reachy_mini_conversation_app.config import AVAILABLE_VOICES, config
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
 from reachy_mini_conversation_app.tools.core_tools import (
     ToolDependencies,
+    reload_tools,
     get_tool_specs,
 )
 from reachy_mini_conversation_app.tools.background_tool_manager import (
@@ -55,7 +56,6 @@ TEXT_OUTPUT_COST_PER_1M = 16.0
 IMAGE_INPUT_COST_PER_1M = 5.0
 
 _RESPONSE_DONE_TIMEOUT: Final[float] = 30.0
-
 
 
 class InputTranscriptChunksByItem(BaseModel):
@@ -154,6 +154,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             from reachy_mini_conversation_app.config import set_custom_profile
 
             set_custom_profile(profile)
+            reload_tools()
             logger.info(
                 "Set custom profile to %r (config=%r)", profile, getattr(_config, "REACHY_MINI_CUSTOM_PROFILE", None)
             )
@@ -215,6 +216,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
     async def start_up(self) -> None:
         """Start the handler with minimal retries on unexpected websocket closure."""
+        reload_tools()
         openai_api_key = config.OPENAI_API_KEY
         if self.gradio_mode and not openai_api_key:
             # api key was not found in .env or in the environment variables
@@ -369,7 +371,8 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             tool_result = bg_tool.result
             logger.info(
                 "Tool '%s' (id=%s) executed successfully.",
-                bg_tool.tool_name, bg_tool.id,
+                bg_tool.tool_name,
+                bg_tool.id,
             )
             logger.debug("Tool '%s' full result: %s", bg_tool.tool_name, tool_result)
         else:
@@ -378,7 +381,11 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
         # Connection may have closed while tool was running
         if not self.connection:
-            logger.warning("Connection closed during tool '%s' (id=%s) execution; cannot send result back", bg_tool.tool_name, bg_tool.id)
+            logger.warning(
+                "Connection closed during tool '%s' (id=%s) execution; cannot send result back",
+                bg_tool.tool_name,
+                bg_tool.id,
+            )
             return
 
         try:
@@ -476,7 +483,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             voice=get_session_voice(),
                         ),
                     ),
-                    tools=get_tool_specs(), # type: ignore[typeddict-item]
+                    tools=get_tool_specs(),  # type: ignore[typeddict-item]
                     tool_choice="auto",
                 )
                 await conn.session.update(session=session_config)
@@ -504,16 +511,13 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             except Exception:
                 pass
 
-
             response_sender_task: asyncio.Task[None] | None = None
             try:
                 # Start the background tool manager
                 self.tool_manager.start_up(tool_callbacks=[self._handle_tool_result])
 
                 # Start the response sender worker
-                response_sender_task = asyncio.create_task(
-                    self._response_sender_loop(), name="response-sender"
-                )
+                response_sender_task = asyncio.create_task(self._response_sender_loop(), name="response-sender")
 
                 async for event in self.connection:
                     logger.debug(f"OpenAI event: {event.type}")
@@ -595,7 +599,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     # Handle assistant transcription
                     if event.type == "response.output_audio_transcript.done":
                         logger.debug(f"Assistant transcript: {event.transcript}")
-                        await self.output_queue.put(AdditionalOutputs({"role": "assistant", "content": event.transcript}))
+                        await self.output_queue.put(
+                            AdditionalOutputs({"role": "assistant", "content": event.transcript})
+                        )
 
                     # Handle audio delta
                     if event.type == "response.output_audio.delta":
@@ -618,14 +624,19 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
                         logger.info(
                             "Tool call received — tool_name=%r, call_id=%s, is_idle=%s, args=%s",
-                            tool_name, call_id, self.is_idle_tool_call, args_json_str,
+                            tool_name,
+                            call_id,
+                            self.is_idle_tool_call,
+                            args_json_str,
                         )
 
                         if not isinstance(tool_name, str) or not isinstance(args_json_str, str):
                             logger.error(
                                 "Invalid tool call: tool_name=%s (type=%s), args=%s (type=%s), call_id=%s",
-                                tool_name, type(tool_name).__name__,
-                                args_json_str, type(args_json_str).__name__,
+                                tool_name,
+                                type(tool_name).__name__,
+                                args_json_str,
+                                type(args_json_str).__name__,
                                 call_id,
                             )
                             continue
@@ -652,7 +663,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                         if self.is_idle_tool_call:
                             self.is_idle_tool_call = False
 
-                        logger.info("Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id)
+                        logger.info(
+                            "Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id
+                        )
 
                     # server error
                     if event.type == "error":

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -683,7 +683,10 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             logger.error("Realtime error [%s]: %s (raw=%s)", code, msg, err)
 
                         # Only show user-facing errors, not internal state errors
-                        if code not in ("input_audio_buffer_commit_empty",):
+                        if code not in (
+                            "input_audio_buffer_commit_empty",
+                            "conversation_already_has_active_response",
+                        ):
                             await self.output_queue.put(
                                 AdditionalOutputs({"role": "assistant", "content": f"[error] {msg}"})
                             )

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -395,7 +395,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     item={
                         "type": "function_call_output",
                         "call_id": bg_tool.id,
-                        "output": json.dumps(tool_result),
+                        "output": json.dumps(tool_result, ensure_ascii=False),
                     },
                 )
 
@@ -403,7 +403,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 AdditionalOutputs(
                     {
                         "role": "assistant",
-                        "content": json.dumps(tool_result),
+                        "content": json.dumps(tool_result, ensure_ascii=False),
                         # Gradio UI metadata.status accept only "pending" and "done". Do not accept bg.tool.status values.
                         "metadata": {
                             "title": f"🛠️ Used tool {bg_tool.tool_name}",

--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -34,7 +34,7 @@
 
           <p>
             In privacy-sensitive environments, use <code>--local-vision</code> to process images on-device. See the
-            <a href="https://github.com/Desmond-Dong/reachy_mini_conversation_app/blob/main/README.md" target="_blank" rel="noopener">
+            <a href="https://github.com/pollen-robotics/reachy_mini_conversation_app/blob/main/README.md" target="_blank" rel="noopener">
               project README
             </a>
             for full setup instructions. An open-source approach is in the works – stay tuned for its release.

--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -34,7 +34,7 @@
 
           <p>
             In privacy-sensitive environments, use <code>--local-vision</code> to process images on-device. See the
-            <a href="https://github.com/pollen-robotics/reachy_mini_conversation_app/blob/main/README.md" target="_blank" rel="noopener">
+            <a href="https://github.com/Desmond-Dong/reachy_mini_conversation_app/blob/main/README.md" target="_blank" rel="noopener">
               project README
             </a>
             for full setup instructions. An open-source approach is in the works – stay tuned for its release.
@@ -68,6 +68,32 @@
         <div class="actions">
           <button id="save-btn">Save key</button>
           <p id="status" class="status"></p>
+        </div>
+      </div>
+
+      <div id="home-assistant-panel" class="panel hidden">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Credentials</p>
+            <h2>Connect Home Assistant</h2>
+          </div>
+          <span class="chip">Optional</span>
+        </div>
+        <p class="muted">Save your Home Assistant MCP endpoint and token separately from the OpenAI key.</p>
+        <div class="row">
+          <label for="ha-enabled">Enable Home Assistant</label>
+          <input id="ha-enabled" type="checkbox" />
+        </div>
+        <div id="ha-fields" class="hidden">
+          <label for="ha-url">Home Assistant MCP URL</label>
+          <input id="ha-url" type="text" placeholder="http://192.168.1.20:8123/api/mcp" autocomplete="off" />
+          <label for="ha-token">Home Assistant Token</label>
+          <input id="ha-token" type="password" placeholder="Long-lived access token" autocomplete="off" />
+          <p id="ha-token-note" class="muted small hidden">A token is already saved. Leave the field blank to keep it.</p>
+        </div>
+        <div class="actions">
+          <button id="save-home-assistant">Save Home Assistant</button>
+          <p id="home-assistant-status" class="status"></p>
         </div>
       </div>
 

--- a/src/reachy_mini_conversation_app/static/main.js
+++ b/src/reachy_mini_conversation_app/static/main.js
@@ -85,6 +85,27 @@ async function saveKey(key) {
   return await resp.json();
 }
 
+async function getHomeAssistantConfig() {
+  const url = new URL("/home_assistant_config", window.location.origin);
+  url.searchParams.set("_", Date.now().toString());
+  const resp = await fetchWithTimeout(url, {}, 3000);
+  if (!resp.ok) throw new Error("home_assistant_load_failed");
+  return await resp.json();
+}
+
+async function saveHomeAssistantConfig(payload) {
+  const resp = await fetch("/home_assistant_config", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const data = await resp.json().catch(() => ({}));
+  if (!resp.ok) {
+    throw new Error(data.error || "home_assistant_save_failed");
+  }
+  return data;
+}
+
 // ---------- Personalities API ----------
 async function getPersonalities() {
   const url = new URL("/personalities", window.location.origin);
@@ -190,9 +211,17 @@ async function init() {
   const formPanel = document.getElementById("form-panel");
   const configuredPanel = document.getElementById("configured");
   const personalityPanel = document.getElementById("personality-panel");
+  const homeAssistantPanel = document.getElementById("home-assistant-panel");
   const saveBtn = document.getElementById("save-btn");
   const changeKeyBtn = document.getElementById("change-key-btn");
   const input = document.getElementById("api-key");
+  const haEnabled = document.getElementById("ha-enabled");
+  const haFields = document.getElementById("ha-fields");
+  const haUrl = document.getElementById("ha-url");
+  const haToken = document.getElementById("ha-token");
+  const haTokenNote = document.getElementById("ha-token-note");
+  const haSave = document.getElementById("save-home-assistant");
+  const haStatus = document.getElementById("home-assistant-status");
 
   // Personality elements
   const pSelect = document.getElementById("personality-select");
@@ -216,6 +245,7 @@ async function init() {
   statusEl.textContent = "Checking configuration...";
   show(formPanel, false);
   show(configuredPanel, false);
+  show(homeAssistantPanel, false);
   show(personalityPanel, false);
 
   const st = (await waitForStatus()) || { has_key: false };
@@ -223,6 +253,106 @@ async function init() {
     statusEl.textContent = "";
     show(configuredPanel, true);
   }
+
+  function renderHomeAssistantFields() {
+    const enabled = !!haEnabled.checked;
+    show(haFields, enabled);
+    if (!enabled) {
+      haStatus.textContent = "Home Assistant is disabled for this instance.";
+      haStatus.className = "status";
+    }
+  }
+
+  function clearHomeAssistantErrors() {
+    haUrl.classList.remove("error");
+    haToken.classList.remove("error");
+  }
+
+  async function refreshHomeAssistantConfig() {
+    try {
+      const data = await getHomeAssistantConfig();
+      haEnabled.checked = !!data.enabled;
+      haUrl.value = data.url || "";
+      haToken.value = "";
+      show(haTokenNote, !!data.has_token);
+      renderHomeAssistantFields();
+      if (data.configured) {
+        haStatus.textContent = "Home Assistant credentials are already configured.";
+        haStatus.className = "status ok";
+      } else if (data.enabled) {
+        haStatus.textContent = "Enter a URL and token to finish enabling Home Assistant.";
+        haStatus.className = "status warn";
+      }
+      return data;
+    } catch (e) {
+      haStatus.textContent = "Failed to load Home Assistant settings.";
+      haStatus.className = "status error";
+      return { enabled: false, configured: false, has_token: false, url: "" };
+    }
+  }
+
+  haEnabled.addEventListener("change", () => {
+    clearHomeAssistantErrors();
+    renderHomeAssistantFields();
+  });
+
+  haUrl.addEventListener("input", clearHomeAssistantErrors);
+  haToken.addEventListener("input", clearHomeAssistantErrors);
+
+  haSave.addEventListener("click", async () => {
+    const enabled = !!haEnabled.checked;
+    const url = (haUrl.value || "").trim();
+    const token = (haToken.value || "").trim();
+    const hasSavedToken = !haTokenNote.classList.contains("hidden");
+
+    clearHomeAssistantErrors();
+    if (enabled) {
+      if (!url) {
+        haStatus.textContent = "Enter a Home Assistant MCP URL.";
+        haStatus.className = "status warn";
+        haUrl.classList.add("error");
+        return;
+      }
+      if (!/^https?:\/\//i.test(url)) {
+        haStatus.textContent = "Home Assistant MCP URL must start with http:// or https://.";
+        haStatus.className = "status warn";
+        haUrl.classList.add("error");
+        return;
+      }
+      if (!token && !hasSavedToken) {
+        haStatus.textContent = "Enter a Home Assistant token or keep an existing saved token.";
+        haStatus.className = "status warn";
+        haToken.classList.add("error");
+        return;
+      }
+    }
+
+    haStatus.textContent = enabled ? "Saving Home Assistant settings..." : "Disabling Home Assistant...";
+    haStatus.className = "status";
+    try {
+      const res = await saveHomeAssistantConfig({ enabled, url, token });
+      haEnabled.checked = !!res.enabled;
+      haUrl.value = res.url || url;
+      haToken.value = "";
+      show(haTokenNote, !!res.has_token);
+      renderHomeAssistantFields();
+      haStatus.textContent = res.enabled
+        ? "Home Assistant settings saved. Enable the home_assistant tool in a personality and restart to use it."
+        : "Home Assistant disabled. Saved credentials were left intact.";
+      haStatus.className = "status ok";
+    } catch (e) {
+      if (e.message === "missing_home_assistant_url") {
+        haStatus.textContent = "Enter a Home Assistant MCP URL.";
+        haUrl.classList.add("error");
+      } else if (e.message === "missing_home_assistant_token") {
+        haStatus.textContent = "Enter a Home Assistant token.";
+        haToken.classList.add("error");
+      } else {
+        haStatus.textContent = "Failed to save Home Assistant settings.";
+      }
+      haStatus.className = "status error";
+    }
+  });
 
   // Handler for "Change API key" button
   changeKeyBtn.addEventListener("click", () => {
@@ -278,11 +408,16 @@ async function init() {
   });
 
   if (!st.has_key) {
+    show(homeAssistantPanel, true);
+    await refreshHomeAssistantConfig();
     statusEl.textContent = "";
     show(formPanel, true);
     show(loading, false);
     return;
   }
+
+  show(homeAssistantPanel, true);
+  await refreshHomeAssistantConfig();
 
   // Wait until backend routes are ready before rendering personalities UI
   const list = (await waitForPersonalityData()) || { choices: [] };

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -285,6 +285,16 @@ def _initialize_tools() -> None:
 _initialize_tools()
 
 
+def reload_tools() -> None:
+    """Reload the tool registry for the currently selected profile."""
+    global ALL_TOOLS, ALL_TOOL_SPECS, _TOOLS_INITIALIZED
+
+    ALL_TOOLS = {}
+    ALL_TOOL_SPECS = []
+    _TOOLS_INITIALIZED = False
+    _initialize_tools()
+
+
 def get_tool_specs(exclusion_list: list[str] = []) -> list[Dict[str, Any]]:
     """Get tool specs, optionally excluding some tools."""
     return [spec for spec in ALL_TOOL_SPECS if spec.get("name") not in exclusion_list]

--- a/src/reachy_mini_conversation_app/tools/home_assistant.py
+++ b/src/reachy_mini_conversation_app/tools/home_assistant.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import os
 from typing import Any, Dict
 from datetime import timedelta
+from urllib.parse import urlsplit, urlunsplit
 
+import httpx
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
@@ -75,22 +77,119 @@ def _should_retry_match_failure(result: Any) -> bool:
     return False
 
 
+def _extract_result_texts(result: Any) -> list[str]:
+    """Extract text payloads from an MCP tool result."""
+    dumped = _to_jsonable(result)
+    if not isinstance(dumped, dict):
+        return []
+    content = dumped.get("content")
+    if not isinstance(content, list):
+        return []
+
+    texts: list[str] = []
+    for item in content:
+        if isinstance(item, dict) and isinstance(item.get("text"), str):
+            texts.append(item["text"])
+    return texts
+
+
+def _build_diagnostic(tool_name: str, arguments: Dict[str, Any], result: Any) -> Dict[str, Any] | None:
+    """Translate common HA match failures into actionable diagnostics."""
+    texts = _extract_result_texts(result)
+    if not texts:
+        return None
+
+    combined = "\n".join(texts)
+    if "MatchFailedReason.ASSISTANT" in combined:
+        return {
+            "type": "assistant_exposure",
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "message": "Home Assistant refused the target because it is not exposed to the Assist/MCP assistant.",
+            "hint": "Expose the target entity to your Home Assistant voice assistant / MCP integration, then try again.",
+        }
+
+    if "cannot target all devices" in combined:
+        return {
+            "type": "missing_target",
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "message": "Home Assistant rejected the call because it could not resolve a specific target device or entity.",
+            "hint": "Use a more specific device name or expose the entity so Home Assistant can match it.",
+        }
+
+    return None
+
+
+def _conversation_api_url(mcp_url: str) -> str:
+    """Derive the Home Assistant conversation API URL from the MCP endpoint URL."""
+    parts = urlsplit(mcp_url)
+    path = parts.path
+    if path.endswith("/api/mcp"):
+        path = path[: -len("/api/mcp")] + "/api/conversation/process"
+    else:
+        path = "/api/conversation/process"
+    return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
+
+
+async def _call_assist_command(url: str, token: str, command: str, language: str | None) -> Dict[str, Any]:
+    """Send a natural-language command to Home Assistant's conversation API."""
+    payload: Dict[str, Any] = {"text": command}
+    if language:
+        payload["language"] = language
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(_conversation_api_url(url), headers=headers, json=payload)
+        response.raise_for_status()
+        data = response.json()
+
+    plain = data if isinstance(data, dict) else {"raw": data}
+    response_text = None
+    try:
+        speech = plain.get("response", {}).get("speech", {})
+        plain_speech = speech.get("plain", {})
+        response_text = plain_speech.get("speech")
+    except Exception:
+        response_text = None
+
+    return {
+        "action": "assist_command",
+        "command": command,
+        "language": language,
+        "response_text": response_text,
+        "result": plain,
+    }
+
+
 class HomeAssistant(Tool):
     """Bridge Home Assistant's MCP server through a single tool."""
 
     name = "home_assistant"
     description = (
-        "Bridge to a Home Assistant MCP server. Use discover_tools first to inspect available Home Assistant "
-        "capabilities, then call_tool with the exact MCP tool name and arguments. Use get_prompt to fetch any "
-        "Home Assistant prompt guidance exposed by the MCP server."
+        "Bridge to Home Assistant. Prefer assist_command for natural-language home control requests so Home Assistant "
+        "can use its own conversation matching. Use discover_tools to inspect available MCP capabilities, call_tool "
+        "for exact MCP tool invocations, and get_prompt to fetch Home Assistant prompt guidance."
     )
     parameters_schema = {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["discover_tools", "get_prompt", "call_tool"],
+                "enum": ["assist_command", "discover_tools", "get_prompt", "call_tool"],
                 "description": "Which Home Assistant MCP action to perform.",
+            },
+            "command": {
+                "type": "string",
+                "description": "Required for assist_command. The user's natural-language Home Assistant request.",
+            },
+            "language": {
+                "type": "string",
+                "description": "Optional BCP-47 language code for assist_command, for example zh-CN or en-US.",
             },
             "tool_name": {
                 "type": "string",
@@ -127,10 +226,20 @@ class HomeAssistant(Tool):
             return {"error": "HOME_ASSISTANT_TOKEN is not configured."}
 
         action = str(kwargs.get("action") or "").strip()
+        command = str(kwargs.get("command") or "").strip()
+        language = str(kwargs.get("language") or "").strip() or None
         tool_name = str(kwargs.get("tool_name") or "").strip()
         prompt_name = str(kwargs.get("prompt_name") or "").strip()
         arguments = _extract_arguments(kwargs)
         headers = {"Authorization": f"Bearer {token}"}
+
+        if action == "assist_command":
+            if not command:
+                return {"error": "command is required for assist_command."}
+            try:
+                return await _call_assist_command(url, token, command, language)
+            except Exception as exc:
+                return {"error": f"Home Assistant assist command failed: {type(exc).__name__}: {exc}"}
 
         try:
             async with streamablehttp_client(
@@ -182,6 +291,7 @@ class HomeAssistant(Tool):
                             "tool_name": tool_name,
                             "arguments": arguments,
                             "result": _to_jsonable(result),
+                            "diagnostic": _build_diagnostic(tool_name, arguments, result),
                         }
 
                     return {"error": f"Unsupported action: {action}"}

--- a/src/reachy_mini_conversation_app/tools/home_assistant.py
+++ b/src/reachy_mini_conversation_app/tools/home_assistant.py
@@ -11,6 +11,10 @@ from mcp.client.streamable_http import streamablehttp_client
 from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
 
 
+CONTROL_FIELDS = {"action", "tool_name", "prompt_name", "arguments", "input_schema"}
+TARGET_MATCH_TOOLS = {"HassTurnOn", "HassTurnOff", "HassToggle"}
+
+
 def _to_jsonable(value: Any) -> Any:
     """Convert SDK objects to plain JSON-like data."""
     if hasattr(value, "model_dump"):
@@ -20,6 +24,55 @@ def _to_jsonable(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [_to_jsonable(item) for item in value]
     return value
+
+
+def _extract_arguments(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Accept a few argument aliases emitted by the model and UI."""
+    for key in ("arguments", "input_schema"):
+        candidate = kwargs.get(key)
+        if isinstance(candidate, dict):
+            return candidate
+
+    passthrough = {key: value for key, value in kwargs.items() if key not in CONTROL_FIELDS}
+    return passthrough if passthrough else {}
+
+
+def _build_retry_arguments(tool_name: str, arguments: Dict[str, Any]) -> list[Dict[str, Any]]:
+    """Build language-agnostic fallback argument sets for HA target matching."""
+    if tool_name not in TARGET_MATCH_TOOLS:
+        return []
+
+    retries: list[Dict[str, Any]] = []
+    if isinstance(arguments.get("name"), str):
+        for redundant_field in ("area_name", "floor_name"):
+            if redundant_field in arguments:
+                updated = dict(arguments)
+                updated.pop(redundant_field, None)
+                if updated != arguments and updated not in retries:
+                    retries.append(updated)
+
+    return retries
+
+
+def _should_retry_match_failure(result: Any) -> bool:
+    """Return whether a tool result looks like a recoverable HA target-match failure."""
+    dumped = _to_jsonable(result)
+    if not isinstance(dumped, dict) or not dumped.get("isError"):
+        return False
+
+    content = dumped.get("content")
+    if not isinstance(content, list):
+        return False
+
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if not isinstance(text, str):
+            continue
+        if "MatchFailedError" in text or "cannot target all devices" in text:
+            return True
+    return False
 
 
 class HomeAssistant(Tool):
@@ -76,8 +129,7 @@ class HomeAssistant(Tool):
         action = str(kwargs.get("action") or "").strip()
         tool_name = str(kwargs.get("tool_name") or "").strip()
         prompt_name = str(kwargs.get("prompt_name") or "").strip()
-        raw_arguments = kwargs.get("arguments") or {}
-        arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
+        arguments = _extract_arguments(kwargs)
         headers = {"Authorization": f"Bearer {token}"}
 
         try:
@@ -119,9 +171,16 @@ class HomeAssistant(Tool):
                         if not tool_name:
                             return {"error": "tool_name is required for call_tool."}
                         result = await session.call_tool(tool_name, arguments=arguments or None)
+                        if _should_retry_match_failure(result):
+                            for candidate_arguments in _build_retry_arguments(tool_name, arguments):
+                                result = await session.call_tool(tool_name, arguments=candidate_arguments or None)
+                                arguments = candidate_arguments
+                                if not _should_retry_match_failure(result):
+                                    break
                         return {
                             "action": action,
                             "tool_name": tool_name,
+                            "arguments": arguments,
                             "result": _to_jsonable(result),
                         }
 

--- a/src/reachy_mini_conversation_app/tools/home_assistant.py
+++ b/src/reachy_mini_conversation_app/tools/home_assistant.py
@@ -1,0 +1,130 @@
+"""Home Assistant MCP bridge tool."""
+
+from __future__ import annotations
+import os
+from typing import Any, Dict
+from datetime import timedelta
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Convert SDK objects to plain JSON-like data."""
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {key: _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    return value
+
+
+class HomeAssistant(Tool):
+    """Bridge Home Assistant's MCP server through a single tool."""
+
+    name = "home_assistant"
+    description = (
+        "Bridge to a Home Assistant MCP server. Use discover_tools first to inspect available Home Assistant "
+        "capabilities, then call_tool with the exact MCP tool name and arguments. Use get_prompt to fetch any "
+        "Home Assistant prompt guidance exposed by the MCP server."
+    )
+    parameters_schema = {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["discover_tools", "get_prompt", "call_tool"],
+                "description": "Which Home Assistant MCP action to perform.",
+            },
+            "tool_name": {
+                "type": "string",
+                "description": "Required for call_tool. Exact MCP tool name returned by discover_tools.",
+            },
+            "arguments": {
+                "type": "object",
+                "description": "Arguments for call_tool or get_prompt.",
+                "additionalProperties": True,
+            },
+            "prompt_name": {
+                "type": "string",
+                "description": "Required for get_prompt. Exact MCP prompt name.",
+            },
+        },
+        "required": ["action"],
+        "additionalProperties": False,
+    }
+
+    async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> Dict[str, Any]:
+        """Dispatch to the configured Home Assistant MCP server."""
+        del deps
+
+        enabled = os.getenv("HOME_ASSISTANT_ENABLED", "0").strip().lower() in {"1", "true", "yes", "on"}
+        url = os.getenv("HOME_ASSISTANT_MCP_URL", "").strip()
+        token = os.getenv("HOME_ASSISTANT_TOKEN", "").strip()
+        if not enabled:
+            return {
+                "error": "Home Assistant is disabled. Enable it from the Credentials page first.",
+            }
+        if not url:
+            return {"error": "HOME_ASSISTANT_MCP_URL is not configured."}
+        if not token:
+            return {"error": "HOME_ASSISTANT_TOKEN is not configured."}
+
+        action = str(kwargs.get("action") or "").strip()
+        tool_name = str(kwargs.get("tool_name") or "").strip()
+        prompt_name = str(kwargs.get("prompt_name") or "").strip()
+        raw_arguments = kwargs.get("arguments") or {}
+        arguments = raw_arguments if isinstance(raw_arguments, dict) else {}
+        headers = {"Authorization": f"Bearer {token}"}
+
+        try:
+            async with streamablehttp_client(
+                url,
+                headers=headers,
+                timeout=timedelta(seconds=30),
+                sse_read_timeout=timedelta(seconds=300),
+            ) as (read_stream, write_stream, _):
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+
+                    if action == "discover_tools":
+                        result = await session.list_tools()
+                        tools = []
+                        for tool in getattr(result, "tools", []):
+                            tools.append(
+                                {
+                                    "name": getattr(tool, "name", ""),
+                                    "description": getattr(tool, "description", ""),
+                                    "input_schema": _to_jsonable(getattr(tool, "inputSchema", {})),
+                                }
+                            )
+                        return {
+                            "action": action,
+                            "available_tools": tools,
+                        }
+
+                    if action == "get_prompt":
+                        if not prompt_name:
+                            return {"error": "prompt_name is required for get_prompt."}
+                        result = await session.get_prompt(prompt_name, arguments=arguments or None)
+                        return {
+                            "action": action,
+                            "prompt": _to_jsonable(result),
+                        }
+
+                    if action == "call_tool":
+                        if not tool_name:
+                            return {"error": "tool_name is required for call_tool."}
+                        result = await session.call_tool(tool_name, arguments=arguments or None)
+                        return {
+                            "action": action,
+                            "tool_name": tool_name,
+                            "result": _to_jsonable(result),
+                        }
+
+                    return {"error": f"Unsupported action: {action}"}
+        except Exception as exc:
+            return {"error": f"Home Assistant MCP request failed: {type(exc).__name__}: {exc}"}

--- a/src/reachy_mini_conversation_app/tools/home_assistant.py
+++ b/src/reachy_mini_conversation_app/tools/home_assistant.py
@@ -252,9 +252,9 @@ class HomeAssistant(Tool):
                     await session.initialize()
 
                     if action == "discover_tools":
-                        result = await session.list_tools()
+                        tools_result = await session.list_tools()
                         tools = []
-                        for tool in getattr(result, "tools", []):
+                        for tool in getattr(tools_result, "tools", []):
                             tools.append(
                                 {
                                     "name": getattr(tool, "name", ""),
@@ -270,28 +270,28 @@ class HomeAssistant(Tool):
                     if action == "get_prompt":
                         if not prompt_name:
                             return {"error": "prompt_name is required for get_prompt."}
-                        result = await session.get_prompt(prompt_name, arguments=arguments or None)
+                        prompt_result = await session.get_prompt(prompt_name, arguments=arguments or None)
                         return {
                             "action": action,
-                            "prompt": _to_jsonable(result),
+                            "prompt": _to_jsonable(prompt_result),
                         }
 
                     if action == "call_tool":
                         if not tool_name:
                             return {"error": "tool_name is required for call_tool."}
-                        result = await session.call_tool(tool_name, arguments=arguments or None)
-                        if _should_retry_match_failure(result):
+                        tool_result = await session.call_tool(tool_name, arguments=arguments or None)
+                        if _should_retry_match_failure(tool_result):
                             for candidate_arguments in _build_retry_arguments(tool_name, arguments):
-                                result = await session.call_tool(tool_name, arguments=candidate_arguments or None)
+                                tool_result = await session.call_tool(tool_name, arguments=candidate_arguments or None)
                                 arguments = candidate_arguments
-                                if not _should_retry_match_failure(result):
+                                if not _should_retry_match_failure(tool_result):
                                     break
                         return {
                             "action": action,
                             "tool_name": tool_name,
                             "arguments": arguments,
-                            "result": _to_jsonable(result),
-                            "diagnostic": _build_diagnostic(tool_name, arguments, result),
+                            "result": _to_jsonable(tool_result),
+                            "diagnostic": _build_diagnostic(tool_name, arguments, tool_result),
                         }
 
                     return {"error": f"Unsupported action: {action}"}


### PR DESCRIPTION
## Summary
- add a built-in home_assistant MCP bridge tool with a small Assist fallback for natural-language commands
- add headless settings fields to save the Home Assistant MCP URL and token without overwriting the OpenAI key
- reload tools when the active profile changes so profile-specific tools are registered correctly

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] .env.example updated (if new config vars were added)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [x] Headless mode (default)
- [ ] Gradio UI (--gradio)
- [ ] Simulation (--gradio required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (--local-vision)
- [ ] Head tracker (--head-tracker {yolo,mediapipe})
- [ ] Camera pipeline (with/without --no-camera)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [x] Profiles or custom tools
</details>

## Notes
- Closes #288.
- uff passes locally.
- A previous CI run failed on mypy; that specific type issue in home_assistant.py has been fixed in commit 92bef7d.
- This PR adds a built-in integration rather than an external tool because it also adds first-class headless credentials UI and profile-aware tool loading.