### PR TITLE
chore: bump up reachy_mini to 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     #Reachy mini
     "reachy_mini_dances_library",
     "reachy_mini_toolbox",
-    "reachy-mini>=1.6.4",
+    "reachy-mini>=1.7.0",
     "gradio_client>=1.13.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4186,7 +4186,7 @@ wheels = [
 
 [[package]]
 name = "reachy-mini"
-version = "1.6.4"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -4222,9 +4222,9 @@ dependencies = [
     { name = "websockets" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/fd/d5b2c5f06c2075fa9a6d315dc1455bb224a58eaefb8885c3d0a6444e32b1/reachy_mini-1.6.4.tar.gz", hash = "sha256:f873460ce95237953130e1aa7a4f678132a0e55e778ea74b1c77d3f5aa736daf", size = 24707904, upload-time = "2026-04-20T10:39:15.69Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/6e/fd11c02787149d6e237f290bb23f8d281f380ba5c0631add0499bc47cc44/reachy_mini-1.7.0.tar.gz", hash = "sha256:42a5424cce1889d4d14cf14b004e23dbcb97d8d8679917d091ed2965bbf29448", size = 24720565, upload-time = "2026-04-22T12:10:39.57Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/e7/7e871d5d02aed83d9b18b6ee6483fe3262f89c1b23c1061682becc27697b/reachy_mini-1.6.4-py3-none-any.whl", hash = "sha256:b23aaccf44c95da9cca6f7b17ceb09e614b89eec37fc512421b9c8069234bdfd", size = 24809998, upload-time = "2026-04-20T10:39:12.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b624ad9fe332c9c6544bc60d9a1a76a5f239d364f75d568f9ed73f1b5e0c/reachy_mini-1.7.0-py3-none-any.whl", hash = "sha256:4f19ce9f7d4f4469768f9521eede6e22a35627a68719be73aa1b4a967e584ebe", size = 24818271, upload-time = "2026-04-22T12:10:36.622Z" },
 ]
 
 [[package]]
@@ -4302,7 +4302,7 @@ requires-dist = [
     { name = "opencv-python", marker = "extra == 'all-vision'", specifier = ">=4.13.0.92" },
     { name = "opencv-python", marker = "extra == 'yolo-vision'", specifier = ">=4.13.0.92" },
     { name = "python-dotenv" },
-    { name = "reachy-mini", specifier = ">=1.6.4" },
+    { name = "reachy-mini", specifier = ">=1.7.0" },
     { name = "reachy-mini-dances-library" },
     { name = "reachy-mini-toolbox" },
     { name = "supervision", marker = "extra == 'all-vision'" },


### PR DESCRIPTION
## Summary
Bumping up sdk to 1.7.0. Tests on Wireless and Lite (macOS) passed.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [x] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>