### PR TITLE
Harden flaky yolo timeout-drain test

### DIFF
--- a/tests/vision/test_yolo_process.py
+++ b/tests/vision/test_yolo_process.py
@@ -124,6 +124,10 @@ def test_head_tracker_skips_new_frame_until_timed_out_reply_is_drained(
         assert blocked_elapsed < 0.05
 
         time.sleep(0.15)
+        # The behavior under test is that once the delayed reply is drained, the
+        # next request succeeds. Give that recovery request a less scheduler-
+        # sensitive timeout so macOS/Windows process wakeups do not flap the test.
+        tracker.request_timeout = 0.2
         eye_center, roll = tracker.get_head_position(frame)
         assert eye_center is not None
         assert np.allclose(eye_center, np.array([2.0, 2.0], dtype=np.float32))


### PR DESCRIPTION
## Summary
Harden the flaky `yolo_process` timeout-drain test so it no longer depends on a 10ms scheduler/process turnaround during the recovery request.

## Root Cause
The test intentionally uses `request_timeout=0.01` to force the first request to time out. That part is correct.

The flake was in the final recovery assertion: after waiting for the delayed reply to become drainable, the test still reused the same 10ms timeout for the next request. On slower macOS and Windows runners, that left too little time for the child process to wake up, receive the new frame, and respond, even though the timeout-drain logic itself was working.

## What Changed
- Kept the initial 10ms timeout to verify the first request times out.
- Kept the assertion that the next call returns quickly while the delayed reply is still pending.
- Relaxed only the final recovery request timeout in `tests/vision/test_yolo_process.py` so the test checks the intended behavior without flapping on platform scheduling differences.

## Impact
This keeps coverage for the timeout-drain behavior while removing the platform-sensitive timing assumption that was causing intermittent macOS/Windows failures.

## Validation
- `ruff check tests/vision/test_yolo_process.py`
- `ruff format --check tests/vision/test_yolo_process.py`
- `uv run pytest -q tests/vision/test_yolo_process.py`
- 100 repeated runs of `uv run pytest -q tests/vision/test_yolo_process.py::test_head_tracker_skips_new_frame_until_timed_out_reply_is_drained`

Closes #306
