### PR TITLE
Apply ruff format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ uv run pytest tests/ -v --cov  # With coverage
 
 ### All at Once
 ```bash
-uv run mypy --pretty --show-error-codes && uv run ruff check . --fix && uv run pytest tests/ -v
+uv run ruff check . --fix && uv run ruff format . && uv run mypy --pretty --show-error-codes && uv run pytest tests/ -v
 ```
 
 </details>

--- a/profiles/example/sweep_look.py
+++ b/profiles/example/sweep_look.py
@@ -15,7 +15,9 @@ class SweepLook(Tool):
     """Sweep head from left to right and back to center, pausing at each position."""
 
     name = "sweep_look"
-    description = "Sweep head from left to right while rotating the body, pausing at each extreme, then return to center"
+    description = (
+        "Sweep head from left to right while rotating the body, pausing at each extreme, then return to center"
+    )
     parameters_schema = {
         "type": "object",
         "properties": {},

--- a/src/reachy_mini_conversation_app/audio/head_wobbler.py
+++ b/src/reachy_mini_conversation_app/audio/head_wobbler.py
@@ -83,7 +83,9 @@ class HeadWobbler:
         while not self._stop_event.is_set():
             queue_ref = self.audio_queue
             try:
-                chunk_generation, sr, chunk, start_delay_s = queue_ref.get(timeout=hop_dt)  # (gen, sr, data, start_delay)
+                chunk_generation, sr, chunk, start_delay_s = queue_ref.get(
+                    timeout=hop_dt
+                )  # (gen, sr, data, start_delay)
             except queue.Empty:
                 if self._should_reset_after_audio(hop_dt):
                     self.reset()

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -383,9 +383,7 @@ class LocalStream:
             payload_data = _status_payload()
             message = "Backend saved."
             if payload_data["requires_restart"]:
-                message = (
-                    "Backend saved. Restart Reachy Mini Conversation from the desktop app to apply it."
-                    )
+                message = "Backend saved. Restart Reachy Mini Conversation from the desktop app to apply it."
             return JSONResponse(
                 {
                     "ok": True,

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -441,9 +441,7 @@ class GeminiLiveHandler(AsyncStreamHandler):
                         image_bytes = base64.b64decode(b64_im)
                     else:
                         image_bytes = bytes(b64_im)
-                    await self.session.send_realtime_input(
-                        video=types.Blob(data=image_bytes, mime_type="image/jpeg")
-                    )
+                    await self.session.send_realtime_input(video=types.Blob(data=image_bytes, mime_type="image/jpeg"))
                     logger.info("Pushed camera snapshot to Gemini via realtime video input")
                 except Exception as ve:
                     logger.warning("Failed to push camera snapshot to Gemini: %s", ve)

--- a/src/reachy_mini_conversation_app/gradio_personality.py
+++ b/src/reachy_mini_conversation_app/gradio_personality.py
@@ -121,7 +121,9 @@ class PersonalityUI:
             interactive=not is_locked,
         )
         self.new_personality_btn = gr.Button("New personality", interactive=not is_locked)
-        self.available_tools_cg = gr.CheckboxGroup(label="Available tools (helper)", choices=[], value=[], interactive=not is_locked)
+        self.available_tools_cg = gr.CheckboxGroup(
+            label="Available tools (helper)", choices=[], value=[], interactive=not is_locked
+        )
         self.save_btn = gr.Button("Save personality (instructions + tools)", interactive=not is_locked)
 
     def additional_inputs_ordered(self) -> list[Any]:

--- a/src/reachy_mini_conversation_app/moves.py
+++ b/src/reachy_mini_conversation_app/moves.py
@@ -105,7 +105,9 @@ class BreathingMove(Move):  # type: ignore
 
             # Interpolate head pose
             head_pose = linear_pose_interpolation(
-                self.interpolation_start_pose, self.neutral_head_pose, interpolation_t,
+                self.interpolation_start_pose,
+                self.neutral_head_pose,
+                interpolation_t,
             )
 
             # Interpolate antennas
@@ -640,7 +642,9 @@ class MovementManager:
 
         return antennas_cmd
 
-    def _issue_control_command(self, head: NDArray[np.float32], antennas: Tuple[float, float], body_yaw: float) -> None:
+    def _issue_control_command(
+        self, head: NDArray[np.float32], antennas: Tuple[float, float], body_yaw: float
+    ) -> None:
         """Send the fused pose to the robot with throttled error logging."""
         try:
             self.current_robot.set_target(head=head, antennas=antennas, body_yaw=body_yaw)
@@ -660,7 +664,10 @@ class MovementManager:
                 self._last_commanded_pose = clone_full_body_pose((head, antennas, body_yaw))
 
     def _update_frequency_stats(
-        self, loop_start: float, prev_loop_start: float, stats: LoopFrequencyStats,
+        self,
+        loop_start: float,
+        prev_loop_start: float,
+        stats: LoopFrequencyStats,
     ) -> LoopFrequencyStats:
         """Update frequency statistics based on the current loop start time."""
         period = loop_start - prev_loop_start

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -56,7 +56,6 @@ IMAGE_INPUT_COST_PER_1M = 5.0
 _RESPONSE_DONE_TIMEOUT: Final[float] = 30.0
 
 
-
 class InputTranscriptChunksByItem(BaseModel):
     """Current item_id and its accumulated deltas. Only one item at a time."""
 
@@ -386,7 +385,8 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             tool_result = bg_tool.result
             logger.info(
                 "Tool '%s' (id=%s) executed successfully.",
-                bg_tool.tool_name, bg_tool.id,
+                bg_tool.tool_name,
+                bg_tool.id,
             )
             logger.debug("Tool '%s' full result: %s", bg_tool.tool_name, tool_result)
         else:
@@ -395,7 +395,11 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
         # Connection may have closed while tool was running
         if not self.connection:
-            logger.warning("Connection closed during tool '%s' (id=%s) execution; cannot send result back", bg_tool.tool_name, bg_tool.id)
+            logger.warning(
+                "Connection closed during tool '%s' (id=%s) execution; cannot send result back",
+                bg_tool.tool_name,
+                bg_tool.id,
+            )
             return
 
         try:
@@ -492,7 +496,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             voice=self._voice_override or get_session_voice(),
                         ),
                     ),
-                    tools=get_tool_specs(), # type: ignore[typeddict-item]
+                    tools=get_tool_specs(),  # type: ignore[typeddict-item]
                     tool_choice="auto",
                 )
                 await conn.session.update(session=session_config)
@@ -520,16 +524,13 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             except Exception:
                 pass
 
-
             response_sender_task: asyncio.Task[None] | None = None
             try:
                 # Start the background tool manager
                 self.tool_manager.start_up(tool_callbacks=[self._handle_tool_result])
 
                 # Start the response sender worker
-                response_sender_task = asyncio.create_task(
-                    self._response_sender_loop(), name="response-sender"
-                )
+                response_sender_task = asyncio.create_task(self._response_sender_loop(), name="response-sender")
 
                 async for event in self.connection:
                     logger.debug(f"OpenAI event: {event.type}")
@@ -613,7 +614,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     # Handle assistant transcription
                     if event.type == "response.output_audio_transcript.done":
                         logger.debug(f"Assistant transcript: {event.transcript}")
-                        await self.output_queue.put(AdditionalOutputs({"role": "assistant", "content": event.transcript}))
+                        await self.output_queue.put(
+                            AdditionalOutputs({"role": "assistant", "content": event.transcript})
+                        )
 
                     # Handle audio delta
                     if event.type == "response.output_audio.delta":
@@ -636,14 +639,19 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
                         logger.info(
                             "Tool call received — tool_name=%r, call_id=%s, is_idle=%s, args=%s",
-                            tool_name, call_id, self.is_idle_tool_call, args_json_str,
+                            tool_name,
+                            call_id,
+                            self.is_idle_tool_call,
+                            args_json_str,
                         )
 
                         if not isinstance(tool_name, str) or not isinstance(args_json_str, str):
                             logger.error(
                                 "Invalid tool call: tool_name=%s (type=%s), args=%s (type=%s), call_id=%s",
-                                tool_name, type(tool_name).__name__,
-                                args_json_str, type(args_json_str).__name__,
+                                tool_name,
+                                type(tool_name).__name__,
+                                args_json_str,
+                                type(args_json_str).__name__,
                                 call_id,
                             )
                             continue
@@ -670,7 +678,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                         if self.is_idle_tool_call:
                             self.is_idle_tool_call = False
 
-                        logger.info("Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id)
+                        logger.info(
+                            "Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id
+                        )
 
                     # server error
                     if event.type == "error":

--- a/src/reachy_mini_conversation_app/prompts.py
+++ b/src/reachy_mini_conversation_app/prompts.py
@@ -27,9 +27,9 @@ def _expand_prompt_includes(content: str) -> str:
     # Pattern to match [<name>] where name is a valid file stem (alphanumeric, underscores, hyphens)
     # pattern = re.compile(r'^\[([a-zA-Z0-9_-]+)\]$')
     # Allow slashes for subdirectories
-    pattern = re.compile(r'^\[([a-zA-Z0-9/_-]+)\]$')
+    pattern = re.compile(r"^\[([a-zA-Z0-9/_-]+)\]$")
 
-    lines = content.split('\n')
+    lines = content.split("\n")
     expanded_lines = []
 
     for line in lines:
@@ -55,7 +55,7 @@ def _expand_prompt_includes(content: str) -> str:
         else:
             expanded_lines.append(line)
 
-    return '\n'.join(expanded_lines)
+    return "\n".join(expanded_lines)
 
 
 def get_session_instructions() -> str:

--- a/src/reachy_mini_conversation_app/tools/background_tool_manager.py
+++ b/src/reachy_mini_conversation_app/tools/background_tool_manager.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 _SYSTEM_TOOL_NAMES: set[str] = {t.value for t in SystemTool}
 
+
 class ToolProgress(BaseModel):
     """Progress of a background tool."""
 
@@ -53,7 +54,9 @@ class ToolCallRoutine(BaseModel):
         """Execute the stored callable with its arguments."""
         if self.tool_name in _SYSTEM_TOOL_NAMES:
             # For safety purposes, we only allow system tools to be called with the tool manager
-            return await dispatch_tool_call_with_manager(tool_name=self.tool_name, args_json=self.args_json_str, deps=self.deps, tool_manager=tool_manager)
+            return await dispatch_tool_call_with_manager(
+                tool_name=self.tool_name, args_json=self.args_json_str, deps=self.deps, tool_manager=tool_manager
+            )
         return await dispatch_tool_call(tool_name=self.tool_name, args_json=self.args_json_str, deps=self.deps)
 
 
@@ -157,7 +160,6 @@ class BackgroundToolManager(BaseModel):
             except RuntimeError:
                 self._loop = asyncio.new_event_loop()
         logger.debug("BackgroundToolManager: event loop set")
-
 
     async def start_tool(
         self,
@@ -319,7 +321,8 @@ class BackgroundToolManager(BaseModel):
             "BackgroundToolManager started. "
             "Max tool execution duration: %s seconds (tools running longer will be auto-cancelled). "
             "Max tool memory retention: %s seconds (completed/failed/cancelled tools older than this are purged).",
-            self._max_tool_duration_seconds, self._max_tool_memory_seconds,
+            self._max_tool_duration_seconds,
+            self._max_tool_memory_seconds,
         )
 
     async def shutdown(self) -> None:

--- a/src/reachy_mini_conversation_app/tools/camera.py
+++ b/src/reachy_mini_conversation_app/tools/camera.py
@@ -46,7 +46,9 @@ class Camera(Tool):
 
         if deps.vision_processor is not None:
             vision_result = await asyncio.to_thread(
-                deps.vision_processor.process_image, frame, question,
+                deps.vision_processor.process_image,
+                frame,
+                question,
             )
             return (
                 {"image_description": vision_result}

--- a/src/reachy_mini_conversation_app/tools/task_status.py
+++ b/src/reachy_mini_conversation_app/tools/task_status.py
@@ -79,7 +79,9 @@ class TaskStatus(Tool):
             }
 
         tools_info = []
-        for tool in [tool for tool in running if tool.tool_name not in [system_tool.value for system_tool in SystemTool]]:
+        for tool in [
+            tool for tool in running if tool.tool_name not in [system_tool.value for system_tool in SystemTool]
+        ]:
             elapsed = time.monotonic() - tool.started_at
             tool_info: Dict[str, Any] = {
                 "tool_id": tool.tool_id,

--- a/src/reachy_mini_conversation_app/vision/head_tracking/yolo_process.py
+++ b/src/reachy_mini_conversation_app/vision/head_tracking/yolo_process.py
@@ -148,9 +148,7 @@ class YoloHeadTrackerProcess:
         project_src = Path(next(iter(package_locations))).resolve().parent
         existing_pythonpath = env.get("PYTHONPATH")
         env["PYTHONPATH"] = (
-            str(project_src)
-            if not existing_pythonpath
-            else f"{project_src}{os.pathsep}{existing_pythonpath}"
+            str(project_src) if not existing_pythonpath else f"{project_src}{os.pathsep}{existing_pythonpath}"
         )
         env["PYTHONUNBUFFERED"] = "1"
 

--- a/src/reachy_mini_conversation_app/vision/local_vision.py
+++ b/src/reachy_mini_conversation_app/vision/local_vision.py
@@ -149,11 +149,7 @@ class VisionProcessor:
 
             except Exception as e:
                 oom_error = getattr(getattr(torch, "cuda", None), "OutOfMemoryError", None)
-                if (
-                    isinstance(oom_error, type)
-                    and issubclass(oom_error, BaseException)
-                    and isinstance(e, oom_error)
-                ):
+                if isinstance(oom_error, type) and issubclass(oom_error, BaseException) and isinstance(e, oom_error):
                     logger.error(f"CUDA OOM on attempt {attempt + 1}: {e}")
                     if self.device == "cuda":
                         torch.cuda.empty_cache()

--- a/tests/test_config_name_collisions.py
+++ b/tests/test_config_name_collisions.py
@@ -5,9 +5,7 @@ import pytest
 import reachy_mini_conversation_app.config as config_mod
 
 
-def test_config_raises_on_external_profile_name_collision(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_config_raises_on_external_profile_name_collision(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Config should fail fast when external/built-in profile names collide."""
     external_profiles = tmp_path / "external_profiles"
     external_profiles.mkdir(parents=True)
@@ -35,9 +33,7 @@ def test_config_raises_on_external_profile_name_collision_with_builtin_alias(
         config_mod.Config()
 
 
-def test_config_raises_on_external_tool_name_collision(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_config_raises_on_external_tool_name_collision(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Config should fail fast when external/built-in tool names collide."""
     external_tools = tmp_path / "external_tools"
     external_tools.mkdir(parents=True)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -169,6 +169,7 @@ def test_backend_config_persists_gemini_selection_and_status(
     assert "MODEL_NAME=gemini-3.1-flash-live-preview" in env_text
     assert "GEMINI_API_KEY=gem-test-token" in env_text
 
+
 def test_backend_config_preserves_explicit_model_override_when_saving_key(
     tmp_path,
     monkeypatch,

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -88,9 +88,7 @@ class _FakeConnectContext:
 
 class _FakeLiveClient:
     def __init__(self, session: _FakeSession):
-        self.aio = SimpleNamespace(
-            live=SimpleNamespace(connect=lambda **_kwargs: _FakeConnectContext(session))
-        )
+        self.aio = SimpleNamespace(live=SimpleNamespace(connect=lambda **_kwargs: _FakeConnectContext(session)))
 
 
 @pytest.mark.asyncio
@@ -151,7 +149,9 @@ async def test_gemini_turn_buffers_transcripts_and_schedules_motion_reset(monkey
     handler.client = _FakeLiveClient(session)
 
     task = asyncio.create_task(handler._run_live_session())
-    await _wait_for(lambda: head_wobbler.request_reset_after_current_audio.called and handler.output_queue.qsize() >= 3)
+    await _wait_for(
+        lambda: head_wobbler.request_reset_after_current_audio.called and handler.output_queue.qsize() >= 3
+    )
 
     handler._stop_event.set()
     await asyncio.wait_for(task, timeout=1.0)

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -29,9 +29,7 @@ async def test_tool_completion_does_not_reset_head_wobbler(monkeypatch: Any) -> 
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
     monkeypatch.setattr(rt_mod, "get_tool_specs", lambda: [])
 
-    async def _fake_dispatch(
-        tool_name: str, args_json: str, deps: Any, **_kw: Any
-    ) -> dict[str, Any]:
+    async def _fake_dispatch(tool_name: str, args_json: str, deps: Any, **_kw: Any) -> dict[str, Any]:
         return {"image_description": "A person in front of a door.", "tool": tool_name}
 
     monkeypatch.setattr(btm_mod, "dispatch_tool_call", _fake_dispatch)
@@ -343,6 +341,7 @@ def test_format_timestamp_uses_wall_clock() -> None:
     year = int(formatted[1:5])
     assert year == datetime.now(timezone.utc).year
 
+
 @pytest.mark.asyncio
 async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -> None:
     """First connection dies with ConnectionClosedError during iteration -> retried.
@@ -358,7 +357,10 @@ async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -
 
     # Make asyncio.sleep return immediately (for backoff)
     _real_sleep = asyncio.sleep
-    async def _mock_sleep(*_a: Any, **_kw: Any) -> None: await _real_sleep(0)
+
+    async def _mock_sleep(*_a: Any, **_kw: Any) -> None:
+        await _real_sleep(0)
+
     monkeypatch.setattr(asyncio, "sleep", _mock_sleep, raising=False)
 
     attempt_counter = {"n": 0}
@@ -370,31 +372,48 @@ async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -
             self._mode = mode
 
             class _Session:
-                async def update(self, **_kw: Any) -> None: return None
+                async def update(self, **_kw: Any) -> None:
+                    return None
+
             self.session = _Session()
 
             class _InputAudioBuffer:
-                async def append(self, **_kw: Any) -> None: return None
+                async def append(self, **_kw: Any) -> None:
+                    return None
+
             self.input_audio_buffer = _InputAudioBuffer()
 
             class _Item:
-                async def create(self, **_kw: Any) -> None: return None
+                async def create(self, **_kw: Any) -> None:
+                    return None
 
             class _Conversation:
                 item = _Item()
+
             self.conversation = _Conversation()
 
             class _Response:
-                async def create(self, **_kw: Any) -> None: return None
-                async def cancel(self, **_kw: Any) -> None: return None
+                async def create(self, **_kw: Any) -> None:
+                    return None
+
+                async def cancel(self, **_kw: Any) -> None:
+                    return None
+
             self.response = _Response()
 
-        async def __aenter__(self) -> "FakeConn": return self
-        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool: return False
-        async def close(self) -> None: return None
+        async def __aenter__(self) -> "FakeConn":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+            return False
+
+        async def close(self) -> None:
+            return None
 
         # Async iterator protocol
-        def __aiter__(self) -> "FakeConn": return self
+        def __aiter__(self) -> "FakeConn":
+            return self
+
         async def __anext__(self) -> None:
             if self._mode == "raise_on_iter":
                 raise FakeCCE("abrupt close (simulated)")
@@ -407,7 +426,8 @@ async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -
             return FakeConn(mode)
 
     class FakeClient:
-        def __init__(self, **_kw: Any) -> None: self.realtime = FakeRealtime()
+        def __init__(self, **_kw: Any) -> None:
+            self.realtime = FakeRealtime()
 
     # Patch the OpenAI client used by the handler
     monkeypatch.setattr(rt_mod, "AsyncOpenAI", FakeClient)
@@ -426,6 +446,7 @@ async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -
     # Optional: confirm we logged the unexpected close once
     warnings = [r for r in caplog.records if r.levelname == "WARNING" and "closed unexpectedly" in r.msg]
     assert len(warnings) == 1
+
 
 # ---- Cost calculation tests ----
 
@@ -575,9 +596,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
                     )
                 )
                 await asyncio.sleep(0)
-                await event_queue.put(
-                    FakeEvent("response.done", response=MagicMock())
-                )
+                await event_queue.put(FakeEvent("response.done", response=MagicMock()))
                 return
 
             # Intentional rejections (simulating a race where another
@@ -600,10 +619,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
             else:
                 await event_queue.put(FakeEvent("response.created"))
 
-            await event_queue.put(
-                FakeEvent("response.done", response=MagicMock())
-            )
-
+            await event_queue.put(FakeEvent("response.done", response=MagicMock()))
 
         async def cancel(self, **_kw: Any) -> None:
             pass
@@ -660,9 +676,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
     monkeypatch.setattr(rt_mod, "AsyncOpenAI", FakeClient)
 
     # Patch dispatch_tool_call so tools complete with a result.
-    async def _fake_dispatch(
-        tool_name: str, args_json: str, deps: Any, **_kw: Any
-    ) -> dict[str, Any]:
+    async def _fake_dispatch(tool_name: str, args_json: str, deps: Any, **_kw: Any) -> dict[str, Any]:
         await asyncio.sleep(random.uniform(0.3, 0.5))
         return {"ok": True, "tool": tool_name}
 
@@ -701,7 +715,6 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
 
     await handler.shutdown()
 
-
     # ---- Assertions ----
 
     # Serialization: every response.create() must have been called only when
@@ -721,23 +734,15 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
 
     # The error event handler must have set _last_response_rejected for each
     # rejection (the log message comes from the event handler code path).
-    rejection_logs = [
-        r for r in caplog.records
-        if "worker will retry" in getattr(r, "msg", "")
-    ]
+    rejection_logs = [r for r in caplog.records if "worker will retry" in getattr(r, "msg", "")]
     assert len(rejection_logs) == len(REJECT_CALL_NUMBERS), (
-        f"Expected {len(REJECT_CALL_NUMBERS)} rejection entries from error handler, "
-        f"got {len(rejection_logs)}"
+        f"Expected {len(REJECT_CALL_NUMBERS)} rejection entries from error handler, got {len(rejection_logs)}"
     )
 
     # The sender loop must have retried after each rejection.
-    retry_logs = [
-        r for r in caplog.records
-        if "response.create was rejected; retrying" in getattr(r, "msg", "")
-    ]
+    retry_logs = [r for r in caplog.records if "response.create was rejected; retrying" in getattr(r, "msg", "")]
     assert len(retry_logs) == len(REJECT_CALL_NUMBERS), (
-        f"Expected {len(REJECT_CALL_NUMBERS)} retry entries from sender loop, "
-        f"got {len(retry_logs)}"
+        f"Expected {len(REJECT_CALL_NUMBERS)} retry entries from sender loop, got {len(retry_logs)}"
     )
 
 
@@ -746,7 +751,8 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
 
 @pytest.mark.asyncio
 async def test_response_sender_loop_times_out_waiting_for_response_done(
-    monkeypatch: Any, caplog: Any,
+    monkeypatch: Any,
+    caplog: Any,
 ) -> None:
     """If response.done is never received the sender loop should time out.
 
@@ -791,18 +797,14 @@ async def test_response_sender_loop_times_out_waiting_for_response_done(
 
     assert create_count == 2, f"Expected 2 response.create calls, got {create_count}"
 
-    timeout_logs = [
-        r for r in caplog.records
-        if "Timed out waiting for response.done" in r.getMessage()
-    ]
-    assert len(timeout_logs) == 2, (
-        f"Expected 2 timeout warnings, got {len(timeout_logs)}"
-    )
+    timeout_logs = [r for r in caplog.records if "Timed out waiting for response.done" in r.getMessage()]
+    assert len(timeout_logs) == 2, f"Expected 2 timeout warnings, got {len(timeout_logs)}"
 
 
 @pytest.mark.asyncio
 async def test_response_sender_loop_times_out_waiting_for_previous_response(
-    monkeypatch: Any, caplog: Any,
+    monkeypatch: Any,
+    caplog: Any,
 ) -> None:
     """If a previous response never completes, the pre-condition wait times out.
 
@@ -844,10 +846,5 @@ async def test_response_sender_loop_times_out_waiting_for_previous_response(
     handler._response_done_event.set()
     await asyncio.wait_for(sender_task, timeout=2.0)
 
-    timeout_logs = [
-        r for r in caplog.records
-        if "Timed out waiting for previous response" in r.getMessage()
-    ]
-    assert len(timeout_logs) == 1, (
-        f"Expected 1 pre-condition timeout warning, got {len(timeout_logs)}"
-    )
+    timeout_logs = [r for r in caplog.records if "Timed out waiting for previous response" in r.getMessage()]
+    assert len(timeout_logs) == 1, f"Expected 1 pre-condition timeout warning, got {len(timeout_logs)}"

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -40,6 +40,7 @@ from reachy_mini_conversation_app.headless_personality import (
 WINDOWS_PATH_BUDGET = 130
 WINDOWS_WHEEL_PATH_BUDGET = 71
 
+
 def _git_tracked_files(project_root: Path) -> list[Path]:
     """Return git-tracked files that still exist in the working tree."""
     try:
@@ -71,8 +72,10 @@ def test_prompts_load_from_compact_builtin_profile(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(config, "PROFILES_DIRECTORY", DEFAULT_PROFILES_DIRECTORY)
 
     expected = (
-        DEFAULT_PROFILES_DIRECTORY / "mad_scientist_assistant" / "instructions.txt"
-    ).read_text(encoding="utf-8").strip()
+        (DEFAULT_PROFILES_DIRECTORY / "mad_scientist_assistant" / "instructions.txt")
+        .read_text(encoding="utf-8")
+        .strip()
+    )
 
     assert prompts_mod.get_session_instructions() == expected
     assert read_instructions_for("mad_scientist_assistant") == expected
@@ -87,9 +90,7 @@ def test_session_voice_defaults_follow_selected_backend(monkeypatch: pytest.Monk
     assert prompts_mod.get_session_voice() == "Kore"
 
 
-def test_packaged_profiles_win_outside_source_checkout(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_packaged_profiles_win_outside_source_checkout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Installed builds should use packaged profiles, not an unrelated sibling folder."""
     unrelated_profiles = tmp_path / "profiles"
     unrelated_profiles.mkdir()
@@ -113,8 +114,7 @@ def test_project_file_paths_stay_within_windows_budget() -> None:
         length = len(relative)
         if length > WINDOWS_PATH_BUDGET:
             violations.append(
-                f"Windows path budget exceeded ({WINDOWS_PATH_BUDGET}): "
-                f"{relative} is {length} characters long"
+                f"Windows path budget exceeded ({WINDOWS_PATH_BUDGET}): {relative} is {length} characters long"
             )
 
     assert not violations, "\n".join(violations)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,12 +19,14 @@ def test_initialize_camera_and_vision_propagates_local_vision_init_failures() ->
         local_vision=True,
     )
 
-    with patch("reachy_mini_conversation_app.utils.CameraWorker") as mock_camera_worker, \
-         patch("reachy_mini_conversation_app.utils.subprocess.run", return_value=MagicMock(returncode=0)), \
-         patch(
-             "reachy_mini_conversation_app.vision.local_vision.initialize_vision_processor",
-             side_effect=RuntimeError("Vision processor initialization failed"),
-         ):
+    with (
+        patch("reachy_mini_conversation_app.utils.CameraWorker") as mock_camera_worker,
+        patch("reachy_mini_conversation_app.utils.subprocess.run", return_value=MagicMock(returncode=0)),
+        patch(
+            "reachy_mini_conversation_app.vision.local_vision.initialize_vision_processor",
+            side_effect=RuntimeError("Vision processor initialization failed"),
+        ),
+    ):
         with pytest.raises(RuntimeError, match="Vision processor initialization failed"):
             initialize_camera_and_vision(args, MagicMock())
 
@@ -39,8 +41,10 @@ def test_initialize_camera_and_vision_raises_when_local_vision_import_crashes() 
         local_vision=True,
     )
 
-    with patch("reachy_mini_conversation_app.utils.CameraWorker") as mock_camera_worker, \
-         patch("reachy_mini_conversation_app.utils.subprocess.run", return_value=MagicMock(returncode=-4)):
+    with (
+        patch("reachy_mini_conversation_app.utils.CameraWorker") as mock_camera_worker,
+        patch("reachy_mini_conversation_app.utils.subprocess.run", return_value=MagicMock(returncode=-4)),
+    ):
         with pytest.raises(CameraVisionInitializationError, match="Local vision import crashed"):
             initialize_camera_and_vision(args, MagicMock())
 
@@ -55,9 +59,12 @@ def test_initialize_camera_and_vision_raises_when_head_tracker_init_fails() -> N
         local_vision=False,
     )
 
-    with patch("reachy_mini_conversation_app.utils.CameraWorker") as mock_camera_worker, patch(
-        "reachy_mini_conversation_app.vision.head_tracking.yolo_process.YoloHeadTrackerProcess",
-        side_effect=RuntimeError("tracker init failed"),
+    with (
+        patch("reachy_mini_conversation_app.utils.CameraWorker") as mock_camera_worker,
+        patch(
+            "reachy_mini_conversation_app.vision.head_tracking.yolo_process.YoloHeadTrackerProcess",
+            side_effect=RuntimeError("tracker init failed"),
+        ),
     ):
         with pytest.raises(
             CameraVisionInitializationError,
@@ -78,9 +85,12 @@ def test_initialize_camera_and_vision_uses_mediapipe_head_tracker_in_process() -
 
     current_robot = MagicMock()
     mediapipe_head_tracker = MagicMock()
-    with patch("reachy_mini_conversation_app.utils.CameraWorker") as mock_camera_worker, patch(
-        "reachy_mini_conversation_app.vision.head_tracking.mediapipe.MediapipeHeadTracker",
-        return_value=mediapipe_head_tracker,
+    with (
+        patch("reachy_mini_conversation_app.utils.CameraWorker") as mock_camera_worker,
+        patch(
+            "reachy_mini_conversation_app.vision.head_tracking.mediapipe.MediapipeHeadTracker",
+            return_value=mediapipe_head_tracker,
+        ),
     ):
         initialize_camera_and_vision(args, current_robot)
 

--- a/tests/vision/test_local_vision.py
+++ b/tests/vision/test_local_vision.py
@@ -39,7 +39,6 @@ def test_vision_config_custom_values() -> None:
     assert config.device_preference == "cpu"
 
 
-
 @pytest.fixture
 def mock_torch() -> Any:
     """Mock torch module to avoid loading actual models."""
@@ -54,9 +53,10 @@ def mock_torch() -> Any:
 @pytest.fixture
 def mock_transformers() -> Any:
     """Mock transformers module."""
-    with patch("reachy_mini_conversation_app.vision.local_vision.AutoProcessor") as proc, \
-         patch("reachy_mini_conversation_app.vision.local_vision.AutoModelForImageTextToText") as model:
-
+    with (
+        patch("reachy_mini_conversation_app.vision.local_vision.AutoProcessor") as proc,
+        patch("reachy_mini_conversation_app.vision.local_vision.AutoModelForImageTextToText") as model,
+    ):
         # Mock processor — apply_chat_template returns a BatchFeature-like object with .to()
         mock_batch = MagicMock()
         mock_batch.to.return_value = mock_batch
@@ -217,10 +217,7 @@ def test_vision_processor_process_image_appends_local_vision_instructions(
 
     processor_mock = mock_transformers["processor"].from_pretrained.return_value
     messages = processor_mock.apply_chat_template.call_args.args[0]
-    assert messages[0]["content"][1]["text"] == (
-        "What is on the table?\n\n"
-        f"{LOCAL_VISION_RESPONSE_INSTRUCTIONS}"
-    )
+    assert messages[0]["content"][1]["text"] == (f"What is on the table?\n\n{LOCAL_VISION_RESPONSE_INSTRUCTIONS}")
 
 
 def test_vision_processor_process_image_with_retry(mock_torch: Any, mock_transformers: Any) -> None:
@@ -271,10 +268,11 @@ def test_vision_processor_process_image_retries_input_transfer_failure(
 
 def test_initialize_vision_processor_success(mock_torch: Any, mock_transformers: Any) -> None:
     """Test initialize_vision_processor creates VisionProcessor successfully."""
-    with patch("reachy_mini_conversation_app.vision.local_vision.snapshot_download") as mock_download, \
-         patch("reachy_mini_conversation_app.vision.local_vision.os.makedirs"), \
-         patch("reachy_mini_conversation_app.vision.local_vision.config") as mock_config:
-
+    with (
+        patch("reachy_mini_conversation_app.vision.local_vision.snapshot_download") as mock_download,
+        patch("reachy_mini_conversation_app.vision.local_vision.os.makedirs"),
+        patch("reachy_mini_conversation_app.vision.local_vision.config") as mock_config,
+    ):
         mock_config.LOCAL_VISION_MODEL = "test/model"
         mock_config.HF_HOME = "/tmp/hf_cache"
 
@@ -284,12 +282,14 @@ def test_initialize_vision_processor_success(mock_torch: Any, mock_transformers:
         assert result._initialized
         mock_download.assert_called_once()
 
+
 def test_initialize_vision_processor_download_failure(mock_torch: Any) -> None:
     """Test initialize_vision_processor surfaces download failures."""
-    with patch("reachy_mini_conversation_app.vision.local_vision.snapshot_download") as mock_download, \
-         patch("reachy_mini_conversation_app.vision.local_vision.os.makedirs"), \
-         patch("reachy_mini_conversation_app.vision.local_vision.config") as mock_config:
-
+    with (
+        patch("reachy_mini_conversation_app.vision.local_vision.snapshot_download") as mock_download,
+        patch("reachy_mini_conversation_app.vision.local_vision.os.makedirs"),
+        patch("reachy_mini_conversation_app.vision.local_vision.config") as mock_config,
+    ):
         mock_config.LOCAL_VISION_MODEL = "test/model"
         mock_config.HF_HOME = "/tmp/hf_cache"
         mock_download.side_effect = Exception("Network error")
@@ -297,13 +297,15 @@ def test_initialize_vision_processor_download_failure(mock_torch: Any) -> None:
         with pytest.raises(Exception, match="Network error"):
             initialize_vision_processor()
 
+
 def test_initialize_vision_processor_processor_failure(mock_torch: Any) -> None:
     """Test initialize_vision_processor surfaces processor initialization failures."""
-    with patch("reachy_mini_conversation_app.vision.local_vision.snapshot_download"), \
-         patch("reachy_mini_conversation_app.vision.local_vision.os.makedirs"), \
-         patch("reachy_mini_conversation_app.vision.local_vision.config") as mock_config, \
-         patch("reachy_mini_conversation_app.vision.local_vision.AutoProcessor") as mock_proc:
-
+    with (
+        patch("reachy_mini_conversation_app.vision.local_vision.snapshot_download"),
+        patch("reachy_mini_conversation_app.vision.local_vision.os.makedirs"),
+        patch("reachy_mini_conversation_app.vision.local_vision.config") as mock_config,
+        patch("reachy_mini_conversation_app.vision.local_vision.AutoProcessor") as mock_proc,
+    ):
         mock_config.LOCAL_VISION_MODEL = "test/model"
         mock_config.HF_HOME = "/tmp/hf_cache"
         mock_proc.from_pretrained.side_effect = Exception("Model load error")
@@ -320,7 +322,9 @@ def test_vision_processor_cuda_oom_recovery(mock_torch: Any, mock_transformers: 
 
     # Make generate raise OOM error
     mock_torch.cuda.OutOfMemoryError = type("OutOfMemoryError", (Exception,), {})
-    mock_transformers["model"].from_pretrained.return_value.generate.side_effect = mock_torch.cuda.OutOfMemoryError("OOM")
+    mock_transformers["model"].from_pretrained.return_value.generate.side_effect = mock_torch.cuda.OutOfMemoryError(
+        "OOM"
+    )
 
     test_image = np.zeros((480, 640, 3), dtype=np.uint8)
     result = processor.process_image(test_image, "Describe this image.")

--- a/tests/vision/test_yolo_process.py
+++ b/tests/vision/test_yolo_process.py
@@ -206,8 +206,6 @@ def test_head_tracker_bootstrap_adds_src_parent_to_pythonpath(
         package_spec = importlib.util.find_spec("reachy_mini_conversation_app")
         package_locations = None if package_spec is None else package_spec.submodule_search_locations
         assert package_locations
-        assert pythonpath.split(os.pathsep)[0] == str(
-            Path(next(iter(package_locations))).resolve().parent
-        )
+        assert pythonpath.split(os.pathsep)[0] == str(Path(next(iter(package_locations))).resolve().parent)
     finally:
         tracker.close()


### PR DESCRIPTION
## Summary
Applies `ruff format` across the repo to bring 21 existing files in line with the formatter rules defined in `pyproject.toml`. Purely mechanical, no functional changes. Follow-up to the `format --check` CI step added in the recent lint workflow update.

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
