### PR TITLE
Fix built-in default profile tools display

### DIFF
--- a/src/reachy_mini_conversation_app/gradio_personality.py
+++ b/src/reachy_mini_conversation_app/gradio_personality.py
@@ -79,6 +79,44 @@ class PersonalityUI:
         except Exception as e:
             return f"Could not load instructions: {e}"
 
+    def _read_tools_for(self, name: str) -> str:
+        try:
+            profile_name = "default" if name == self.DEFAULT_OPTION else name
+            target = self._resolve_profile_dir(profile_name) / "tools.txt"
+            if target.exists():
+                return target.read_text(encoding="utf-8")
+        except Exception:
+            pass
+        return ""
+
+    def _available_tools_for(self, selected: str) -> tuple[list[str], list[str]]:
+        shared: list[str] = []
+        try:
+            for py in self._tools_dir.glob("*.py"):
+                if py.stem in {"__init__", "core_tools"}:
+                    continue
+                shared.append(py.stem)
+        except Exception:
+            pass
+        local: list[str] = []
+        try:
+            if selected != self.DEFAULT_OPTION:
+                for py in (self._profiles_root / selected).glob("*.py"):
+                    local.append(py.stem)
+        except Exception:
+            pass
+        return sorted(shared), sorted(local)
+
+    @staticmethod
+    def _parse_enabled_tools(text: str) -> list[str]:
+        enabled: list[str] = []
+        for line in text.splitlines():
+            s = line.strip()
+            if not s or s.startswith("#"):
+                continue
+            enabled.append(s)
+        return enabled
+
     @staticmethod
     def _sanitize_name(name: str) -> str:
         import re
@@ -101,6 +139,10 @@ class PersonalityUI:
             current_value = config.REACHY_MINI_CUSTOM_PROFILE or self.DEFAULT_OPTION
             dropdown_label = "Select personality"
             dropdown_choices = [self.DEFAULT_OPTION, *(self._list_personalities())]
+        initial_tools_txt = self._read_tools_for(current_value)
+        shared_tools, local_tools = self._available_tools_for(current_value)
+        initial_available_tools = sorted(set(shared_tools + local_tools))
+        initial_enabled_tools = self._parse_enabled_tools(initial_tools_txt)
 
         self.personalities_dropdown = gr.Dropdown(
             label=dropdown_label,
@@ -113,7 +155,12 @@ class PersonalityUI:
         self.preview_md = gr.Markdown(value=self._read_instructions_for(current_value))
         self.person_name_tb = gr.Textbox(label="Personality name", interactive=not is_locked)
         self.person_instr_ta = gr.TextArea(label="Personality instructions", lines=10, interactive=not is_locked)
-        self.tools_txt_ta = gr.TextArea(label="tools.txt", lines=10, interactive=not is_locked)
+        self.tools_txt_ta = gr.TextArea(
+            label="tools.txt",
+            value=initial_tools_txt,
+            lines=10,
+            interactive=not is_locked,
+        )
         self.voice_dropdown = gr.Dropdown(
             label="Voice",
             choices=get_available_voices_for_backend(),
@@ -122,7 +169,10 @@ class PersonalityUI:
         )
         self.new_personality_btn = gr.Button("New personality", interactive=not is_locked)
         self.available_tools_cg = gr.CheckboxGroup(
-            label="Available tools (helper)", choices=[], value=[], interactive=not is_locked
+            label="Available tools (helper)",
+            choices=initial_available_tools,
+            value=initial_enabled_tools,
+            interactive=not is_locked,
         )
         self.save_btn = gr.Button("Save personality (instructions + tools)", interactive=not is_locked)
 
@@ -183,43 +233,12 @@ class PersonalityUI:
                     value=get_default_voice_for_backend(),
                 )
 
-        def _available_tools_for(selected: str) -> tuple[list[str], list[str]]:
-            shared: list[str] = []
-            try:
-                for py in self._tools_dir.glob("*.py"):
-                    if py.stem in {"__init__", "core_tools"}:
-                        continue
-                    shared.append(py.stem)
-            except Exception:
-                pass
-            local: list[str] = []
-            try:
-                if selected != self.DEFAULT_OPTION:
-                    for py in (self._profiles_root / selected).glob("*.py"):
-                        local.append(py.stem)
-            except Exception:
-                pass
-            return sorted(shared), sorted(local)
-
-        def _parse_enabled_tools(text: str) -> list[str]:
-            enabled: list[str] = []
-            for line in text.splitlines():
-                s = line.strip()
-                if not s or s.startswith("#"):
-                    continue
-                enabled.append(s)
-            return enabled
-
         def _load_profile_for_edit(selected: str) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], str]:
             instr = self._read_instructions_for(selected)
-            tools_txt = ""
-            if selected != self.DEFAULT_OPTION:
-                tp = self._resolve_profile_dir(selected) / "tools.txt"
-                if tp.exists():
-                    tools_txt = tp.read_text(encoding="utf-8")
-            shared, local = _available_tools_for(selected)
+            tools_txt = self._read_tools_for(selected)
+            shared, local = self._available_tools_for(selected)
             all_tools = sorted(set(shared + local))
-            enabled = _parse_enabled_tools(tools_txt)
+            enabled = self._parse_enabled_tools(tools_txt)
             status_text = f"Loaded profile '{selected}'."
             return (
                 gr.update(value=instr),
@@ -239,7 +258,7 @@ class PersonalityUI:
                     gr.update(value=""),
                     gr.update(value=instr_val),
                     gr.update(value=tools_txt_val),
-                    gr.update(choices=sorted(_available_tools_for(self.DEFAULT_OPTION)[0]), value=[]),
+                    gr.update(choices=sorted(self._available_tools_for(self.DEFAULT_OPTION)[0]), value=[]),
                     "Fill in a name, instructions and (optional) tools, then Save.",
                     gr.update(value=get_default_voice_for_backend()),
                 )

--- a/src/reachy_mini_conversation_app/headless_personality.py
+++ b/src/reachy_mini_conversation_app/headless_personality.py
@@ -76,6 +76,16 @@ def read_instructions_for(name: str) -> str:
         return f"Could not load instructions: {e}"
 
 
+def read_tools_for(name: str) -> str:
+    """Read the tools.txt content for the given profile name."""
+    try:
+        profile_name = "default" if name == DEFAULT_OPTION else name
+        target = resolve_profile_dir(profile_name) / "tools.txt"
+        return target.read_text(encoding="utf-8") if target.exists() else ""
+    except Exception:
+        return ""
+
+
 def available_tools_for(selected: str) -> List[str]:
     """List available tool modules for the given profile selection."""
     shared: List[str] = []

--- a/src/reachy_mini_conversation_app/headless_personality_ui.py
+++ b/src/reachy_mini_conversation_app/headless_personality_ui.py
@@ -30,6 +30,7 @@ from .headless_personality import (
     _write_profile,
     list_personalities,
     available_tools_for,
+    read_tools_for,
     resolve_profile_dir,
     read_instructions_for,
 )
@@ -92,14 +93,11 @@ def mount_personality_routes(
     @app.get("/personalities/load")
     def _load(name: str) -> dict:  # type: ignore
         instr = read_instructions_for(name)
-        tools_txt = ""
+        tools_txt = read_tools_for(name)
         voice = get_default_voice_for_backend()
         uses_default_voice = True
         if name != DEFAULT_OPTION:
             pdir = resolve_profile_dir(name)
-            tp = pdir / "tools.txt"
-            if tp.exists():
-                tools_txt = tp.read_text(encoding="utf-8")
             vf = pdir / "voice.txt"
             if vf.exists():
                 v = vf.read_text(encoding="utf-8").strip()

--- a/src/reachy_mini_conversation_app/headless_personality_ui.py
+++ b/src/reachy_mini_conversation_app/headless_personality_ui.py
@@ -28,9 +28,9 @@ from .headless_personality import (
     DEFAULT_OPTION,
     _sanitize_name,
     _write_profile,
+    read_tools_for,
     list_personalities,
     available_tools_for,
-    read_tools_for,
     resolve_profile_dir,
     read_instructions_for,
 )

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -227,6 +227,22 @@ def test_headless_personality_routes_return_gemini_voices_when_backend_selected(
     assert response.json() == GEMINI_AVAILABLE_VOICES
 
 
+def test_headless_personality_routes_load_builtin_default_tools() -> None:
+    """Headless personality UI should expose built-in default tools on initial load."""
+    app = FastAPI()
+    handler = MagicMock()
+    mount_personality_routes(app, handler, lambda: None)
+
+    client = TestClient(app)
+    response = client.get("/personalities/load", params={"name": "(built-in default)"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tools_text"]
+    assert "dance" in data["enabled_tools"]
+    assert "camera" in data["enabled_tools"]
+
+
 def test_headless_personality_routes_apply_voice_accepts_query_param() -> None:
     """Headless personality UI should apply a voice change from a POST query param."""
     app = FastAPI()

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -91,8 +91,10 @@ def test_builtin_default_profile_tools_load_for_ui() -> None:
     assert read_tools_for(DEFAULT_OPTION) == expected
 
 
-def test_gradio_personality_ui_prefills_builtin_default_tools() -> None:
+def test_gradio_personality_ui_prefills_builtin_default_tools(monkeypatch: pytest.MonkeyPatch) -> None:
     """Gradio should show the built-in default profile tools on first render."""
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
     ui = PersonalityUI()
     ui.create_components()
 

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -8,7 +8,10 @@ import pytest
 import reachy_mini_conversation_app.config as config_mod
 import reachy_mini_conversation_app.prompts as prompts_mod
 from reachy_mini_conversation_app.config import DEFAULT_PROFILES_DIRECTORY, config
+from reachy_mini_conversation_app.gradio_personality import PersonalityUI
 from reachy_mini_conversation_app.headless_personality import (
+    DEFAULT_OPTION,
+    read_tools_for,
     resolve_profile_dir,
     read_instructions_for,
 )
@@ -79,6 +82,27 @@ def test_prompts_load_from_compact_builtin_profile(monkeypatch: pytest.MonkeyPat
 
     assert prompts_mod.get_session_instructions() == expected
     assert read_instructions_for("mad_scientist_assistant") == expected
+
+
+def test_builtin_default_profile_tools_load_for_ui() -> None:
+    """The UI should read built-in default tools from the packaged default profile."""
+    expected = (DEFAULT_PROFILES_DIRECTORY / "default" / "tools.txt").read_text(encoding="utf-8")
+
+    assert read_tools_for(DEFAULT_OPTION) == expected
+
+
+def test_gradio_personality_ui_prefills_builtin_default_tools() -> None:
+    """Gradio should show the built-in default profile tools on first render."""
+    ui = PersonalityUI()
+    ui.create_components()
+
+    expected_tools = read_tools_for(ui.DEFAULT_OPTION)
+    expected_enabled = [
+        line.strip() for line in expected_tools.splitlines() if line.strip() and not line.strip().startswith("#")
+    ]
+
+    assert ui.tools_txt_ta.value == expected_tools
+    assert sorted(ui.available_tools_cg.value) == sorted(expected_enabled)
 
 
 def test_session_voice_defaults_follow_selected_backend(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Fix the profile editors so the built-in default profile shows its enabled tools instead of rendering an empty tools list.

## Root Cause
The UI used a special sentinel value, `(built-in default)`, for the built-in default profile. The runtime already mapped that selection to `profiles/default/tools.txt`, but the Gradio editor and the headless settings API skipped reading `tools.txt` for that sentinel and returned an empty value.

## What Changed
- Added shared/default-aware `tools.txt` loading for the built-in default profile.
- Prefilled the Gradio tools textarea and checkbox list on first render using the selected startup profile.
- Updated the headless personality load endpoint to return the built-in default profile tools.
- Added regressions for the built-in default profile in both UI paths.

## Impact
Starting the app with `(built-in default)` now shows the same enabled tools in the UI that the backend already loads at runtime.

## Validation
- `pytest -q tests/test_profile_paths.py::test_builtin_default_profile_tools_load_for_ui tests/test_profile_paths.py::test_gradio_personality_ui_prefills_builtin_default_tools tests/test_console.py::test_headless_personality_routes_load_builtin_default_tools`

Closes #303
