### PR TITLE
Make startup settings authoritative

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,6 @@ HF_HOME=./cache
 # Hugging Face token for accessing datasets/models
 HF_TOKEN=
 
-# Profile selection (defaults to "default" when unset)
-# REACHY_MINI_CUSTOM_PROFILE=
-
 # Optional external profile/tool directories
 # REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY=external_content/external_profiles
 # REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY=external_content/external_tools

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ HF_HOME=./cache
 HF_TOKEN=
 
 # Profile selection (defaults to "default" when unset)
-REACHY_MINI_CUSTOM_PROFILE="example"
+# REACHY_MINI_CUSTOM_PROFILE=
 
 # Optional external profile/tool directories
 # REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY=external_content/external_profiles

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ Built-in motion content is published as open Hugging Face datasets:
 
 Create custom profiles with dedicated instructions and enabled tools.
 
-Set `REACHY_MINI_CUSTOM_PROFILE=<name>` to load `profiles/<name>/` (see `.env.example`). If unset, the `default` profile is used.
+For normal usage, select a profile from the UI and save it for startup. That selection is persisted in `startup_settings.json`.
+
+If no startup settings have been saved yet, you can still seed startup from the environment with `REACHY_MINI_CUSTOM_PROFILE=<name>` to load `profiles/<name>/`. If neither is set, the `default` profile is used.
 
 Each profile should include `instructions.txt` (prompt text). `tools.txt` (list of allowed tools) is recommended. If missing for a non-default profile, the app falls back to `profiles/default/tools.txt`. Profiles can optionally contain custom tool implementations.
 
@@ -266,7 +268,7 @@ To create a locked variant of the app that cannot switch profiles, edit `src/rea
 ```python
 LOCKED_PROFILE: str | None = "mars_rover"  # Lock to this profile
 ```
-When `LOCKED_PROFILE` is set, the app always uses that profile, ignoring `REACHY_MINI_CUSTOM_PROFILE` env var & the Gradio UI shows "(locked)" and disables all profile editing controls.
+When `LOCKED_PROFILE` is set, the app always uses that profile, ignoring saved startup settings, `REACHY_MINI_CUSTOM_PROFILE`, and the Gradio UI. The UI shows "(locked)" and disables all profile editing controls.
 This is useful for creating dedicated clones of the app with a fixed personality. Clone scripts can simply edit this constant to lock the variant.
 
 </details>
@@ -294,9 +296,10 @@ external_content/
 
 **Environment variables:**
 
-Set these values in your `.env` (copy from `.env.example`):
+Set these values in your `.env` when you want env-driven external profile/tool selection:
 
 ```env
+# Optional fallback/manual profile selector:
 REACHY_MINI_CUSTOM_PROFILE=my_profile
 REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY=./external_content/external_profiles
 REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY=./external_content/external_tools

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -59,6 +59,11 @@ except Exception:  # pragma: no cover - only loaded when settings_app is used
 
 logger = logging.getLogger(__name__)
 
+LEGACY_STARTUP_ENV_NAMES = (
+    "REACHY_MINI_CUSTOM_PROFILE",
+    "REACHY_MINI_VOICE_OVERRIDE",
+)
+
 
 def _estimate_pending_playback_seconds(robot: ReachyMini) -> float:
     """Best-effort estimate of audio still queued in the local player."""
@@ -205,6 +210,34 @@ class LocalStream:
         except Exception as e:
             logger.warning("Failed to persist %s: %s", ", ".join(sorted(normalized_updates)), e)
 
+    def _remove_persisted_env_values(self, env_names: tuple[str, ...]) -> None:
+        """Remove keys from the instance `.env` without mutating the current runtime."""
+        normalized_names = tuple(sorted({name.strip() for name in env_names if name and name.strip()}))
+        if not normalized_names or not self._instance_path:
+            return
+
+        env_path = Path(self._instance_path) / ".env"
+        if not env_path.exists():
+            return
+
+        try:
+            lines = env_path.read_text(encoding="utf-8").splitlines()
+            filtered_lines = [
+                line
+                for line in lines
+                if not any(line.strip().startswith(f"{env_name}=") for env_name in normalized_names)
+            ]
+            if filtered_lines == lines:
+                return
+
+            final_text = "\n".join(filtered_lines)
+            if final_text:
+                final_text += "\n"
+            env_path.write_text(final_text, encoding="utf-8")
+            logger.info("Removed %s from %s", ", ".join(normalized_names), env_path)
+        except Exception as e:
+            logger.warning("Failed to remove %s: %s", ", ".join(normalized_names), e)
+
     def _persist_api_key(self, key: str) -> None:
         """Persist OPENAI_API_KEY to environment and instance `.env`."""
         self._persist_env_value("OPENAI_API_KEY", key)
@@ -245,6 +278,7 @@ class LocalStream:
                 profile=selection,
                 voice=normalized_voice_override,
             )
+            self._remove_persisted_env_values(LEGACY_STARTUP_ENV_NAMES)
             logger.info("Persisted startup personality settings to %s", Path(self._instance_path))
         except Exception as e:
             logger.warning("Failed to persist startup personality settings: %s", e)

--- a/src/reachy_mini_conversation_app/startup_settings.py
+++ b/src/reachy_mini_conversation_app/startup_settings.py
@@ -7,8 +7,6 @@ import logging
 from pathlib import Path
 from dataclasses import dataclass
 
-from dotenv import dotenv_values
-
 
 logger = logging.getLogger(__name__)
 
@@ -36,24 +34,6 @@ def _startup_settings_path(instance_path: str | Path | None) -> Path | None:
     if instance_path is None:
         return None
     return Path(instance_path) / STARTUP_SETTINGS_FILENAME
-
-
-def _read_instance_env_override(instance_path: str | Path | None, env_name: str) -> str | None:
-    """Return an instance-local env override value when it is explicitly set."""
-    if instance_path is None:
-        return None
-
-    env_path = Path(instance_path) / ".env"
-    if not env_path.exists():
-        return None
-
-    try:
-        payload = dotenv_values(env_path)
-    except Exception as exc:
-        logger.warning("Failed to read startup env override from %s: %s", env_path, exc)
-        return None
-
-    return _normalize_optional_text(payload.get(env_name))
 
 
 def read_startup_settings(instance_path: str | Path | None) -> StartupSettings:
@@ -118,8 +98,6 @@ def load_startup_settings_into_runtime(instance_path: str | Path | None) -> Star
 
     settings_path = _startup_settings_path(instance_path)
     settings = read_startup_settings(instance_path)
-    if _read_instance_env_override(instance_path, "REACHY_MINI_CUSTOM_PROFILE") is not None:
-        return StartupSettings(voice=settings.voice)
     if settings_path is None or not settings_path.exists():
         if os.getenv("REACHY_MINI_CUSTOM_PROFILE"):
             return StartupSettings(voice=settings.voice)

--- a/src/reachy_mini_conversation_app/startup_settings.py
+++ b/src/reachy_mini_conversation_app/startup_settings.py
@@ -7,6 +7,8 @@ import logging
 from pathlib import Path
 from dataclasses import dataclass
 
+from dotenv import dotenv_values
+
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,24 @@ def _startup_settings_path(instance_path: str | Path | None) -> Path | None:
     if instance_path is None:
         return None
     return Path(instance_path) / STARTUP_SETTINGS_FILENAME
+
+
+def _read_instance_env_override(instance_path: str | Path | None, env_name: str) -> str | None:
+    """Return an instance-local env override value when it is explicitly set."""
+    if instance_path is None:
+        return None
+
+    env_path = Path(instance_path) / ".env"
+    if not env_path.exists():
+        return None
+
+    try:
+        payload = dotenv_values(env_path)
+    except Exception as exc:
+        logger.warning("Failed to read startup env override from %s: %s", env_path, exc)
+        return None
+
+    return _normalize_optional_text(payload.get(env_name))
 
 
 def read_startup_settings(instance_path: str | Path | None) -> StartupSettings:
@@ -96,9 +116,13 @@ def load_startup_settings_into_runtime(instance_path: str | Path | None) -> Star
     if LOCKED_PROFILE is not None:
         return StartupSettings()
 
+    settings_path = _startup_settings_path(instance_path)
     settings = read_startup_settings(instance_path)
-    if os.getenv("REACHY_MINI_CUSTOM_PROFILE"):
+    if _read_instance_env_override(instance_path, "REACHY_MINI_CUSTOM_PROFILE") is not None:
         return StartupSettings(voice=settings.voice)
+    if settings_path is None or not settings_path.exists():
+        if os.getenv("REACHY_MINI_CUSTOM_PROFILE"):
+            return StartupSettings(voice=settings.voice)
 
     set_custom_profile(settings.profile)
     return settings

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -13,6 +13,10 @@ from fastapi.testclient import TestClient
 from reachy_mini.media.media_manager import MediaBackend
 from reachy_mini_conversation_app.config import GEMINI_AVAILABLE_VOICES, config
 from reachy_mini_conversation_app.console import LocalStream
+from reachy_mini_conversation_app.startup_settings import (
+    StartupSettings,
+    load_startup_settings_into_runtime,
+)
 from reachy_mini_conversation_app.headless_personality_ui import mount_personality_routes
 
 
@@ -322,3 +326,34 @@ def test_local_stream_persist_personality_stores_voice_override(tmp_path) -> Non
     assert settings_path.exists()
     assert settings_path.read_text(encoding="utf-8") == '{\n  "profile": "sorry_bro",\n  "voice": "shimmer"\n}\n'
     assert stream._read_persisted_personality() == "sorry_bro"
+
+
+def test_local_stream_persist_personality_clears_legacy_startup_env_overrides(tmp_path, monkeypatch) -> None:
+    """Saving startup settings should remove legacy `.env` profile and voice overrides."""
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "OPENAI_API_KEY=test-key\n"
+        "REACHY_MINI_CUSTOM_PROFILE=mad_scientist_assistant\n"
+        "REACHY_MINI_VOICE_OVERRIDE=shimmer\n",
+        encoding="utf-8",
+    )
+    stream = LocalStream(MagicMock(), MagicMock(), instance_path=str(tmp_path))
+
+    stream._persist_personality(None, "Aiden")
+
+    env_text = env_path.read_text(encoding="utf-8")
+    assert "OPENAI_API_KEY=test-key" in env_text
+    assert "REACHY_MINI_CUSTOM_PROFILE=" not in env_text
+    assert "REACHY_MINI_VOICE_OVERRIDE=" not in env_text
+
+    applied_profiles: list[str | None] = []
+    monkeypatch.delenv("REACHY_MINI_CUSTOM_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.config.set_custom_profile",
+        lambda profile: applied_profiles.append(profile),
+    )
+
+    settings = load_startup_settings_into_runtime(tmp_path)
+
+    assert settings == StartupSettings(voice="Aiden")
+    assert applied_profiles == [None]

--- a/tests/test_startup_settings.py
+++ b/tests/test_startup_settings.py
@@ -31,11 +31,11 @@ def test_load_startup_settings_into_runtime_applies_profile_when_no_env(monkeypa
     assert applied_profiles == ["sorry_bro"]
 
 
-def test_load_startup_settings_into_runtime_ignores_explicit_instance_profile_env(monkeypatch, tmp_path) -> None:
-    """An instance-local profile env config should win for profile selection only."""
+def test_load_startup_settings_into_runtime_saved_settings_override_instance_env(monkeypatch, tmp_path) -> None:
+    """Saved startup settings should override an instance-local profile env value."""
     write_startup_settings(tmp_path, profile="sorry_bro", voice="shimmer")
-    (tmp_path / ".env").write_text('REACHY_MINI_CUSTOM_PROFILE="env_profile"\n', encoding="utf-8")
     applied_profiles: list[str | None] = []
+    monkeypatch.setenv("REACHY_MINI_CUSTOM_PROFILE", "env_profile")
     monkeypatch.setattr(
         "reachy_mini_conversation_app.config.set_custom_profile",
         lambda profile: applied_profiles.append(profile),
@@ -43,8 +43,8 @@ def test_load_startup_settings_into_runtime_ignores_explicit_instance_profile_en
 
     settings = load_startup_settings_into_runtime(tmp_path)
 
-    assert settings == StartupSettings(voice="shimmer")
-    assert applied_profiles == []
+    assert settings == StartupSettings(profile="sorry_bro", voice="shimmer")
+    assert applied_profiles == ["sorry_bro"]
 
 
 def test_load_startup_settings_into_runtime_saved_settings_override_inherited_env(monkeypatch, tmp_path) -> None:

--- a/tests/test_startup_settings.py
+++ b/tests/test_startup_settings.py
@@ -31,11 +31,11 @@ def test_load_startup_settings_into_runtime_applies_profile_when_no_env(monkeypa
     assert applied_profiles == ["sorry_bro"]
 
 
-def test_load_startup_settings_into_runtime_ignores_explicit_profile_env(monkeypatch, tmp_path) -> None:
-    """Explicit profile env config should win for profile selection only."""
+def test_load_startup_settings_into_runtime_ignores_explicit_instance_profile_env(monkeypatch, tmp_path) -> None:
+    """An instance-local profile env config should win for profile selection only."""
     write_startup_settings(tmp_path, profile="sorry_bro", voice="shimmer")
+    (tmp_path / ".env").write_text('REACHY_MINI_CUSTOM_PROFILE="env_profile"\n', encoding="utf-8")
     applied_profiles: list[str | None] = []
-    monkeypatch.setenv("REACHY_MINI_CUSTOM_PROFILE", "env_profile")
     monkeypatch.setattr(
         "reachy_mini_conversation_app.config.set_custom_profile",
         lambda profile: applied_profiles.append(profile),
@@ -44,4 +44,37 @@ def test_load_startup_settings_into_runtime_ignores_explicit_profile_env(monkeyp
     settings = load_startup_settings_into_runtime(tmp_path)
 
     assert settings == StartupSettings(voice="shimmer")
+    assert applied_profiles == []
+
+
+def test_load_startup_settings_into_runtime_saved_settings_override_inherited_env(monkeypatch, tmp_path) -> None:
+    """Saved startup settings should override a profile inherited from another `.env`."""
+    write_startup_settings(tmp_path, profile="nature_documentarian", voice="cedar")
+    applied_profiles: list[str | None] = []
+    monkeypatch.setenv("REACHY_MINI_CUSTOM_PROFILE", "example")
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.config.set_custom_profile",
+        lambda profile: applied_profiles.append(profile),
+    )
+
+    settings = load_startup_settings_into_runtime(tmp_path)
+
+    assert settings == StartupSettings(profile="nature_documentarian", voice="cedar")
+    assert applied_profiles == ["nature_documentarian"]
+
+
+def test_load_startup_settings_into_runtime_preserves_inherited_env_without_saved_settings(
+    monkeypatch, tmp_path
+) -> None:
+    """Inherited env config should still apply when no startup settings have been saved."""
+    applied_profiles: list[str | None] = []
+    monkeypatch.setenv("REACHY_MINI_CUSTOM_PROFILE", "example")
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.config.set_custom_profile",
+        lambda profile: applied_profiles.append(profile),
+    )
+
+    settings = load_startup_settings_into_runtime(tmp_path)
+
+    assert settings == StartupSettings()
     assert applied_profiles == []


### PR DESCRIPTION
## Summary
This is a follow-up to #307.

Startup profile persistence now treats `startup_settings.json` as the source of truth for saved UI startup settings. Env-based profile selection is only used as a fallback when no startup settings have been saved yet.

## Root Cause
There were two regressions after `#307` moved startup profile and voice persistence into `startup_settings.json`:
- saving from the UI did not remove the older startup keys from the instance `.env`
  - `REACHY_MINI_CUSTOM_PROFILE`
  - `REACHY_MINI_VOICE_OVERRIDE`
- startup still treated inherited `REACHY_MINI_CUSTOM_PROFILE` values in the process environment as higher priority than saved startup settings

In practice, that meant saved startup settings could still be overridden on restart by stale env state such as `mad_scientist_assistant` or `example`.

## Changes
- remove legacy startup profile and voice keys from the instance `.env` when persisting startup settings
- make `startup_settings.json` authoritative whenever it exists
- use env-based profile selection only as a fallback when no startup settings file exists yet
- remove the startup profile setting from `.env.example`
- add regressions for both the stale-instance-`.env` path and the inherited-env precedence path

## Validation
- `ruff check src/reachy_mini_conversation_app/console.py src/reachy_mini_conversation_app/startup_settings.py tests/test_console.py tests/test_startup_settings.py`
- `ruff format --check src/reachy_mini_conversation_app/console.py src/reachy_mini_conversation_app/startup_settings.py tests/test_console.py tests/test_startup_settings.py`
- `uv run pytest -q tests/test_console.py::test_local_stream_persist_personality_stores_voice_override tests/test_console.py::test_local_stream_persist_personality_clears_legacy_startup_env_overrides tests/test_startup_settings.py`