### PR TITLE
Rebase speech-to-speech backend on latest main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Realtime backend to use: "openai" or "gemini"
+# Realtime backend to use: "openai", "speech-to-speech", or "gemini"
 BACKEND_PROVIDER="openai"
 # For Gemini set "gemini-3.1-flash-live-preview"
 MODEL_NAME="gpt-realtime"
@@ -6,6 +6,8 @@ MODEL_NAME="gpt-realtime"
 # Set up your API key according to your backend
 OPENAI_API_KEY=
 # GEMINI_API_KEY=
+# Required when BACKEND_PROVIDER="speech-to-speech"
+S2S_REALTIME_SESSION_URL="https://v8si2gztnaqwjvf2.us-east-1.aws.endpoints.huggingface.cloud/session"
 
 # Local vision model (only used with --local-vision CLI flag)
 # By default, vision is handled by the selected realtime backend when the camera tool is used

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ tags:
 
 # Reachy Mini conversation app
 
-Conversational app for the Reachy Mini robot combining real-time voice APIs (OpenAI Realtime or Gemini Live), vision pipelines, and choreographed motion libraries.
+Conversational app for the Reachy Mini robot combining real-time voice APIs (OpenAI Realtime, a deployed speech-to-speech backend, or Gemini Live), vision pipelines, and choreographed motion libraries.
 
 ![Reachy Mini Dance](docs/assets/reachy_mini_dance.gif)
 
@@ -30,8 +30,9 @@ Conversational app for the Reachy Mini robot combining real-time voice APIs (Ope
 - [License](#license)
 
 ## Overview
-- Real-time audio conversation loop with `fastrtc` for low-latency streaming. Supports two backends:
+- Real-time audio conversation loop with `fastrtc` for low-latency streaming. Supports three backends:
   - **OpenAI Realtime** (`gpt-realtime`) — default
+  - **Speech-to-speech** (`gpt-realtime` via an OpenAI-compatible session allocator) — optional deployed backend
   - **Gemini Live** (`gemini-3.1-flash-live-preview`) — alternative, using the Google GenAI SDK
 - Vision processing uses the selected realtime backend by default (when camera tool is used), with optional on-device local vision using SmolVLM2 (CPU/GPU/MPS) via `--local-vision`.
 - Layered motion system queues primary moves (dances, emotions, goto poses, breathing) while blending speech-reactive wobble and head-tracking.
@@ -121,17 +122,31 @@ Some wheels (like PyTorch) are large and require compatible CUDA or CPU builds�
 ## Configuration
 
 1. Copy `.env.example` to `.env`
-2. Fill in your API key and backend choice
+2. Fill in the backend-specific settings you need
 
 | Variable | Description |
 |----------|-------------|
 | `OPENAI_API_KEY` | Optional override or fallback for OpenAI mode. In the headless settings flow, the app can use bundled OpenAI access when available; set your own key to override it or provide a fallback. |
 | `GEMINI_API_KEY` | Required for Gemini mode. Also accepts `GOOGLE_API_KEY`. Get one at [aistudio.google.com](https://aistudio.google.com/apikey). |
-| `BACKEND_PROVIDER` | Realtime backend to use: `openai` (default) or `gemini`. |
-| `MODEL_NAME` | Optional model override for the selected backend. Defaults to `gpt-realtime` for OpenAI and `gemini-3.1-flash-live-preview` for Gemini Live. |
+| `S2S_REALTIME_SESSION_URL` | Required for `speech-to-speech` mode. This is the HTTP session allocation endpoint that returns the OpenAI-compatible realtime connect URL. |
+| `BACKEND_PROVIDER` | Realtime backend to use: `openai` (default), `speech-to-speech`, or `gemini`. |
+| `MODEL_NAME` | Optional model override for the selected backend. Defaults to `gpt-realtime` for OpenAI and speech-to-speech, and `gemini-3.1-flash-live-preview` for Gemini Live. |
 | `HF_HOME` | Cache directory for local Hugging Face downloads (only used with `--local-vision` flag, defaults to `./cache`). |
 | `HF_TOKEN` | Optional token for Hugging Face access (for gated/private assets). |
 | `LOCAL_VISION_MODEL` | Hugging Face model path for local vision processing (only used with `--local-vision` flag, defaults to `HuggingFaceTB/SmolVLM2-2.2B-Instruct`). |
+
+### Switching to speech-to-speech
+
+To use the deployed speech-to-speech backend instead of direct OpenAI Realtime:
+
+```env
+BACKEND_PROVIDER="speech-to-speech"
+MODEL_NAME="gpt-realtime"
+S2S_REALTIME_SESSION_URL="https://your-session-allocator.example/session"
+```
+
+> [!NOTE]
+> Speech-to-speech uses the same OpenAI-compatible realtime handler as OpenAI mode, but allocates a session first and uses a different curated voice set (Aiden, Ryan, Dylan, Eric, Ono_Anna, Serena, Sohee, Uncle_Fu, Vivian). If a profile does not specify a voice, the backend default is used.
 
 ### Switching to Gemini Live
 
@@ -143,7 +158,7 @@ MODEL_NAME="gemini-3.1-flash-live-preview"
 GEMINI_API_KEY=your-gemini-api-key
 ```
 
-`BACKEND_PROVIDER` is the primary switch. The app still falls back to `MODEL_NAME` for compatibility with older configs, and all features (tools, profiles, head tracking) work with both backends.
+`BACKEND_PROVIDER` is the primary switch. The app still falls back to `MODEL_NAME` for compatibility with older configs, and all features (tools, profiles, head tracking) work with all three backends.
 
 > [!NOTE]
 > Gemini Live uses a different set of voices: Aoede, Charon, Fenrir, Kore (default), Leda, Orus, Puck, Zephyr. If your profile's `voice.txt` specifies an OpenAI voice, it will fall back to Kore.

--- a/profiles/example/tools.txt
+++ b/profiles/example/tools.txt
@@ -4,8 +4,8 @@ dance
 stop_dance
 play_emotion
 stop_emotion
-# camera
-# do_nothing
+camera
+do_nothing
 # head_tracking
 # move_head
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 
     #Environment variables
     "python-dotenv",
+    "httpx",
 
     #OpenAI
     "openai>=2.30.0",

--- a/src/reachy_mini_conversation_app/audio/head_wobbler.py
+++ b/src/reachy_mini_conversation_app/audio/head_wobbler.py
@@ -22,9 +22,14 @@ logger = logging.getLogger(__name__)
 class HeadWobbler:
     """Converts audio deltas (base64) into head movement offsets."""
 
-    def __init__(self, set_speech_offsets: Callable[[Tuple[float, float, float, float, float, float]], None]) -> None:
+    def __init__(
+        self,
+        set_speech_offsets: Callable[[Tuple[float, float, float, float, float, float]], None],
+        default_sample_rate: int | None = None,
+    ) -> None:
         """Initialize the head wobbler."""
         self._apply_offsets = set_speech_offsets
+        self._default_sample_rate = default_sample_rate
         self._base_ts: float | None = None
         self._hops_done: int = 0
 
@@ -40,10 +45,13 @@ class HeadWobbler:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
 
-    def feed(self, delta_b64: str, start_delay_s: float = 0.0) -> None:
+    def feed(self, delta_b64: str, sample_rate: int | None = None, start_delay_s: float = 0.0) -> None:
         """Thread-safe: push base64 audio into the consumer queue."""
         buf = np.frombuffer(base64.b64decode(delta_b64), dtype=np.int16).reshape(1, -1)
-        self.feed_pcm(buf, SAMPLE_RATE, start_delay_s=start_delay_s)
+        sr = sample_rate if sample_rate is not None else self._default_sample_rate
+        if sr is None:
+            sr = SAMPLE_RATE
+        self.feed_pcm(buf, sr, start_delay_s=start_delay_s)
 
     def feed_pcm(self, pcm: NDArray[np.int16], sample_rate: int, start_delay_s: float = 0.0) -> None:
         """Thread-safe: push PCM audio into the consumer queue."""

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -44,7 +44,7 @@ DEFAULT_PROFILES_DIRECTORY = _resolve_default_profiles_directory()
 # Full list of voices supported by the OpenAI Realtime / TTS API.
 # Source: https://developers.openai.com/api/docs/guides/text-to-speech/#voice-options
 # "marin" and "cedar" are recommended for gpt-realtime.
-AVAILABLE_VOICES: list[str] = [
+OPENAI_AVAILABLE_VOICES: list[str] = [
     "alloy",
     "ash",
     "ballad",
@@ -55,6 +55,20 @@ AVAILABLE_VOICES: list[str] = [
     "sage",
     "shimmer",
     "verse",
+]
+
+# Voices supported by the deployed speech-to-speech backend.
+# Source: faster-qwen3-tts demo speaker catalog.
+S2S_AVAILABLE_VOICES: list[str] = [
+    "Aiden",
+    "Ryan",
+    "Dylan",
+    "Eric",
+    "Ono_Anna",
+    "Serena",
+    "Sohee",
+    "Uncle_Fu",
+    "Vivian",
 ]
 
 # Voices supported by the Gemini Live API
@@ -71,14 +85,17 @@ GEMINI_AVAILABLE_VOICES: list[str] = [
 
 OPENAI_BACKEND = "openai"
 GEMINI_BACKEND = "gemini"
+SPEECH_TO_SPEECH_BACKEND = "speech-to-speech"
 DEFAULT_BACKEND_PROVIDER = OPENAI_BACKEND
 DEFAULT_MODEL_NAME_BY_BACKEND = {
     OPENAI_BACKEND: "gpt-realtime",
     GEMINI_BACKEND: "gemini-3.1-flash-live-preview",
+    SPEECH_TO_SPEECH_BACKEND: "gpt-realtime",
 }
 DEFAULT_VOICE_BY_BACKEND = {
     OPENAI_BACKEND: "cedar",
     GEMINI_BACKEND: "Kore",
+    SPEECH_TO_SPEECH_BACKEND: "Aiden",
 }
 
 logger = logging.getLogger(__name__)
@@ -96,6 +113,8 @@ def _normalize_backend_provider(
 ) -> str:
     """Normalize backend selection, falling back to MODEL_NAME for compatibility."""
     candidate = (backend_provider or "").strip().lower()
+    if candidate in {"speech_to_speech", "s2s"}:
+        candidate = SPEECH_TO_SPEECH_BACKEND
     if candidate in DEFAULT_MODEL_NAME_BY_BACKEND:
         return candidate
     return GEMINI_BACKEND if _is_gemini_model_name(model_name) else DEFAULT_BACKEND_PROVIDER
@@ -111,7 +130,7 @@ def _resolve_model_name(
     if candidate:
         if normalized_backend == GEMINI_BACKEND and _is_gemini_model_name(candidate):
             return candidate
-        if normalized_backend == OPENAI_BACKEND and not _is_gemini_model_name(candidate):
+        if normalized_backend in {OPENAI_BACKEND, SPEECH_TO_SPEECH_BACKEND} and not _is_gemini_model_name(candidate):
             return candidate
         logger.warning(
             "MODEL_NAME=%r does not match BACKEND_PROVIDER=%r, using default %r",
@@ -218,6 +237,7 @@ class Config:
         os.getenv("MODEL_NAME"),
     )
     MODEL_NAME = _resolve_model_name(BACKEND_PROVIDER, os.getenv("MODEL_NAME"))
+    S2S_REALTIME_SESSION_URL = os.getenv("S2S_REALTIME_SESSION_URL")
     HF_HOME = os.getenv("HF_HOME", "./cache")
     LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     HF_TOKEN = os.getenv("HF_TOKEN")  # Optional, falls back to hf auth login if not set
@@ -312,6 +332,7 @@ def refresh_runtime_config_from_env() -> None:
         os.getenv("MODEL_NAME"),
     )
     config.MODEL_NAME = _resolve_model_name(config.BACKEND_PROVIDER, os.getenv("MODEL_NAME"))
+    config.S2S_REALTIME_SESSION_URL = os.getenv("S2S_REALTIME_SESSION_URL")
     config.REACHY_MINI_CUSTOM_PROFILE = LOCKED_PROFILE or os.getenv("REACHY_MINI_CUSTOM_PROFILE")
 
 
@@ -332,7 +353,9 @@ def get_available_voices_for_backend(backend: str | None = None) -> list[str]:
     normalized_backend = get_backend_choice() if backend is None else _normalize_backend_provider(backend)
     if normalized_backend == GEMINI_BACKEND:
         return list(GEMINI_AVAILABLE_VOICES)
-    return list(AVAILABLE_VOICES)
+    if normalized_backend == SPEECH_TO_SPEECH_BACKEND:
+        return list(S2S_AVAILABLE_VOICES)
+    return list(OPENAI_AVAILABLE_VOICES)
 
 
 def get_default_voice_for_backend(backend: str | None = None) -> str:
@@ -344,6 +367,11 @@ def get_default_voice_for_backend(backend: str | None = None) -> str:
 def is_gemini_model() -> bool:
     """Return True if the configured MODEL_NAME is a Gemini Live model."""
     return get_backend_choice() == GEMINI_BACKEND
+
+
+# Backward-compatible aliases for legacy imports.
+AVAILABLE_VOICES: list[str] = list(OPENAI_AVAILABLE_VOICES)
+DEFAULT_VOICE = DEFAULT_VOICE_BY_BACKEND[DEFAULT_BACKEND_PROVIDER]
 
 
 def set_custom_profile(profile: str | None) -> None:

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -27,6 +27,7 @@ from reachy_mini_conversation_app.config import (
     GEMINI_BACKEND,
     LOCKED_PROFILE,
     OPENAI_BACKEND,
+    SPEECH_TO_SPEECH_BACKEND,
     config,
     get_backend_choice,
     get_model_name_for_backend,
@@ -57,6 +58,11 @@ except Exception:  # pragma: no cover - only loaded when settings_app is used
 
 
 logger = logging.getLogger(__name__)
+LOCAL_MEDIA_BACKENDS = tuple(
+    getattr(MediaBackend, name)
+    for name in ("LOCAL", "GSTREAMER", "GSTREAMER_NO_VIDEO", "DEFAULT", "DEFAULT_NO_VIDEO")
+    if hasattr(MediaBackend, name)
+)
 
 
 def _estimate_pending_playback_seconds(robot: ReachyMini) -> float:
@@ -105,6 +111,7 @@ class LocalStream:
         self._instance_path: Optional[str] = instance_path
         self._settings_initialized = False
         self._asyncio_loop = None
+        self._runtime_backend = get_backend_choice()
 
     # ---- Settings UI ----
     def _read_env_lines(self, env_path: Path) -> list[str]:
@@ -144,7 +151,9 @@ class LocalStream:
     def _active_backend(self) -> str:
         """Return the backend family of the currently running handler."""
         handler_name = type(self.handler).__name__.lower()
-        return GEMINI_BACKEND if "gemini" in handler_name else OPENAI_BACKEND
+        if "gemini" in handler_name:
+            return GEMINI_BACKEND
+        return self._runtime_backend
 
     @staticmethod
     def _has_key(value: Optional[str]) -> bool:
@@ -152,9 +161,11 @@ class LocalStream:
         return bool(value and str(value).strip())
 
     def _has_required_key(self, backend: str) -> bool:
-        """Return whether the requested backend has its required credential."""
+        """Return whether the requested backend has the minimum required config."""
         if backend == GEMINI_BACKEND:
             return self._has_key(config.GEMINI_API_KEY)
+        if backend == SPEECH_TO_SPEECH_BACKEND:
+            return self._has_key(config.S2S_REALTIME_SESSION_URL)
         return self._has_key(config.OPENAI_API_KEY)
 
     def _persist_env_value(self, env_name: str, value: str) -> None:
@@ -314,8 +325,10 @@ class LocalStream:
             active_backend = self._active_backend()
             has_openai_key = self._has_required_key(OPENAI_BACKEND)
             has_gemini_key = self._has_required_key(GEMINI_BACKEND)
+            has_s2s_session_url = self._has_required_key(SPEECH_TO_SPEECH_BACKEND)
             can_proceed_with_openai = has_openai_key
             can_proceed_with_gemini = has_gemini_key
+            can_proceed_with_s2s = has_s2s_session_url
             can_proceed = self._has_required_key(active_backend)
             requires_restart = backend_provider != active_backend
             return {
@@ -324,9 +337,11 @@ class LocalStream:
                 "has_key": can_proceed,
                 "has_openai_key": has_openai_key,
                 "has_gemini_key": has_gemini_key,
+                "has_s2s_session_url": has_s2s_session_url,
                 "can_proceed": can_proceed,
                 "can_proceed_with_openai": can_proceed_with_openai,
                 "can_proceed_with_gemini": can_proceed_with_gemini,
+                "can_proceed_with_speech_to_speech": can_proceed_with_s2s,
                 "requires_restart": requires_restart,
             }
 
@@ -367,7 +382,7 @@ class LocalStream:
         @self._settings_app.post("/backend_config")
         def _set_backend(payload: BackendPayload) -> JSONResponse:
             backend = payload.backend.strip().lower()
-            if backend not in {OPENAI_BACKEND, GEMINI_BACKEND}:
+            if backend not in {OPENAI_BACKEND, GEMINI_BACKEND, SPEECH_TO_SPEECH_BACKEND}:
                 return JSONResponse({"ok": False, "error": "invalid_backend"}, status_code=400)
 
             api_key = (payload.api_key or "").strip()
@@ -466,6 +481,12 @@ class LocalStream:
 
         # If key is still missing -> wait until provided via the settings UI
         if not self._has_required_key(active_backend):
+            if active_backend == SPEECH_TO_SPEECH_BACKEND:
+                logger.error(
+                    "S2S_REALTIME_SESSION_URL is not configured. "
+                    "Speech-to-speech mode cannot start without a session allocator URL."
+                )
+                return
             key_name = "GEMINI_API_KEY" if active_backend == GEMINI_BACKEND else "OPENAI_API_KEY"
             logger.warning("%s not found. Open the app settings page to enter it.", key_name)
             # Poll until the key becomes available (set via the settings UI)
@@ -548,7 +569,7 @@ class LocalStream:
         backend = getattr(self._robot.media, "backend", None)
         audio = getattr(self._robot.media, "audio", None)
         if audio is not None:
-            if backend == MediaBackend.LOCAL and hasattr(audio, "clear_player") and callable(audio.clear_player):
+            if backend in LOCAL_MEDIA_BACKENDS and hasattr(audio, "clear_player") and callable(audio.clear_player):
                 audio.clear_player()
             elif (
                 backend == MediaBackend.WEBRTC

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -46,7 +46,14 @@ def run(
     """Run the Reachy Mini conversation app."""
     # Putting these dependencies here makes the dashboard faster to load when the conversation app is installed
     from reachy_mini_conversation_app.moves import MovementManager
-    from reachy_mini_conversation_app.config import config, is_gemini_model, refresh_runtime_config_from_env
+    from reachy_mini_conversation_app.config import (
+        GEMINI_BACKEND,
+        OPENAI_BACKEND,
+        SPEECH_TO_SPEECH_BACKEND,
+        config,
+        get_backend_choice,
+        refresh_runtime_config_from_env,
+    )
 
     logger = setup_logger(args.debug)
     logger.info("Starting Reachy Mini Conversation App")
@@ -120,7 +127,12 @@ def run(
         camera_worker=camera_worker,
     )
 
-    head_wobbler = HeadWobbler(set_speech_offsets=movement_manager.set_speech_offsets)
+    from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
+
+    head_wobbler = HeadWobbler(
+        set_speech_offsets=movement_manager.set_speech_offsets,
+        default_sample_rate=OpenaiRealtimeHandler._get_realtime_sample_rate(),
+    )
 
     deps = ToolDependencies(
         reachy_mini=robot,
@@ -141,43 +153,40 @@ def run(
     )
     logger.debug(f"Chatbot avatar images: {chatbot.avatar_images}")
 
-    if is_gemini_model():
+    active_backend = get_backend_choice()
+    if active_backend == GEMINI_BACKEND:
         from reachy_mini_conversation_app.gemini_live import GeminiLiveHandler
 
         logger.info("Using Gemini Live handler for model: %s", config.MODEL_NAME)
         handler = GeminiLiveHandler(deps, gradio_mode=args.gradio, instance_path=instance_path)
     else:
-        from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
-
-        logger.info("Using OpenAI Realtime handler for model: %s", config.MODEL_NAME)
+        backend_label = "speech-to-speech" if active_backend == SPEECH_TO_SPEECH_BACKEND else "OpenAI Realtime"
+        logger.info("Using %s handler for model: %s", backend_label, config.MODEL_NAME)
         handler = OpenaiRealtimeHandler(deps, gradio_mode=args.gradio, instance_path=instance_path)  # type: ignore[assignment]
 
     stream_manager: gr.Blocks | LocalStream | None = None
 
     if args.gradio:
-        uses_gemini_backend = is_gemini_model()
-        api_key_textbox = gr.Textbox(
-            label="GEMINI_API_KEY" if uses_gemini_backend else "OPENAI API Key",
-            type="password",
-            value=(os.getenv("GEMINI_API_KEY") if uses_gemini_backend else os.getenv("OPENAI_API_KEY"))
-            if not get_space()
-            else "",
-        )
-
         from reachy_mini_conversation_app.gradio_personality import PersonalityUI
 
         personality_ui = PersonalityUI()
         personality_ui.create_components()
+        additional_inputs = [chatbot, *personality_ui.additional_inputs_ordered()]
+        if active_backend in {GEMINI_BACKEND, OPENAI_BACKEND}:
+            api_key_textbox = gr.Textbox(
+                label="GEMINI_API_KEY" if active_backend == GEMINI_BACKEND else "OPENAI API Key",
+                type="password",
+                value=(os.getenv("GEMINI_API_KEY") if active_backend == GEMINI_BACKEND else os.getenv("OPENAI_API_KEY"))
+                if not get_space()
+                else "",
+            )
+            additional_inputs.insert(1, api_key_textbox)
 
         stream = Stream(
             handler=handler,
             mode="send-receive",
             modality="audio",
-            additional_inputs=[
-                chatbot,
-                api_key_textbox,
-                *personality_ui.additional_inputs_ordered(),
-            ],
+            additional_inputs=additional_inputs,
             additional_outputs=[chatbot],
             additional_outputs_handler=update_chatbot,
             ui_args={"title": "Talk with Reachy Mini"},

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -4,10 +4,12 @@ import base64
 import random
 import asyncio
 import logging
-from typing import Any, Final, Tuple, Literal, Optional
+from typing import Any, Final, Tuple, Optional
 from pathlib import Path
 from datetime import datetime
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
+import httpx
 import numpy as np
 import gradio as gr
 from openai import AsyncOpenAI
@@ -28,7 +30,14 @@ from openai.resources.realtime.realtime import AsyncRealtimeConnection
 from openai.types.realtime.realtime_audio_formats_param import AudioPCM
 from openai.types.realtime.realtime_audio_input_turn_detection_param import ServerVad
 
-from reachy_mini_conversation_app.config import AVAILABLE_VOICES, config
+from reachy_mini_conversation_app.config import (
+    OPENAI_BACKEND,
+    SPEECH_TO_SPEECH_BACKEND,
+    config,
+    get_available_voices_for_backend,
+    get_backend_choice,
+    get_default_voice_for_backend,
+)
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
 from reachy_mini_conversation_app.tools.core_tools import (
     ToolDependencies,
@@ -43,8 +52,8 @@ from reachy_mini_conversation_app.tools.background_tool_manager import (
 
 logger = logging.getLogger(__name__)
 
-OPEN_AI_INPUT_SAMPLE_RATE: Final[Literal[24000]] = 24000
-OPEN_AI_OUTPUT_SAMPLE_RATE: Final[Literal[24000]] = 24000
+OPENAI_REALTIME_SAMPLE_RATE: Final[int] = 24000
+S2S_REALTIME_SAMPLE_RATE: Final[int] = 16000
 
 # Cost tracking from usage data (pricing as of Feb 2026 https://openai.com/api/pricing/)
 AUDIO_INPUT_COST_PER_1M = 32.0
@@ -84,22 +93,20 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
     def __init__(self, deps: ToolDependencies, gradio_mode: bool = False, instance_path: Optional[str] = None):
         """Initialize the handler."""
+        sample_rate = self._get_realtime_sample_rate()
         super().__init__(
             expected_layout="mono",
-            output_sample_rate=OPEN_AI_OUTPUT_SAMPLE_RATE,
-            input_sample_rate=OPEN_AI_INPUT_SAMPLE_RATE,
+            output_sample_rate=sample_rate,
+            input_sample_rate=sample_rate,
         )
-
-        # Override typing of the sample rates to match OpenAI's requirements
-        self.output_sample_rate: Literal[24000] = self.output_sample_rate
-        self.input_sample_rate: Literal[24000] = self.input_sample_rate
 
         self.deps = deps
 
-        # Override type annotations for OpenAI strict typing (only for values used in API)
-        self.output_sample_rate = OPEN_AI_OUTPUT_SAMPLE_RATE
-        self.input_sample_rate = OPEN_AI_INPUT_SAMPLE_RATE
+        self.output_sample_rate = sample_rate
+        self.input_sample_rate = sample_rate
+        self._backend = get_backend_choice()
 
+        self.client: AsyncOpenAI
         self.connection: AsyncRealtimeConnection | None = None
         self.output_queue: "asyncio.Queue[Tuple[int, NDArray[np.int16]] | AdditionalOutputs]" = asyncio.Queue()
 
@@ -112,6 +119,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         # Track how the API key was provided (env vs textbox) and its value
         self._key_source: Literal["env", "textbox"] = "env"
         self._provided_api_key: str | None = None
+        self._realtime_connect_query: dict[str, str] = {}
 
         # Debouncing for partial transcripts
         self.partial_transcript_task: asyncio.Task[None] | None = None
@@ -134,6 +142,39 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         self._response_done_event: asyncio.Event = asyncio.Event()
         self._response_done_event.set()
         self._last_response_rejected: bool = False
+
+    @staticmethod
+    def _get_realtime_sample_rate() -> int:
+        """Use the backend-native audio rate for OpenAI-compatible sessions."""
+        if get_backend_choice() == SPEECH_TO_SPEECH_BACKEND:
+            return S2S_REALTIME_SAMPLE_RATE
+        return OPENAI_REALTIME_SAMPLE_RATE
+
+    def _get_session_voice(self) -> str | None:
+        """Resolve the voice to use for the active backend."""
+        if self._voice_override is not None:
+            return self._voice_override
+        if self._backend == SPEECH_TO_SPEECH_BACKEND:
+            return get_session_voice(None)
+        if get_backend_choice() == self._backend:
+            return get_session_voice()
+        return get_session_voice(get_default_voice_for_backend(self._backend))
+
+    def _get_openai_session_audio_rates(self) -> tuple[int | None, int | None]:
+        """Return the audio rates to send in ``session.update``.
+
+        The deployed speech-to-speech backend runs best at 16 kHz. Passing
+        ``None`` to the OpenAI-compatible session config lets that backend keep
+        its preferred default while we still stream 16 kHz audio locally.
+        """
+        input_rate: int | None = self.input_sample_rate
+        output_rate: int | None = self.output_sample_rate
+        if self._backend == SPEECH_TO_SPEECH_BACKEND:
+            if input_rate == S2S_REALTIME_SAMPLE_RATE:
+                input_rate = None
+            if output_rate == S2S_REALTIME_SAMPLE_RATE:
+                output_rate = None
+        return input_rate, output_rate
 
     def copy(self) -> "OpenaiRealtimeHandler":
         """Create a copy of the handler."""
@@ -161,7 +202,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
             try:
                 instructions = get_session_instructions()
-                voice = get_session_voice()
+                voice = self._get_session_voice()
             except BaseException as e:  # catch SystemExit from prompt loader without crashing
                 logger.error("Failed to resolve personality content: %s", e)
                 return f"Failed to apply personality: {e}"
@@ -169,16 +210,18 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
             # Attempt a live update first, then force a full restart to ensure it sticks
             if self.connection is not None:
                 try:
-                    await self.connection.session.update(
-                        session=RealtimeSessionCreateRequestParam(
-                            type="realtime",
-                            instructions=instructions,
-                            audio=RealtimeAudioConfigParam(
-                                output=RealtimeAudioConfigOutputParam(
-                                    voice=voice,
-                                ),
+                    session_kwargs: dict[str, Any] = {
+                        "type": "realtime",
+                        "instructions": instructions,
+                    }
+                    if voice:
+                        session_kwargs["audio"] = RealtimeAudioConfigParam(
+                            output=RealtimeAudioConfigOutputParam(
+                                voice=voice,
                             ),
-                        ),
+                        )
+                    await self.connection.session.update(
+                        session=RealtimeSessionCreateRequestParam(**session_kwargs),
                     )
                     logger.info("Applied personality via live update: %s", profile or "built-in default")
                 except Exception as e:
@@ -215,7 +258,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
     def get_current_voice(self) -> str:
         """Return the voice currently selected for this handler."""
-        return self._voice_override or get_session_voice()
+        return self._voice_override or (self._get_session_voice() or get_default_voice_for_backend(self._backend))
 
     async def _emit_debounced_partial(self, transcript: str, item_id: str, sequence_counter: int) -> None:
         """Emit partial transcript after debounce delay."""
@@ -233,7 +276,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
     async def start_up(self) -> None:
         """Start the handler with minimal retries on unexpected websocket closure."""
         openai_api_key = config.OPENAI_API_KEY
-        if self.gradio_mode and not openai_api_key:
+        if self.gradio_mode and self._backend == OPENAI_BACKEND and not openai_api_key:
             # api key was not found in .env or in the environment variables
             await self.wait_for_args()  # type: ignore[no-untyped-call]
             args = list(self.latest_args)
@@ -244,7 +287,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 self._provided_api_key = textbox_api_key
             else:
                 openai_api_key = config.OPENAI_API_KEY
-        else:
+        elif self._backend == OPENAI_BACKEND:
             if not openai_api_key or not openai_api_key.strip():
                 # In headless console mode, LocalStream now blocks startup until the key is provided.
                 # However, unit tests may invoke this handler directly with a stubbed client.
@@ -252,7 +295,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 logger.warning("OPENAI_API_KEY missing. Proceeding with a placeholder (tests/offline).")
                 openai_api_key = "DUMMY"
 
-        self.client = AsyncOpenAI(api_key=openai_api_key)
+        self.client = await self._build_realtime_client(api_key=openai_api_key)
 
         max_attempts = 3
         for attempt in range(1, max_attempts + 1):
@@ -264,6 +307,8 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 # Abrupt close (e.g., "no close frame received or sent") → retry
                 logger.warning("Realtime websocket closed unexpectedly (attempt %d/%d): %s", attempt, max_attempts, e)
                 if attempt < max_attempts:
+                    if self._backend == SPEECH_TO_SPEECH_BACKEND:
+                        self.client = await self._build_realtime_client()
                     # exponential backoff with jitter
                     base_delay = 2 ** (attempt - 1)  # 1s, 2s, 4s, 8s, etc.
                     jitter = random.uniform(0, 0.5)
@@ -304,6 +349,8 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 self._connected_event.clear()
             except Exception:
                 pass
+            if self._backend == SPEECH_TO_SPEECH_BACKEND:
+                self.client = await self._build_realtime_client()
             asyncio.create_task(self._run_realtime_session(), name="openai-realtime-restart")
             try:
                 await asyncio.wait_for(self._connected_event.wait(), timeout=5.0)
@@ -476,21 +523,28 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
     async def _run_realtime_session(self) -> None:
         """Establish and manage a single realtime session."""
-        async with self.client.realtime.connect(model=config.MODEL_NAME) as conn:
+        input_rate, output_rate = self._get_openai_session_audio_rates()
+        async with self.client.realtime.connect(
+            model=config.MODEL_NAME,
+            extra_query=self._realtime_connect_query,
+        ) as conn:
             try:
+                voice = self._get_session_voice()
+                output_audio_kwargs: dict[str, Any] = {
+                    "format": AudioPCM(type="audio/pcm", rate=output_rate),  # type: ignore[typeddict-item]
+                }
+                if voice:
+                    output_audio_kwargs["voice"] = voice
                 session_config = RealtimeSessionCreateRequestParam(
                     type="realtime",
                     instructions=get_session_instructions(),
                     audio=RealtimeAudioConfigParam(
                         input=RealtimeAudioConfigInputParam(
-                            format=AudioPCM(type="audio/pcm", rate=self.input_sample_rate),
+                            format=AudioPCM(type="audio/pcm", rate=input_rate),  # type: ignore[typeddict-item]
                             transcription=AudioTranscriptionParam(model="gpt-4o-transcribe", language="en"),
                             turn_detection=ServerVad(type="server_vad", interrupt_response=True),
                         ),
-                        output=RealtimeAudioConfigOutputParam(
-                            format=AudioPCM(type="audio/pcm", rate=self.output_sample_rate),
-                            voice=self._voice_override or get_session_voice(),
-                        ),
+                        output=RealtimeAudioConfigOutputParam(**output_audio_kwargs),
                     ),
                     tools=get_tool_specs(), # type: ignore[typeddict-item]
                     tool_choice="auto",
@@ -499,7 +553,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 logger.info(
                     "Realtime session initialized with profile=%r voice=%r",
                     getattr(config, "REACHY_MINI_CUSTOM_PROFILE", None),
-                    self._voice_override or get_session_voice(),
+                    voice,
                 )
                 # If we reached here, the session update succeeded which implies the API key worked.
                 # Persist the key to a newly created .env (copied from .env.example) if needed.
@@ -618,7 +672,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                     # Handle audio delta
                     if event.type == "response.output_audio.delta":
                         if self.gradio_mode and self.deps.head_wobbler is not None:
-                            self.deps.head_wobbler.feed(event.delta)
+                            self.deps.head_wobbler.feed(event.delta, sample_rate=self.output_sample_rate)
                         self.last_activity_time = asyncio.get_event_loop().time()
                         logger.debug("last activity time updated to %s", self.last_activity_time)
                         await self.output_queue.put(
@@ -810,7 +864,9 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         for any keys that might contain voice names. Falls back to a curated
         list known to work with realtime if discovery fails.
         """
-        fallback = list(AVAILABLE_VOICES)
+        fallback = get_available_voices_for_backend(self._backend)
+        if self._backend == SPEECH_TO_SPEECH_BACKEND:
+            return fallback
         try:
             # Best effort discovery; safe-guarded for unexpected shapes
             model = await self.client.models.retrieve(config.MODEL_NAME)
@@ -855,11 +911,51 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                 _collect(raw)
             # Ensure default present and stable order
             voices = sorted(candidates) if candidates else fallback
-            if "cedar" not in voices:
-                voices = ["cedar", *[v for v in voices if v != "cedar"]]
+            default_voice = get_default_voice_for_backend(self._backend)
+            if default_voice not in voices:
+                voices = [default_voice, *[v for v in voices if v != default_voice]]
             return voices
         except Exception:
             return fallback
+
+    async def _build_realtime_client(self, api_key: str | None = None) -> AsyncOpenAI:
+        """Build the OpenAI-compatible realtime client for the selected backend."""
+        resolved_api_key = (api_key or self._provided_api_key or config.OPENAI_API_KEY or "").strip()
+        if self._backend != SPEECH_TO_SPEECH_BACKEND:
+            self._realtime_connect_query = {}
+            if not resolved_api_key:
+                logger.warning("OPENAI_API_KEY missing. Proceeding with a placeholder (tests/offline).")
+                resolved_api_key = "DUMMY"
+            return AsyncOpenAI(api_key=resolved_api_key)
+
+        session_url = getattr(config, "S2S_REALTIME_SESSION_URL", None)
+        if not session_url:
+            raise RuntimeError(
+                "S2S_REALTIME_SESSION_URL must be set when BACKEND_PROVIDER=speech-to-speech"
+            )
+
+        async with httpx.AsyncClient(timeout=10.0) as http_client:
+            response = await http_client.post(session_url)
+            response.raise_for_status()
+            payload = response.json()
+
+        connect_url = payload.get("connect_url")
+        if not isinstance(connect_url, str) or not connect_url:
+            raise RuntimeError(f"Session allocator response did not contain a valid connect_url: {payload!r}")
+
+        parsed = urlsplit(connect_url)
+        path = parsed.path.rstrip("/")
+        if not path.endswith("/realtime"):
+            raise ValueError(f"Expected realtime connect URL ending with /realtime, got: {connect_url}")
+
+        base_path = path[: -len("/realtime")]
+        logger.info("Allocated realtime session %s", payload.get("session_id") or "<unknown>")
+        self._realtime_connect_query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+        return AsyncOpenAI(
+            api_key=resolved_api_key or "DUMMY",
+            base_url=urlunsplit(("https" if parsed.scheme == "wss" else "http", parsed.netloc, base_path, "", "")),
+            websocket_base_url=urlunsplit((parsed.scheme, parsed.netloc, base_path, "", "")),
+        )
 
     async def send_idle_signal(self, idle_duration: float) -> None:
         """Send an idle signal to the openai server."""

--- a/src/reachy_mini_conversation_app/prompts.py
+++ b/src/reachy_mini_conversation_app/prompts.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 PROMPTS_LIBRARY_DIRECTORY = Path(__file__).parent / "prompts"
 INSTRUCTIONS_FILENAME = "instructions.txt"
 VOICE_FILENAME = "voice.txt"
+_BACKEND_DEFAULT = object()
 
 
 def _expand_prompt_includes(content: str) -> str:
@@ -91,14 +92,14 @@ def get_session_instructions() -> str:
         sys.exit(1)
 
 
-def get_session_voice(default: str | None = None) -> str:
+def get_session_voice(default: object = _BACKEND_DEFAULT) -> str | None:
     """Resolve the voice to use for the session.
 
     If a custom profile is selected and contains a voice.txt, return its
     trimmed content; otherwise return the provided default or the active
     backend default voice.
     """
-    fallback = get_default_voice_for_backend() if default is None else default
+    fallback = get_default_voice_for_backend() if default is _BACKEND_DEFAULT else default
     profile = config.REACHY_MINI_CUSTOM_PROFILE
     if not profile:
         return fallback

--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -16,7 +16,7 @@
       <header class="hero">
         <div class="pill">Headless control</div>
         <h1>Reachy Mini Conversation</h1>
-        <p class="subtitle">Choose a realtime backend, add a Gemini token if needed, and tweak personalities without the full UI.</p>
+        <p class="subtitle">Choose a realtime backend, add credentials when needed, and tweak personalities without the full UI.</p>
       </header>
 
       <aside class="privacy-notice" role="note" aria-label="Privacy notice">
@@ -55,7 +55,7 @@
           <span id="backend-chip" class="chip">Required</span>
         </div>
         <p id="backend-note" class="muted backend-note">
-          OpenAI Realtime uses the distributed OpenAI key. Gemini Live needs your own <code>GEMINI_API_KEY</code>.
+          OpenAI Realtime can use the distributed OpenAI key. Gemini Live needs your own <code>GEMINI_API_KEY</code>. Speech-to-speech uses the configured <code>S2S_REALTIME_SESSION_URL</code>.
         </p>
         <p class="muted backend-note">
           Backend changes are saved here, then applied after you restart Reachy Mini Conversation from the dashboard or desktop app.
@@ -66,6 +66,13 @@
             <span class="backend-choice-body">
               <span class="backend-choice-title">OpenAI Realtime</span>
               <span class="backend-choice-copy">Start quickly with the bundled OpenAI access.</span>
+            </span>
+          </label>
+          <label class="backend-choice" data-backend-card="speech-to-speech">
+            <input type="radio" name="backend" value="speech-to-speech" />
+            <span class="backend-choice-body">
+              <span class="backend-choice-title">Speech-to-speech</span>
+              <span class="backend-choice-copy">Use the deployed OpenAI-compatible session allocator when it is configured.</span>
             </span>
           </label>
           <label class="backend-choice" data-backend-card="gemini">

--- a/src/reachy_mini_conversation_app/static/main.js
+++ b/src/reachy_mini_conversation_app/static/main.js
@@ -1,5 +1,6 @@
 const OPENAI_BACKEND = "openai";
 const GEMINI_BACKEND = "gemini";
+const SPEECH_TO_SPEECH_BACKEND = "speech-to-speech";
 const BACKEND_META = {
   [OPENAI_BACKEND]: {
     label: "OpenAI Realtime",
@@ -13,6 +14,19 @@ const BACKEND_META = {
     formCopy: "OpenAI Realtime uses the distributed key when available. Paste your own key if you want an override or need a fallback.",
     requiredCredentialsCopy: "OpenAI Realtime usually uses the distributed key. If it is unavailable here, paste your own OpenAI key to continue.",
     note: "OpenAI Realtime uses the distributed OpenAI key. You can still paste your own key if you want to override it.",
+  },
+  [SPEECH_TO_SPEECH_BACKEND]: {
+    label: "Speech-to-speech",
+    formTitle: "Speech-to-speech",
+    inputLabel: "S2S session allocator",
+    placeholder: "",
+    saveButton: "Unavailable here",
+    changeButton: "",
+    readyTitle: "Speech-to-speech ready",
+    readyCopy: "Speech-to-speech is configured. The deployed session allocator is ready to use after restart.",
+    formCopy: "Speech-to-speech uses the configured session allocator URL and does not need an API key in this UI.",
+    requiredCredentialsCopy: "Speech-to-speech needs S2S_REALTIME_SESSION_URL in the instance environment. It cannot be entered from this screen.",
+    note: "Speech-to-speech uses the configured S2S_REALTIME_SESSION_URL. OpenAI Realtime can use the distributed OpenAI key, and Gemini Live needs your own GEMINI_API_KEY.",
   },
   [GEMINI_BACKEND]: {
     label: "Gemini Live",
@@ -30,13 +44,20 @@ const BACKEND_META = {
 };
 
 function backendHasCredentials(status, backend) {
-  return backend === GEMINI_BACKEND ? !!status.has_gemini_key : !!status.has_openai_key;
+  if (backend === GEMINI_BACKEND) return !!status.has_gemini_key;
+  if (backend === SPEECH_TO_SPEECH_BACKEND) return !!status.has_s2s_session_url;
+  return !!status.has_openai_key;
 }
 
 function backendCanProceed(status, backend) {
   if (backend === GEMINI_BACKEND) {
     return status.can_proceed_with_gemini !== undefined
       ? !!status.can_proceed_with_gemini
+      : backendHasCredentials(status, backend);
+  }
+  if (backend === SPEECH_TO_SPEECH_BACKEND) {
+    return status.can_proceed_with_speech_to_speech !== undefined
+      ? !!status.can_proceed_with_speech_to_speech
       : backendHasCredentials(status, backend);
   }
   return status.can_proceed_with_openai !== undefined
@@ -49,7 +70,9 @@ function backendMeta(backend) {
 }
 
 function formatBackendNote(text) {
-  return text.replace("GEMINI_API_KEY", "<code>GEMINI_API_KEY</code>");
+  return text
+    .replace("GEMINI_API_KEY", "<code>GEMINI_API_KEY</code>")
+    .replace("S2S_REALTIME_SESSION_URL", "<code>S2S_REALTIME_SESSION_URL</code>");
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -291,7 +314,13 @@ async function init() {
   let editingCredentials = false;
 
   function setSelectedBackend(backend) {
-    selectedBackend = backend === GEMINI_BACKEND ? GEMINI_BACKEND : OPENAI_BACKEND;
+    if (backend === GEMINI_BACKEND) {
+      selectedBackend = GEMINI_BACKEND;
+    } else if (backend === SPEECH_TO_SPEECH_BACKEND) {
+      selectedBackend = SPEECH_TO_SPEECH_BACKEND;
+    } else {
+      selectedBackend = OPENAI_BACKEND;
+    }
     backendInputs.forEach((radio) => {
       radio.checked = radio.value === selectedBackend;
     });
@@ -308,6 +337,7 @@ async function init() {
     const canProceedWithSelectedBackend = backendCanProceed(status, selectedBackend);
     const selectedMatchesPersisted = selectedBackend === persistedBackend;
     const selectedMatchesActive = selectedBackend === activeBackend;
+    const needsCredentialInput = selectedBackend !== SPEECH_TO_SPEECH_BACKEND;
 
     backendChip.textContent = selectedBackend === persistedBackend ? "Saved" : "Selected";
     backendNote.innerHTML = formatBackendNote(meta.note);
@@ -323,6 +353,10 @@ async function init() {
 
     show(configuredPanel, canProceedWithSelectedBackend && !editingCredentials);
     show(formPanel, editingCredentials || !canProceedWithSelectedBackend);
+    show(apiKeyLabel, needsCredentialInput);
+    show(input, needsCredentialInput);
+    show(saveBtn, needsCredentialInput);
+    show(changeKeyBtn, needsCredentialInput && canProceedWithSelectedBackend && !editingCredentials);
     show(
       backendSaveBtn,
       canProceedWithSelectedBackend && !selectedMatchesPersisted,
@@ -361,9 +395,11 @@ async function init() {
     has_key: false,
     has_openai_key: false,
     has_gemini_key: false,
+    has_s2s_session_url: false,
     can_proceed: false,
     can_proceed_with_openai: false,
     can_proceed_with_gemini: false,
+    can_proceed_with_speech_to_speech: false,
     requires_restart: false,
   };
   setSelectedBackend(st.backend_provider || OPENAI_BACKEND);
@@ -404,6 +440,10 @@ async function init() {
   });
 
   saveBtn.addEventListener("click", async () => {
+    if (selectedBackend === SPEECH_TO_SPEECH_BACKEND) {
+      setStatusMessage(statusEl, "Speech-to-speech does not take credentials on this screen.", "warn");
+      return;
+    }
     const key = input.value.trim();
     if (!key) {
       setStatusMessage(statusEl, "Please enter a valid key.", "warn");

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -11,9 +11,16 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from reachy_mini.media.media_manager import MediaBackend
-from reachy_mini_conversation_app.config import GEMINI_AVAILABLE_VOICES, config
+from reachy_mini_conversation_app.config import (
+    GEMINI_AVAILABLE_VOICES,
+    S2S_AVAILABLE_VOICES,
+    config,
+)
 from reachy_mini_conversation_app.console import LocalStream
 from reachy_mini_conversation_app.headless_personality_ui import mount_personality_routes
+
+
+LOCAL_TEST_BACKEND = getattr(MediaBackend, "LOCAL", MediaBackend.GSTREAMER)
 
 
 def test_clear_audio_queue_prefers_clear_player_when_available() -> None:
@@ -23,7 +30,7 @@ def test_clear_audio_queue_prefers_clear_player_when_available() -> None:
         clear_player=MagicMock(),
         clear_output_buffer=MagicMock(),
     )
-    robot = SimpleNamespace(media=SimpleNamespace(audio=audio, backend=MediaBackend.LOCAL))
+    robot = SimpleNamespace(media=SimpleNamespace(audio=audio, backend=LOCAL_TEST_BACKEND))
     stream = LocalStream(handler, robot)
 
     stream.clear_audio_queue()
@@ -90,7 +97,7 @@ async def test_play_loop_feeds_head_wobbler_with_local_playback_delay() -> None:
     )
     media = SimpleNamespace(
         audio=audio,
-        backend=MediaBackend.LOCAL,
+        backend=LOCAL_TEST_BACKEND,
         get_output_audio_samplerate=lambda: 24000,
         push_audio_sample=MagicMock(),
     )
@@ -210,6 +217,44 @@ def test_backend_config_preserves_explicit_model_override_when_saving_key(
     assert "OPENAI_API_KEY=openai-test-key" in env_text
 
 
+def test_backend_config_persists_s2s_selection_without_credentials(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Settings API should allow switching to speech-to-speech without an API key."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "openai")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+    monkeypatch.setattr(config, "OPENAI_API_KEY", None)
+    monkeypatch.setattr(config, "GEMINI_API_KEY", None)
+    monkeypatch.setattr(config, "S2S_REALTIME_SESSION_URL", "https://lb.example.test/session")
+    monkeypatch.setenv("BACKEND_PROVIDER", "openai")
+    monkeypatch.setenv("MODEL_NAME", "gpt-realtime")
+    monkeypatch.setenv("S2S_REALTIME_SESSION_URL", "https://lb.example.test/session")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    app = FastAPI()
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    stream = LocalStream(MagicMock(), robot, settings_app=app, instance_path=str(tmp_path))
+    stream._init_settings_ui_if_needed()
+
+    client = TestClient(app)
+    response = client.post("/backend_config", json={"backend": "speech-to-speech"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["backend_provider"] == "speech-to-speech"
+    assert data["active_backend"] == "openai"
+    assert data["has_s2s_session_url"] is True
+    assert data["can_proceed_with_speech_to_speech"] is True
+    assert data["requires_restart"] is True
+
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "BACKEND_PROVIDER=speech-to-speech" in env_text
+    assert "MODEL_NAME=gpt-realtime" in env_text
+
+
 def test_headless_personality_routes_return_gemini_voices_when_backend_selected(monkeypatch) -> None:
     """Headless personality UI should expose Gemini voices when Gemini is selected."""
     monkeypatch.setattr(config, "BACKEND_PROVIDER", "gemini")
@@ -224,6 +269,22 @@ def test_headless_personality_routes_return_gemini_voices_when_backend_selected(
 
     assert response.status_code == 200
     assert response.json() == GEMINI_AVAILABLE_VOICES
+
+
+def test_headless_personality_routes_return_s2s_voices_when_backend_selected(monkeypatch) -> None:
+    """Headless personality UI should expose S2S voices when speech-to-speech is selected."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "speech-to-speech")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+
+    app = FastAPI()
+    handler = MagicMock()
+    mount_personality_routes(app, handler, lambda: None)
+
+    client = TestClient(app)
+    response = client.get("/voices")
+
+    assert response.status_code == 200
+    assert response.json() == S2S_AVAILABLE_VOICES
 
 
 def test_headless_personality_routes_apply_voice_accepts_query_param() -> None:

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -11,6 +11,7 @@ import pytest
 
 import reachy_mini_conversation_app.openai_realtime as rt_mod
 import reachy_mini_conversation_app.tools.background_tool_manager as btm_mod
+from reachy_mini_conversation_app.config import config
 from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler, _compute_response_cost
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.tools.background_tool_manager import ToolCallRoutine
@@ -851,3 +852,186 @@ async def test_response_sender_loop_times_out_waiting_for_previous_response(
     assert len(timeout_logs) == 1, (
         f"Expected 1 pre-condition timeout warning, got {len(timeout_logs)}"
     )
+
+
+@pytest.mark.asyncio
+async def test_start_up_s2s_gradio_does_not_wait_for_api_key(monkeypatch: Any) -> None:
+    """Speech-to-speech startup should skip the Gradio API-key textbox flow."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "speech-to-speech")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+    monkeypatch.setattr(config, "OPENAI_API_KEY", None)
+
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = rt_mod.OpenaiRealtimeHandler(deps, gradio_mode=True)
+
+    build_client = AsyncMock(return_value=MagicMock())
+    run_realtime_session = AsyncMock(return_value=None)
+    wait_for_args = AsyncMock(side_effect=AssertionError("wait_for_args should not be called"))
+
+    object.__setattr__(handler, "_build_realtime_client", build_client)
+    object.__setattr__(handler, "_run_realtime_session", run_realtime_session)
+    object.__setattr__(handler, "wait_for_args", wait_for_args)
+
+    await handler.start_up()
+
+    wait_for_args.assert_not_awaited()
+    build_client.assert_awaited_once_with(api_key=None)
+    run_realtime_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_realtime_session_omits_s2s_voice_when_unset(monkeypatch: Any) -> None:
+    """S2S sessions should omit voice when no profile voice is configured."""
+    monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
+    monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=None: default)
+    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda: [])
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "speech-to-speech")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+    monkeypatch.setattr(config, "S2S_REALTIME_SESSION_URL", "https://lb.example.test/session")
+
+    captured_update: dict[str, Any] = {}
+
+    class FakeSession:
+        async def update(self, **kwargs: Any) -> None:
+            captured_update.update(kwargs)
+
+    class FakeInputAudioBuffer:
+        async def append(self, **_kw: Any) -> None:
+            pass
+
+    class FakeItem:
+        async def create(self, **_kw: Any) -> None:
+            pass
+
+    class FakeConversation:
+        item = FakeItem()
+
+    class FakeResponse:
+        async def create(self, **_kw: Any) -> None:
+            pass
+
+        async def cancel(self, **_kw: Any) -> None:
+            pass
+
+    class FakeConn:
+        session = FakeSession()
+        input_audio_buffer = FakeInputAudioBuffer()
+        conversation = FakeConversation()
+        response = FakeResponse()
+
+        async def __aenter__(self) -> "FakeConn":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+        def __aiter__(self) -> "FakeConn":
+            return self
+
+        async def __anext__(self) -> Any:
+            raise StopAsyncIteration
+
+    class FakeRealtime:
+        def connect(self, **_kw: Any) -> FakeConn:
+            return FakeConn()
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.realtime = FakeRealtime()
+
+    handler = OpenaiRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+    handler.client = FakeClient()
+
+    await handler._run_realtime_session()
+
+    session = captured_update["session"]
+    assert session["audio"]["input"]["format"]["rate"] is None
+    assert session["audio"]["output"]["format"]["rate"] is None
+    assert "voice" not in session["audio"]["output"]
+
+
+@pytest.mark.asyncio
+async def test_run_realtime_session_passes_allocated_session_query(monkeypatch: Any) -> None:
+    """S2S sessions must forward the allocated session token when connecting."""
+    monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
+    monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=None: "Aiden")
+    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda: [])
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "speech-to-speech")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+
+    captured_connect: dict[str, Any] = {}
+
+    class FakeSession:
+        async def update(self, **_kw: Any) -> None:
+            pass
+
+    class FakeInputAudioBuffer:
+        async def append(self, **_kw: Any) -> None:
+            pass
+
+    class FakeItem:
+        async def create(self, **_kw: Any) -> None:
+            pass
+
+    class FakeConversation:
+        item = FakeItem()
+
+    class FakeResponse:
+        async def create(self, **_kw: Any) -> None:
+            pass
+
+        async def cancel(self, **_kw: Any) -> None:
+            pass
+
+    class FakeConn:
+        session = FakeSession()
+        input_audio_buffer = FakeInputAudioBuffer()
+        conversation = FakeConversation()
+        response = FakeResponse()
+
+        async def __aenter__(self) -> "FakeConn":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+        def __aiter__(self) -> "FakeConn":
+            return self
+
+        async def __anext__(self) -> Any:
+            raise StopAsyncIteration
+
+    class FakeRealtime:
+        def connect(self, **kwargs: Any) -> FakeConn:
+            captured_connect.update(kwargs)
+            return FakeConn()
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.realtime = FakeRealtime()
+
+    handler = OpenaiRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+    handler.client = FakeClient()
+    handler._realtime_connect_query = {"session_token": "abc123"}
+
+    await handler._run_realtime_session()
+
+    assert captured_connect["extra_query"] == {"session_token": "abc123"}
+
+
+@pytest.mark.asyncio
+async def test_handler_uses_s2s_sample_rate_for_s2s_backend(monkeypatch: Any) -> None:
+    """S2S should keep the 16 kHz local streaming configuration."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "speech-to-speech")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+
+    handler = OpenaiRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+
+    assert handler.input_sample_rate == 16000
+    assert handler.output_sample_rate == 16000

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -1,6 +1,7 @@
 import shutil
 import zipfile
 import subprocess
+import os
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -87,6 +88,15 @@ def test_session_voice_defaults_follow_selected_backend(monkeypatch: pytest.Monk
     assert prompts_mod.get_session_voice() == "Kore"
 
 
+def test_session_voice_defaults_follow_s2s_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """S2S should fall back to its curated backend default voice."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "speech-to-speech")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
+    assert prompts_mod.get_session_voice() == "Aiden"
+
+
 def test_packaged_profiles_win_outside_source_checkout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -132,12 +142,15 @@ def test_wheel_file_paths_stay_within_windows_budget(tmp_path: Path) -> None:
         shutil.copy2(source_file, target_file)
 
     try:
+        env = os.environ.copy()
+        env["UV_CACHE_DIR"] = str(tmp_path / "uv-cache")
         subprocess.run(
-            ["uv", "build", "--wheel", "--out-dir", str(dist_dir)],
+            ["uv", "build", "--wheel", "--out-dir", str(dist_dir), "--no-build-isolation", "--offline"],
             cwd=source_checkout,
             check=True,
             capture_output=True,
             text=True,
+            env=env,
         )
     except (OSError, subprocess.CalledProcessError) as exc:
         details = exc.stderr if isinstance(exc, subprocess.CalledProcessError) and exc.stderr else str(exc)


### PR DESCRIPTION
## Summary
- rebases and reshapes the speech-to-speech backend work from #279 on top of current `main`
- integrates speech-to-speech as a third backend alongside OpenAI and Gemini instead of reverting the newer backend architecture on `main`
- keeps the speech-to-speech-specific behavior: session allocation, curated voices/defaults, 16 kHz handling, and backend-aware startup/settings behavior
- updates docs and examples, and adds regression coverage for the rebased path

## Why
- #279 was opened against an older `main`
- `main` now includes a generalized multi-backend setup with a separate Gemini handler and shared backend selection flow
- this PR refreshes that work in a non-destructive way without overwriting or force-pushing the original PR branch

## Validation
- `pytest -q tests/test_openai_realtime.py tests/test_console.py tests/test_profile_paths.py`
