### PR TITLE
Fix duplicated tool-loading logs

### DIFF
--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -27,14 +27,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-if not logger.handlers:
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s:%(lineno)d | %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
-
-
 ALL_TOOLS: Dict[str, "Tool"] = {}
 ALL_TOOL_SPECS: List[Dict[str, Any]] = []
 _TOOLS_INITIALIZED = False


### PR DESCRIPTION
## Summary
Fix duplicated tool-loading log lines in `core_tools`.

## Root cause
`reachy_mini_conversation_app.tools.core_tools` attached its own `StreamHandler` while the app also configures the root logger in `setup_logger()`. Because the module logger still propagated to root, each `core_tools` log record was emitted twice.

## Change
Remove the module-local handler setup from `core_tools.py` so it inherits the app-wide logging configuration instead.

## Impact
Tool loading and registration logs now appear once on `main`, matching the rest of the application logging.

Fixes #308

## Validation
- `uv run ruff check src/reachy_mini_conversation_app/tools/core_tools.py`
