### PR TITLE
Fix: hide head tracking when disabled

### DIFF
--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -237,7 +237,6 @@ class Config:
     TOOLS_DIRECTORY = Path(_tools_directory_env) if _tools_directory_env else None
     AUTOLOAD_EXTERNAL_TOOLS = _env_flag("AUTOLOAD_EXTERNAL_TOOLS", default=False)
     REACHY_MINI_CUSTOM_PROFILE = LOCKED_PROFILE or os.getenv("REACHY_MINI_CUSTOM_PROFILE")
-    HEAD_TRACKER_ENABLED: bool = False
 
     logger.debug(f"Custom Profile: {REACHY_MINI_CUSTOM_PROFILE}")
 
@@ -345,11 +344,6 @@ def get_default_voice_for_backend(backend: str | None = None) -> str:
 def is_gemini_model() -> bool:
     """Return True if the configured MODEL_NAME is a Gemini Live model."""
     return get_backend_choice() == GEMINI_BACKEND
-
-
-def set_head_tracker_enabled(enabled: bool) -> None:
-    """Set whether a head-tracker backend was initialised at startup."""
-    config.HEAD_TRACKER_ENABLED = enabled
 
 
 def set_custom_profile(profile: str | None) -> None:

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -237,6 +237,7 @@ class Config:
     TOOLS_DIRECTORY = Path(_tools_directory_env) if _tools_directory_env else None
     AUTOLOAD_EXTERNAL_TOOLS = _env_flag("AUTOLOAD_EXTERNAL_TOOLS", default=False)
     REACHY_MINI_CUSTOM_PROFILE = LOCKED_PROFILE or os.getenv("REACHY_MINI_CUSTOM_PROFILE")
+    HEAD_TRACKER_ENABLED: bool = False
 
     logger.debug(f"Custom Profile: {REACHY_MINI_CUSTOM_PROFILE}")
 
@@ -344,6 +345,11 @@ def get_default_voice_for_backend(backend: str | None = None) -> str:
 def is_gemini_model() -> bool:
     """Return True if the configured MODEL_NAME is a Gemini Live model."""
     return get_backend_choice() == GEMINI_BACKEND
+
+
+def set_head_tracker_enabled(enabled: bool) -> None:
+    """Set whether a head-tracker backend was initialised at startup."""
+    config.HEAD_TRACKER_ENABLED = enabled
 
 
 def set_custom_profile(profile: str | None) -> None:

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -366,8 +366,12 @@ class GeminiLiveHandler(AsyncStreamHandler):
         instructions = get_session_instructions()
         voice = _resolve_gemini_voice(self._voice_override or get_session_voice())
 
+        exclusion_list: list[str] = []
+        if not config.HEAD_TRACKER_ENABLED:
+            exclusion_list.append("head_tracking")
+
         # Convert OpenAI-style tool specs to Gemini function declarations
-        tool_specs = get_tool_specs()
+        tool_specs = get_tool_specs(exclusion_list)
         function_declarations = _openai_tool_specs_to_gemini(tool_specs)
 
         tools_config: List[Dict[str, Any]] = []
@@ -389,6 +393,8 @@ class GeminiLiveHandler(AsyncStreamHandler):
             output_audio_transcription=types.AudioTranscriptionConfig(),
         )
 
+        active_tools = [spec["name"] for spec in tool_specs]
+        logger.info("Tools to be used in conversation: %s", active_tools)
         logger.info(
             "Gemini Live config: model=%r voice=%r tools=%d",
             config.MODEL_NAME,

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -34,7 +34,7 @@ from reachy_mini_conversation_app.config import (
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
 from reachy_mini_conversation_app.tools.core_tools import (
     ToolDependencies,
-    get_tool_specs,
+    get_active_tool_specs,
 )
 from reachy_mini_conversation_app.camera_frame_encoding import encode_bgr_frame_as_jpeg
 from reachy_mini_conversation_app.tools.background_tool_manager import (
@@ -366,12 +366,12 @@ class GeminiLiveHandler(AsyncStreamHandler):
         instructions = get_session_instructions()
         voice = _resolve_gemini_voice(self._voice_override or get_session_voice())
 
-        exclusion_list: list[str] = []
-        if not config.HEAD_TRACKER_ENABLED:
-            exclusion_list.append("head_tracking")
-
         # Convert OpenAI-style tool specs to Gemini function declarations
-        tool_specs = get_tool_specs(exclusion_list)
+        tool_specs = get_active_tool_specs(self.deps)
+        logger.info(
+            "Tools to be used in conversation: %s",
+            [tool["name"] for tool in tool_specs],
+        )
         function_declarations = _openai_tool_specs_to_gemini(tool_specs)
 
         tools_config: List[Dict[str, Any]] = []
@@ -393,8 +393,6 @@ class GeminiLiveHandler(AsyncStreamHandler):
             output_audio_transcription=types.AudioTranscriptionConfig(),
         )
 
-        active_tools = [spec["name"] for spec in tool_specs]
-        logger.info("Tools to be used in conversation: %s", active_tools)
         logger.info(
             "Gemini Live config: model=%r voice=%r tools=%d",
             config.MODEL_NAME,

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -49,7 +49,6 @@ def run(
     from reachy_mini_conversation_app.config import (
         config,
         is_gemini_model,
-        set_head_tracker_enabled,
         refresh_runtime_config_from_env,
     )
     from reachy_mini_conversation_app.startup_settings import (
@@ -129,12 +128,6 @@ def run(
     except CameraVisionInitializationError as e:
         logger.error("Failed to initialize camera/vision: %s", e)
         sys.exit(1)
-
-    set_head_tracker_enabled(args.head_tracker is not None and not args.no_camera)
-    if config.HEAD_TRACKER_ENABLED:
-        logger.info("head_tracking enabled (head tracker: %s).", args.head_tracker)
-    else:
-        logger.info("head_tracking excluded. To enable: --head-tracker mediapipe or --head-tracker yolo.")
 
     movement_manager = MovementManager(
         current_robot=robot,

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -46,7 +46,7 @@ def run(
     """Run the Reachy Mini conversation app."""
     # Putting these dependencies here makes the dashboard faster to load when the conversation app is installed
     from reachy_mini_conversation_app.moves import MovementManager
-    from reachy_mini_conversation_app.config import config, is_gemini_model, refresh_runtime_config_from_env
+    from reachy_mini_conversation_app.config import config, is_gemini_model, refresh_runtime_config_from_env, set_head_tracker_enabled
     from reachy_mini_conversation_app.startup_settings import (
         StartupSettings,
         load_startup_settings_into_runtime,
@@ -124,6 +124,14 @@ def run(
     except CameraVisionInitializationError as e:
         logger.error("Failed to initialize camera/vision: %s", e)
         sys.exit(1)
+
+    set_head_tracker_enabled(args.head_tracker is not None and not args.no_camera)
+    if config.HEAD_TRACKER_ENABLED:
+        logger.info("head_tracking enabled (head tracker: %s).", args.head_tracker)
+    else:
+        logger.info(
+            "head_tracking excluded. To enable: --head-tracker mediapipe or --head-tracker yolo."
+        )
 
     movement_manager = MovementManager(
         current_robot=robot,

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -46,7 +46,12 @@ def run(
     """Run the Reachy Mini conversation app."""
     # Putting these dependencies here makes the dashboard faster to load when the conversation app is installed
     from reachy_mini_conversation_app.moves import MovementManager
-    from reachy_mini_conversation_app.config import config, is_gemini_model, refresh_runtime_config_from_env, set_head_tracker_enabled
+    from reachy_mini_conversation_app.config import (
+        config,
+        is_gemini_model,
+        set_head_tracker_enabled,
+        refresh_runtime_config_from_env,
+    )
     from reachy_mini_conversation_app.startup_settings import (
         StartupSettings,
         load_startup_settings_into_runtime,
@@ -129,9 +134,7 @@ def run(
     if config.HEAD_TRACKER_ENABLED:
         logger.info("head_tracking enabled (head tracker: %s).", args.head_tracker)
     else:
-        logger.info(
-            "head_tracking excluded. To enable: --head-tracker mediapipe or --head-tracker yolo."
-        )
+        logger.info("head_tracking excluded. To enable: --head-tracker mediapipe or --head-tracker yolo.")
 
     movement_manager = MovementManager(
         current_robot=robot,

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -32,7 +32,7 @@ from reachy_mini_conversation_app.config import AVAILABLE_VOICES, config
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
 from reachy_mini_conversation_app.tools.core_tools import (
     ToolDependencies,
-    get_tool_specs,
+    get_active_tool_specs,
 )
 from reachy_mini_conversation_app.tools.background_tool_manager import (
     ToolCallRoutine,
@@ -499,13 +499,11 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
     async def _run_realtime_session(self) -> None:
         """Establish and manage a single realtime session."""
-        exclusion_list: list[str] = []
-        if not config.HEAD_TRACKER_ENABLED:
-            exclusion_list.append("head_tracking")
-
-        active_tools = [spec["name"] for spec in get_tool_specs(exclusion_list)]
-        logger.info("Tools to be used in conversation: %s", active_tools)
-
+        tool_specs = get_active_tool_specs(self.deps)
+        logger.info(
+            "Tools to be used in conversation: %s",
+            [tool["name"] for tool in tool_specs],
+        )
         async with self.client.realtime.connect(model=config.MODEL_NAME) as conn:
             try:
                 session_config = RealtimeSessionCreateRequestParam(
@@ -522,7 +520,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             voice=self._voice_override or get_session_voice(),
                         ),
                     ),
-                    tools=get_tool_specs(exclusion_list),  # type: ignore[typeddict-item]
+                    tools=tool_specs,  # type: ignore[typeddict-item]
                     tool_choice="auto",
                 )
                 await conn.session.update(session=session_config)

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -499,6 +499,13 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
     async def _run_realtime_session(self) -> None:
         """Establish and manage a single realtime session."""
+        exclusion_list: list[str] = []
+        if not config.HEAD_TRACKER_ENABLED:
+            exclusion_list.append("head_tracking")
+
+        active_tools = [spec["name"] for spec in get_tool_specs(exclusion_list)]
+        logger.info("Tools to be used in conversation: %s", active_tools)
+
         async with self.client.realtime.connect(model=config.MODEL_NAME) as conn:
             try:
                 session_config = RealtimeSessionCreateRequestParam(
@@ -515,7 +522,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
                             voice=self._voice_override or get_session_voice(),
                         ),
                     ),
-                    tools=get_tool_specs(),  # type: ignore[typeddict-item]
+                    tools=get_tool_specs(exclusion_list),  # type: ignore[typeddict-item]
                     tool_choice="auto",
                 )
                 await conn.session.update(session=session_config)

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -282,6 +282,14 @@ def get_tool_specs(exclusion_list: list[str] = []) -> list[Dict[str, Any]]:
     return [spec for spec in ALL_TOOL_SPECS if spec.get("name") not in exclusion_list]
 
 
+def get_active_tool_specs(deps: ToolDependencies) -> list[Dict[str, Any]]:
+    """Get tool specs filtered by what the current session deps support."""
+    exclusion_list: list[str] = []
+    if not (deps.camera_worker and deps.camera_worker.head_tracker):
+        exclusion_list.append("head_tracking")
+    return get_tool_specs(exclusion_list)
+
+
 # Dispatcher
 def _safe_load_obj(args_json: str) -> Dict[str, Any]:
     try:

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -96,7 +96,7 @@ async def test_gemini_turn_buffers_transcripts_and_schedules_motion_reset(monkey
     """Gemini turns should emit one transcript per role and let the wobbler reset after speech."""
     monkeypatch.setattr(gemini_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(gemini_mod, "get_session_voice", lambda: "Kore")
-    monkeypatch.setattr(gemini_mod, "get_tool_specs", lambda *_: [])
+    monkeypatch.setattr(gemini_mod, "get_active_tool_specs", lambda _: [])
 
     movement_manager = MagicMock()
     movement_manager.is_idle.return_value = False

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -10,6 +10,7 @@ import pytest
 from fastrtc import AdditionalOutputs
 
 import reachy_mini_conversation_app.gemini_live as gemini_mod
+import reachy_mini_conversation_app.tools.core_tools as ct_mod
 from reachy_mini_conversation_app.gemini_live import GeminiLiveHandler
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.tools.tool_constants import ToolState
@@ -278,3 +279,37 @@ def test_copy_preserves_current_voice_override() -> None:
     copied_handler = handler.copy()
 
     assert copied_handler.get_current_voice() == "Zephyr"
+
+
+def test_gemini_excludes_head_tracking_when_no_head_tracker(monkeypatch) -> None:
+    """head_tracking tool must not appear in Gemini session config when head_tracker is not active."""
+    monkeypatch.setattr(gemini_mod, "get_session_instructions", lambda: "test")
+    monkeypatch.setattr(gemini_mod, "get_session_voice", lambda: "Kore")
+
+    # mock ALL_TOOL_SPECS to include at least head_tracking and one other tool, to verify that only head_tracking is excluded, not all tools
+    monkeypatch.setattr(
+        ct_mod,
+        "ALL_TOOL_SPECS",
+        [
+            {"type": "function", "name": "head_tracking", "description": "head_tracking", "parameters": {}},
+            {"type": "function", "name": "fake_tool", "description": "fake_tool", "parameters": {}},
+        ],
+    )
+
+    # case 1: no camera at all, --no-camera flag passed
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock(), camera_worker=None)
+    handler = GeminiLiveHandler(deps)
+    live_config = handler._build_live_config()
+    tool_names = [fd.name for fd in live_config.tools[0].function_declarations] if live_config.tools else []
+    assert "head_tracking" not in tool_names, "case 1 failed: camera_worker=None"
+    assert "fake_tool" in tool_names, "case 1 failed: a non-head-tracking tool was unexpectedly excluded"
+
+    # case 2: camera is running but --head-tracker flag was not passed
+    camera_worker = MagicMock()
+    camera_worker.head_tracker = None
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock(), camera_worker=camera_worker)
+    handler = GeminiLiveHandler(deps)
+    live_config = handler._build_live_config()
+    tool_names = [fd.name for fd in live_config.tools[0].function_declarations] if live_config.tools else []
+    assert "head_tracking" not in tool_names, "case 2 failed: camera_worker.head_tracker=None"
+    assert "fake_tool" in tool_names, "case 2 failed: a non-head-tracking tool was unexpectedly excluded"

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -96,7 +96,7 @@ async def test_gemini_turn_buffers_transcripts_and_schedules_motion_reset(monkey
     """Gemini turns should emit one transcript per role and let the wobbler reset after speech."""
     monkeypatch.setattr(gemini_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(gemini_mod, "get_session_voice", lambda: "Kore")
-    monkeypatch.setattr(gemini_mod, "get_tool_specs", lambda: [])
+    monkeypatch.setattr(gemini_mod, "get_tool_specs", lambda *_: [])
 
     movement_manager = MagicMock()
     movement_manager.is_idle.return_value = False

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -27,7 +27,7 @@ async def test_tool_completion_does_not_reset_head_wobbler(monkeypatch: Any) -> 
     """Tool completion should not interrupt ongoing speech wobble."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
-    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda *_: [])
+    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
 
     async def _fake_dispatch(tool_name: str, args_json: str, deps: Any, **_kw: Any) -> dict[str, Any]:
         return {"image_description": "A person in front of a door.", "tool": tool_name}
@@ -133,7 +133,7 @@ async def test_non_idle_tool_call_does_not_queue_progress_response(monkeypatch: 
     """Tool-call startup should not enqueue a second speech response."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
-    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda *_: [])
+    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
 
     class FakeEvent:
         def __init__(self, etype: str, **kwargs: Any) -> None:
@@ -231,7 +231,7 @@ async def test_output_audio_done_schedules_head_wobbler_reset(monkeypatch: Any) 
     """OpenAI speech completion should let the wobbler reset itself after queued audio."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
-    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda *_: [])
+    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
 
     class FakeEvent:
         def __init__(self, etype: str, **kwargs: Any) -> None:
@@ -572,7 +572,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
     monkeypatch.setattr(rt_mod, "ConnectionClosedError", FakeCCE)
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
-    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda *_: [])
+    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
 
     N_TOOL_RESULTS = 400
     REJECT_CALL_NUMBERS = {1, 3, 5, 10, 25, 50, 75, 100, 150, 200, 300, 399}

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -27,7 +27,7 @@ async def test_tool_completion_does_not_reset_head_wobbler(monkeypatch: Any) -> 
     """Tool completion should not interrupt ongoing speech wobble."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
-    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda: [])
+    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda *_: [])
 
     async def _fake_dispatch(tool_name: str, args_json: str, deps: Any, **_kw: Any) -> dict[str, Any]:
         return {"image_description": "A person in front of a door.", "tool": tool_name}
@@ -133,7 +133,7 @@ async def test_non_idle_tool_call_does_not_queue_progress_response(monkeypatch: 
     """Tool-call startup should not enqueue a second speech response."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
-    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda: [])
+    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda *_: [])
 
     class FakeEvent:
         def __init__(self, etype: str, **kwargs: Any) -> None:
@@ -231,7 +231,7 @@ async def test_output_audio_done_schedules_head_wobbler_reset(monkeypatch: Any) 
     """OpenAI speech completion should let the wobbler reset itself after queued audio."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
-    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda: [])
+    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda *_: [])
 
     class FakeEvent:
         def __init__(self, etype: str, **kwargs: Any) -> None:
@@ -572,7 +572,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
     monkeypatch.setattr(rt_mod, "ConnectionClosedError", FakeCCE)
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
-    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda: [])
+    monkeypatch.setattr(rt_mod, "get_tool_specs", lambda *_: [])
 
     N_TOOL_RESULTS = 400
     REJECT_CALL_NUMBERS = {1, 3, 5, 10, 25, 50, 75, 100, 150, 200, 300, 399}

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import reachy_mini_conversation_app.openai_realtime as rt_mod
+import reachy_mini_conversation_app.tools.core_tools as ct_mod
 import reachy_mini_conversation_app.tools.background_tool_manager as btm_mod
 from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler, _compute_response_cost
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
@@ -894,3 +895,104 @@ async def test_response_sender_loop_times_out_waiting_for_previous_response(
 
     timeout_logs = [r for r in caplog.records if "Timed out waiting for previous response" in r.getMessage()]
     assert len(timeout_logs) == 1, f"Expected 1 pre-condition timeout warning, got {len(timeout_logs)}"
+
+
+@pytest.mark.asyncio
+async def test_openai_excludes_head_tracking_when_no_head_tracker(monkeypatch: Any) -> None:
+    """head_tracking tool must not appear in OpenAI session config when head_tracker is not active."""
+    monkeypatch.setattr(rt_mod, "get_session_instructions", lambda: "test")
+    monkeypatch.setattr(rt_mod, "get_session_voice", lambda: "alloy")
+
+    # mock ALL_TOOL_SPECS to include at least head_tracking and one other tool, to verify that only head_tracking is excluded, not all tools
+    monkeypatch.setattr(
+        ct_mod,
+        "ALL_TOOL_SPECS",
+        [
+            {"type": "function", "name": "head_tracking", "description": "head_tracking", "parameters": {}},
+            {"type": "function", "name": "fake_tool", "description": "fake_tool", "parameters": {}},
+        ],
+    )
+
+    session_kwargs: dict = {}
+
+    class FakeSession:
+        async def update(self, **kwargs: Any) -> None:
+            session_kwargs["session"] = kwargs.get("session")
+
+    class FakeInputAudioBuffer:
+        async def append(self, **_kw: Any) -> None:
+            pass
+
+    class FakeItem:
+        async def create(self, **_kw: Any) -> None:
+            pass
+
+    class FakeConversation:
+        item = FakeItem()
+
+    class FakeResponse:
+        async def create(self, **_kw: Any) -> None:
+            pass
+
+        async def cancel(self, **_kw: Any) -> None:
+            pass
+
+    class FakeConn:
+        session = FakeSession()
+        input_audio_buffer = FakeInputAudioBuffer()
+        conversation = FakeConversation()
+        response = FakeResponse()
+
+        async def __aenter__(self) -> "FakeConn":
+            return self
+
+        async def __aexit__(self, *_: Any) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+        def __aiter__(self) -> "FakeConn":
+            return self
+
+        async def __anext__(self) -> Any:
+            raise StopAsyncIteration
+
+    class FakeRealtime:
+        def connect(self, **_kw: Any) -> FakeConn:
+            return FakeConn()
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.realtime = FakeRealtime()
+
+    # case 1: no camera at all, --no-camera flag passed
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock(), camera_worker=None)
+    handler = OpenaiRealtimeHandler(deps)
+    handler.client = FakeClient()
+    object.__setattr__(handler.tool_manager, "start_up", MagicMock())
+    object.__setattr__(handler.tool_manager, "shutdown", AsyncMock())
+
+    await handler._run_realtime_session()
+
+    session_tools = session_kwargs.get("session", {}).get("tools", [])
+    tool_names = [t["name"] for t in session_tools]
+    assert "head_tracking" not in tool_names, "case 1 failed: camera_worker=None"
+    assert "fake_tool" in tool_names, "case 1 failed: a non-head-tracking tool was unexpectedly excluded"
+
+    # case 2: camera is running but --head-tracker flag was not passed
+    session_kwargs.clear()
+    camera_worker = MagicMock()
+    camera_worker.head_tracker = None
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock(), camera_worker=camera_worker)
+    handler = OpenaiRealtimeHandler(deps)
+    handler.client = FakeClient()
+    object.__setattr__(handler.tool_manager, "start_up", MagicMock())
+    object.__setattr__(handler.tool_manager, "shutdown", AsyncMock())
+
+    await handler._run_realtime_session()
+
+    session_tools = session_kwargs.get("session", {}).get("tools", [])
+    tool_names = [t["name"] for t in session_tools]
+    assert "head_tracking" not in tool_names, "case 2 failed: camera_worker.head_tracker=None"
+    assert "fake_tool" in tool_names, "case 2 failed: a non-head-tracking tool was unexpectedly excluded"


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
<!-- What does this PR change and why? -->
- Fixes issue #301 
- When `--head-tracker` is not set (or `--no-camera` is used), the head_tracking tool is excluded from the tool list sent to both OpenAI Realtime and Gemini Live
- Added startup logging for `--head-tracker` enabled/disabled and active tool set logging when user starts the conversation session 

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [x] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [x] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
<!-- Optional: context, caveats, migration notes -->
