### PR TITLE
fix: make HF preview space deletion non-interactive

### DIFF
--- a/.github/workflows/pr-hf-space-preview.yml
+++ b/.github/workflows/pr-hf-space-preview.yml
@@ -177,7 +177,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: ${{ steps.preview.outputs.space_id }}
-        run: uvx hf repos delete "${HF_SPACE_ID}" --repo-type space --missing-ok
+        run: uvx hf repos delete "${HF_SPACE_ID}" --repo-type space --missing-ok --yes
 
       - name: Update comment to reflect deletion
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary
Add `--yes` to the Hugging Face preview Space deletion step so the GitHub actions cleanup job can remove PR preview spaces without hanging on a confirmation prompt.


## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
