### PR TITLE
Pin github actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
       - "src/**"
       - "tests/**"
       - "pyproject.toml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +20,15 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Ruff check
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
         with:
           version: "0.12.0"
+
+      - name: Ruff format
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
+        with:
+          version: "0.12.0"
+          args: "format --check"

--- a/.github/workflows/pr-hf-space-preview.yml
+++ b/.github/workflows/pr-hf-space-preview.yml
@@ -37,7 +37,7 @@ jobs:
           echo "space_url=https://huggingface.co/spaces/${HF_SPACE_NAMESPACE}/${HF_SPACE_BASE_NAME}_PR${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout pull request branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -46,7 +46,7 @@ jobs:
       - name: Sync preview space
         id: sync
         continue-on-error: true
-        uses: huggingface/hub-sync@v0.1.0
+        uses: huggingface/hub-sync@6fbce0a787a7146710e588abe7a4fd5eca07f47c  # v0.1.0
         with:
           github_repo_id: ${{ github.repository }}
           huggingface_repo_id: ${{ steps.preview.outputs.space_id }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Create or update preview comment
         if: steps.sync.outcome == 'success'
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           HF_PREVIEW_COMMENT_MARKER: ${{ env.HF_PREVIEW_COMMENT_MARKER }}
           HF_SPACE_URL: ${{ steps.preview.outputs.space_url }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Comment sync failure
         if: steps.sync.outcome == 'failure'
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           HF_PREVIEW_COMMENT_MARKER: ${{ env.HF_PREVIEW_COMMENT_MARKER }}
         with:
@@ -171,7 +171,7 @@ jobs:
           echo "space_id=${HF_SPACE_NAMESPACE}/${HF_SPACE_BASE_NAME}_PR${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: Delete preview space
         env:
@@ -180,7 +180,7 @@ jobs:
         run: uvx hf repos delete "${HF_SPACE_ID}" --repo-type space --missing-ok
 
       - name: Update comment to reflect deletion
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           HF_PREVIEW_COMMENT_MARKER: ${{ env.HF_PREVIEW_COMMENT_MARKER }}
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,7 @@ jobs:
       # System deps (platform-specific)
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
         with:
           packages: libcairo2-dev libgirepository1.0-dev
           version: 1.0
@@ -61,13 +61,13 @@ jobs:
           echo "No extra system packages required (using wheel-bundled libs)"
 
       # Checkout & toolchain
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       # HF cache
       - name: Set HF_HOME
@@ -77,7 +77,7 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/.hf"
 
       - name: Cache Hugging Face hub
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ${{ runner.temp }}/.hf
           key: hf-${{ runner.os }}-${{ hashFiles('uv.lock', 'pyproject.toml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -27,6 +27,6 @@ jobs:
         run: git fetch --tags --force
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           generate_release_notes: true

--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true
       - name: Sync GitHub to Hugging Face Hub
-        uses: huggingface/hub-sync@v0.1.0
+        uses: huggingface/hub-sync@6fbce0a787a7146710e588abe7a4fd5eca07f47c  # v0.1.0
         with:
           github_repo_id: pollen-robotics/reachy_mini_conversation_app
           huggingface_repo_id: pollen-robotics/reachy_mini_conversation_app

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -32,10 +32,10 @@ jobs:
           packages: libcairo2-dev libgirepository1.0-dev
           version: 1.0
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -10,7 +10,7 @@ jobs:
   uv-lock-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: hbelmiro/uv-lock-check@v0.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d  # v0.2.0
         with:
           command: "uv lock --check"


### PR DESCRIPTION
Pins all GitHub actions to full commit SHAs instead of version tags. Original version numbers are preserved as comments next to each SHA for readability and easier future upgrades.

## Summary
<!-- What does this PR change and why? -->

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>