### PR TITLE
Force logging config when running with --debug

### DIFF
--- a/src/reachy_mini_conversation_app/utils.py
+++ b/src/reachy_mini_conversation_app/utils.py
@@ -106,6 +106,7 @@ def setup_logger(debug: bool) -> logging.Logger:
     logging.basicConfig(
         level=getattr(logging, log_level, logging.INFO),
         format="%(asctime)s %(levelname)s %(name)s:%(lineno)d | %(message)s",
+        force=True,
     )
     logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
Logging is not being printed out even when passing `--debug`, so this forces the conversation app logging config to be applied.