### PR TITLE
323 connect to messaging app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,18 @@ HF_TOKEN=
 # → Integrations → Webhooks → New Webhook → Copy Webhook URL. Leave blank to disable.
 DISCORD_WEBHOOK_URL=
 
+# Discord DM — enables the `send_discord_dm` tool so the robot can DM you directly.
+# Requires a bot (webhooks cannot DM):
+#   1. https://discord.com/developers/applications → New Application → Bot → Reset Token
+#      → copy as DISCORD_BOT_TOKEN.
+#   2. Install the bot to any server you're also in (OAuth2 → URL Generator, scope=bot,
+#      perms=Send Messages).
+#   3. In Discord: User Settings → Advanced → enable Developer Mode, then right-click
+#      your avatar → Copy User ID → paste as DISCORD_USER_ID.
+# Leave blank to disable.
+DISCORD_BOT_TOKEN=
+DISCORD_USER_ID=
+
 # Optional external profile/tool directories
 # REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY=external_content/external_profiles
 # REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY=external_content/external_tools

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,13 @@ DISCORD_WEBHOOK_URL=
 DISCORD_BOT_TOKEN=
 DISCORD_USER_ID=
 
+# Discord inbound — when enabled, the robot polls DMs from DISCORD_USER_ID and
+# forwards text and image attachments into the live voice conversation
+# (OpenAI Realtime only). PDFs / audio / video are ignored with a reply.
+# Requires DISCORD_BOT_TOKEN + DISCORD_USER_ID above. Opt-in.
+DISCORD_INBOUND_ENABLED=false
+DISCORD_INBOUND_POLL_SECONDS=10
+
 # Optional external profile/tool directories
 # REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY=external_content/external_profiles
 # REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY=external_content/external_tools

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ HF_HOME=./cache
 # Hugging Face token for accessing datasets/models
 HF_TOKEN=
 
+# Discord webhook URL — enables the `send_discord` tool so the robot can send you
+# messages and pictures. Create one in Discord: right-click a channel → Edit Channel
+# → Integrations → Webhooks → New Webhook → Copy Webhook URL. Leave blank to disable.
+DISCORD_WEBHOOK_URL=
+
 # Optional external profile/tool directories
 # REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY=external_content/external_profiles
 # REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY=external_content/external_tools

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ reachy-mini-conversation-app --gradio
 | `play_emotion` | Play a recorded emotion clip via Hugging Face datasets. | Core install only. Uses the default open emotions dataset: [`pollen-robotics/reachy-mini-emotions-library`](https://huggingface.co/datasets/pollen-robotics/reachy-mini-emotions-library). |
 | `stop_emotion` | Clear queued emotions. | Core install only. |
 | `do_nothing` | Explicitly remain idle. | Core install only. |
+| `send_discord` | Send a message (and optionally the current camera frame) to a Discord channel via a webhook. | Requires `DISCORD_WEBHOOK_URL` in `.env`. |
+| `send_discord_dm` | DM the configured user (and optionally the current camera frame) via a Discord bot. | Requires `DISCORD_BOT_TOKEN` and `DISCORD_USER_ID` in `.env`; bot must share a server with the user. |
 
 ## Advanced features
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ reachy-mini-conversation-app --gradio
 | `send_discord` | Send a message (and optionally the current camera frame) to a Discord channel via a webhook. | Requires `DISCORD_WEBHOOK_URL` in `.env`. |
 | `send_discord_dm` | DM the configured user (and optionally the current camera frame) via a Discord bot. | Requires `DISCORD_BOT_TOKEN` and `DISCORD_USER_ID` in `.env`; bot must share a server with the user. |
 
+### Discord inbound (optional)
+
+When `DISCORD_INBOUND_ENABLED=true` (and the bot is configured), the robot polls
+the configured user's DM and forwards text and image attachments directly into
+the live OpenAI Realtime voice conversation — send a message or a photo from
+your phone and the robot replies out loud. Other attachment types (PDFs,
+audio, video) are ignored with a "text and images only" reply. Polling
+interval is `DISCORD_INBOUND_POLL_SECONDS` (default 10 s).
+
 ## Advanced features
 
 Built-in motion content is published as open Hugging Face datasets:

--- a/profiles/bored_teenager/tools.txt
+++ b/profiles/bored_teenager/tools.txt
@@ -6,3 +6,4 @@ camera
 do_nothing
 head_tracking
 move_head
+send_discord

--- a/profiles/default/tools.txt
+++ b/profiles/default/tools.txt
@@ -7,3 +7,4 @@ do_nothing
 head_tracking
 move_head
 send_discord
+send_discord_dm

--- a/profiles/default/tools.txt
+++ b/profiles/default/tools.txt
@@ -6,3 +6,4 @@ camera
 do_nothing
 head_tracking
 move_head
+send_discord

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -316,6 +316,9 @@ def refresh_runtime_config_from_env() -> None:
     )
     config.MODEL_NAME = _resolve_model_name(config.BACKEND_PROVIDER, os.getenv("MODEL_NAME"))
     config.REACHY_MINI_CUSTOM_PROFILE = LOCKED_PROFILE or os.getenv("REACHY_MINI_CUSTOM_PROFILE")
+    config.DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
+    config.DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+    config.DISCORD_USER_ID = os.getenv("DISCORD_USER_ID")
 
 
 def get_backend_choice(model_name: str | None = None) -> str:

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -222,6 +222,8 @@ class Config:
     LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     HF_TOKEN = os.getenv("HF_TOKEN")  # Optional, falls back to hf auth login if not set
     DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")  # Optional, enables the send_discord tool
+    DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")  # Optional, enables the send_discord_dm tool
+    DISCORD_USER_ID = os.getenv("DISCORD_USER_ID")  # Optional, Discord user ID that receives DMs
 
     logger.debug(
         "Backend provider: %s, Model: %s, HF_HOME: %s, Vision Model: %s",

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -224,6 +224,8 @@ class Config:
     DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")  # Optional, enables the send_discord tool
     DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")  # Optional, enables the send_discord_dm tool
     DISCORD_USER_ID = os.getenv("DISCORD_USER_ID")  # Optional, Discord user ID that receives DMs
+    DISCORD_INBOUND_ENABLED = _env_flag("DISCORD_INBOUND_ENABLED", default=False)
+    DISCORD_INBOUND_POLL_SECONDS = float(os.getenv("DISCORD_INBOUND_POLL_SECONDS") or "10")
 
     logger.debug(
         "Backend provider: %s, Model: %s, HF_HOME: %s, Vision Model: %s",
@@ -319,6 +321,8 @@ def refresh_runtime_config_from_env() -> None:
     config.DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
     config.DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
     config.DISCORD_USER_ID = os.getenv("DISCORD_USER_ID")
+    config.DISCORD_INBOUND_ENABLED = _env_flag("DISCORD_INBOUND_ENABLED", default=False)
+    config.DISCORD_INBOUND_POLL_SECONDS = float(os.getenv("DISCORD_INBOUND_POLL_SECONDS") or "10")
 
 
 def get_backend_choice(model_name: str | None = None) -> str:

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -221,6 +221,7 @@ class Config:
     HF_HOME = os.getenv("HF_HOME", "./cache")
     LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     HF_TOKEN = os.getenv("HF_TOKEN")  # Optional, falls back to hf auth login if not set
+    DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")  # Optional, enables the send_discord tool
 
     logger.debug(
         "Backend provider: %s, Model: %s, HF_HOME: %s, Vision Model: %s",

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -315,6 +315,11 @@ class LocalStream:
             backend: str
             api_key: Optional[str] = None
 
+        class DiscordConfigPayload(BaseModel):
+            webhook_url: Optional[str] = None
+            bot_token: Optional[str] = None
+            user_id: Optional[str] = None
+
         def _status_payload() -> dict[str, object]:
             backend_provider = get_backend_choice()
             active_backend = self._active_backend()
@@ -423,6 +428,36 @@ class LocalStream:
             except Exception as e:
                 logger.warning(f"API key validation failed: {e}")
                 return JSONResponse({"valid": False, "error": "validation_error"}, status_code=500)
+
+        def _discord_status() -> dict[str, bool]:
+            return {
+                "has_webhook_url": bool((os.getenv("DISCORD_WEBHOOK_URL") or "").strip()),
+                "has_bot_token": bool((os.getenv("DISCORD_BOT_TOKEN") or "").strip()),
+                "has_user_id": bool((os.getenv("DISCORD_USER_ID") or "").strip()),
+            }
+
+        # GET /discord_config -> presence flags for the Discord tool credentials
+        @self._settings_app.get("/discord_config")
+        def _get_discord_config() -> JSONResponse:
+            return JSONResponse(_discord_status())
+
+        # POST /discord_config -> persist Discord tool credentials (empty/missing = unchanged)
+        @self._settings_app.post("/discord_config")
+        def _set_discord_config(payload: DiscordConfigPayload) -> JSONResponse:
+            updates: dict[str, str] = {}
+            for env_name, raw in (
+                ("DISCORD_WEBHOOK_URL", payload.webhook_url),
+                ("DISCORD_BOT_TOKEN", payload.bot_token),
+                ("DISCORD_USER_ID", payload.user_id),
+            ):
+                if raw is None:
+                    continue
+                value = raw.strip()
+                if value:
+                    updates[env_name] = value
+            if updates:
+                self._persist_env_values(updates)
+            return JSONResponse({"ok": True, **_discord_status()})
 
         self._settings_initialized = True
 

--- a/src/reachy_mini_conversation_app/discord_inbound.py
+++ b/src/reachy_mini_conversation_app/discord_inbound.py
@@ -1,0 +1,224 @@
+"""Background worker that polls a Discord DM and forwards content to the realtime session.
+
+Text and supported image attachments become `input_text` / `input_image` content
+parts on a new user conversation item. Other attachment types are ignored and
+the sender gets a brief "text and images only" reply back.
+"""
+
+import base64
+import asyncio
+import logging
+import threading
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from reachy_mini_conversation_app.config import config
+from reachy_mini_conversation_app.tools._discord_common import DISCORD_API_BASE, bot_auth_header
+
+
+if TYPE_CHECKING:
+    from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
+
+
+logger = logging.getLogger(__name__)
+
+
+_SUPPORTED_IMAGE_CTYPES = {"image/png", "image/jpeg", "image/gif", "image/webp"}
+_UNSUPPORTED_REPLY = "I can only handle text and images for now."
+_INJECT_TIMEOUT_S = 15.0
+
+
+class DiscordInboundWorker:
+    """Polls the configured Discord DM and injects new messages into the realtime session."""
+
+    def __init__(self, realtime_handler: "OpenaiRealtimeHandler") -> None:
+        """Initialize."""
+        self._handler = realtime_handler
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._dm_channel_id: str | None = None
+        self._last_seen_id: str | None = None
+
+    def start(self) -> None:
+        """Start the polling thread if bot credentials are configured."""
+        bot_token = (config.DISCORD_BOT_TOKEN or "").strip()
+        user_id = (config.DISCORD_USER_ID or "").strip()
+        if not bot_token or not user_id:
+            logger.info("discord inbound: bot token / user id missing, worker not started")
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True, name="discord-inbound")
+        self._thread.start()
+        logger.info(
+            "discord inbound worker started (poll every %.1fs)",
+            config.DISCORD_INBOUND_POLL_SECONDS,
+        )
+
+    def stop(self) -> None:
+        """Stop the polling thread."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+        logger.debug("discord inbound worker stopped")
+
+    def _run_loop(self) -> None:
+        """Run the polling loop until stopped."""
+        with httpx.Client(timeout=15.0) as client:
+            while not self._stop_event.is_set():
+                try:
+                    self._tick(client)
+                except Exception as e:
+                    logger.warning("discord inbound tick failed: %s", e)
+                poll_s = max(1.0, float(config.DISCORD_INBOUND_POLL_SECONDS))
+                self._stop_event.wait(timeout=poll_s)
+
+    def _tick(self, client: httpx.Client) -> None:
+        """Poll for new DM messages and forward them."""
+        bot_token = (config.DISCORD_BOT_TOKEN or "").strip()
+        user_id = (config.DISCORD_USER_ID or "").strip()
+        if not bot_token or not user_id:
+            return
+        headers = bot_auth_header(bot_token)
+
+        if self._dm_channel_id is None and not self._open_dm_channel(client, headers, user_id):
+            return
+
+        params: dict[str, Any] = {"limit": 10}
+        if self._last_seen_id:
+            params["after"] = self._last_seen_id
+        resp = client.get(
+            f"{DISCORD_API_BASE}/channels/{self._dm_channel_id}/messages",
+            params=params,
+            headers=headers,
+        )
+        if resp.status_code == 401:
+            logger.error("discord inbound: invalid bot token, stopping worker")
+            self._stop_event.set()
+            return
+        if resp.status_code != 200:
+            logger.warning("discord inbound: fetch failed HTTP %d: %s", resp.status_code, resp.text[:200])
+            return
+
+        try:
+            messages = resp.json()
+        except Exception:
+            logger.warning("discord inbound: malformed messages response")
+            return
+        if not isinstance(messages, list):
+            return
+
+        # Discord returns newest-first; process oldest-first so last_seen_id advances monotonically.
+        messages.sort(key=lambda m: int(m.get("id", "0")))
+
+        # On the first successful poll (no baseline yet) skip history — only react to new messages.
+        if self._last_seen_id is None and messages:
+            self._last_seen_id = messages[-1]["id"]
+            return
+
+        for msg in messages:
+            if (msg.get("author") or {}).get("bot"):
+                self._last_seen_id = msg["id"]
+                continue
+            self._process_message(client, headers, msg)
+            self._last_seen_id = msg["id"]
+
+    def _open_dm_channel(self, client: httpx.Client, headers: dict[str, str], user_id: str) -> bool:
+        """Open (idempotent) a DM channel with the configured user; cache its id."""
+        resp = client.post(
+            f"{DISCORD_API_BASE}/users/@me/channels",
+            json={"recipient_id": user_id},
+            headers=headers,
+        )
+        if resp.status_code != 200:
+            logger.warning(
+                "discord inbound: open DM failed HTTP %d: %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+            return False
+        try:
+            self._dm_channel_id = resp.json()["id"]
+        except Exception:
+            logger.warning("discord inbound: malformed DM channel response")
+            return False
+        logger.info("discord inbound: DM channel opened (id=%s)", self._dm_channel_id)
+        return True
+
+    def _process_message(
+        self,
+        client: httpx.Client,
+        headers: dict[str, str],
+        msg: dict[str, Any],
+    ) -> None:
+        """Build realtime content parts from a Discord message and inject them."""
+        parts: list[dict[str, Any]] = []
+        unsupported = False
+
+        text = (msg.get("content") or "").strip()
+        if text:
+            parts.append({"type": "input_text", "text": text})
+
+        for attachment in msg.get("attachments") or []:
+            content_type = (attachment.get("content_type") or "").lower()
+            if content_type in _SUPPORTED_IMAGE_CTYPES:
+                try:
+                    data_url = self._download_as_data_url(client, attachment, content_type)
+                except Exception as e:
+                    logger.warning(
+                        "discord inbound: failed to download %s: %s",
+                        attachment.get("url"),
+                        e,
+                    )
+                    continue
+                parts.append({"type": "input_image", "image_url": data_url})
+            else:
+                unsupported = True
+
+        if parts:
+            logger.info(
+                "discord inbound: forwarding message %s (%d parts)",
+                msg.get("id"),
+                len(parts),
+            )
+            if not self._inject_parts(parts):
+                logger.warning("discord inbound: inject failed for message %s", msg.get("id"))
+
+        if unsupported and self._dm_channel_id is not None:
+            try:
+                client.post(
+                    f"{DISCORD_API_BASE}/channels/{self._dm_channel_id}/messages",
+                    json={"content": _UNSUPPORTED_REPLY},
+                    headers=headers,
+                )
+            except Exception as e:
+                logger.warning("discord inbound: failed to post 'unsupported' reply: %s", e)
+
+    def _download_as_data_url(
+        self,
+        client: httpx.Client,
+        attachment: dict[str, Any],
+        content_type: str,
+    ) -> str:
+        """Download an attachment and encode it as a data URL for realtime input_image."""
+        url = attachment["url"]
+        resp = client.get(url, timeout=30.0)
+        resp.raise_for_status()
+        b64 = base64.b64encode(resp.content).decode("ascii")
+        return f"data:{content_type};base64,{b64}"
+
+    def _inject_parts(self, parts: list[dict[str, Any]]) -> bool:
+        """Schedule inject_user_content on the handler's event loop and wait for the result."""
+        loop = self._handler._realtime_loop
+        if loop is None:
+            logger.warning("discord inbound: handler has no event loop yet, dropping")
+            return False
+        future = asyncio.run_coroutine_threadsafe(
+            self._handler.inject_user_content(parts),
+            loop,
+        )
+        try:
+            return bool(future.result(timeout=_INJECT_TIMEOUT_S))
+        except Exception as e:
+            logger.warning("discord inbound: inject coroutine raised: %s", e)
+            return False

--- a/src/reachy_mini_conversation_app/headless_personality.py
+++ b/src/reachy_mini_conversation_app/headless_personality.py
@@ -91,7 +91,7 @@ def available_tools_for(selected: str) -> List[str]:
     shared: List[str] = []
     try:
         for py in _tools_dir().glob("*.py"):
-            if py.stem in {"__init__", "core_tools"}:
+            if py.stem == "core_tools" or py.stem.startswith("_"):
                 continue
             shared.append(py.stem)
     except Exception:

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -226,6 +226,18 @@ def run(
     if camera_worker:
         camera_worker.start()
 
+    discord_inbound = None
+    if (
+        config.DISCORD_INBOUND_ENABLED
+        and config.DISCORD_BOT_TOKEN
+        and config.DISCORD_USER_ID
+        and not is_gemini_model()
+    ):
+        from reachy_mini_conversation_app.discord_inbound import DiscordInboundWorker
+
+        discord_inbound = DiscordInboundWorker(handler)  # type: ignore[arg-type]
+        discord_inbound.start()
+
     def poll_stop_event() -> None:
         """Poll the stop event to allow graceful shutdown."""
         if app_stop_event is not None:
@@ -249,6 +261,8 @@ def run(
         head_wobbler.stop()
         if camera_worker:
             camera_worker.stop()
+        if discord_inbound is not None:
+            discord_inbound.stop()
 
         # Ensure media is explicitly closed before disconnecting
         try:

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -134,6 +134,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
         # Internal lifecycle flags
         self._connected_event: asyncio.Event = asyncio.Event()
+        self._realtime_loop: asyncio.AbstractEventLoop | None = None
 
         # Background tool manager
         self.tool_manager = BackgroundToolManager()
@@ -338,6 +339,45 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
         """
         await self._pending_responses.put(kwargs)
 
+    async def inject_user_content(
+        self,
+        parts: list[dict[str, Any]],
+        *,
+        request_response: bool = True,
+        wait_for_session_s: float = 10.0,
+    ) -> bool:
+        """Append a user-authored conversation item (text / image parts) to the live session.
+
+        Waits up to ``wait_for_session_s`` seconds for the realtime session to be
+        connected. Returns True if the item was sent, False if the session wasn't
+        available or the send failed. Safe to call from the same event loop as the
+        handler. For cross-thread callers, schedule via
+        ``asyncio.run_coroutine_threadsafe(handler.inject_user_content(...), handler._loop)``.
+        """
+        if not parts:
+            return False
+        try:
+            await asyncio.wait_for(self._connected_event.wait(), timeout=wait_for_session_s)
+        except asyncio.TimeoutError:
+            logger.warning("inject_user_content: no realtime session within %.1fs", wait_for_session_s)
+            return False
+        if self.connection is None:
+            return False
+        try:
+            await self.connection.conversation.item.create(
+                item={  # type: ignore[misc,arg-type]
+                    "type": "message",
+                    "role": "user",
+                    "content": parts,
+                },
+            )
+        except Exception as e:
+            logger.warning("inject_user_content: item.create failed: %s", e)
+            return False
+        if request_response:
+            await self._safe_response_create()
+        return True
+
     async def _response_sender_loop(self) -> None:
         """Dedicated worker that sends ``response.create()`` calls serially.
 
@@ -499,6 +539,7 @@ class OpenaiRealtimeHandler(AsyncStreamHandler):
 
     async def _run_realtime_session(self) -> None:
         """Establish and manage a single realtime session."""
+        self._realtime_loop = asyncio.get_running_loop()
         async with self.client.realtime.connect(model=config.MODEL_NAME) as conn:
             try:
                 session_config = RealtimeSessionCreateRequestParam(

--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -175,6 +175,35 @@
         </div>
         <p id="personality-status" class="status" role="status" aria-live="polite" aria-atomic="true"></p>
       </div>
+
+      <div id="discord-panel" class="panel hidden">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Optional tools</p>
+            <h2>Discord integration</h2>
+          </div>
+          <span id="discord-chip" class="chip">Optional</span>
+        </div>
+        <p class="muted">
+          Fill these in to enable the <code>send_discord</code> tool (post to a channel via webhook) and the <code>send_discord_dm</code> tool (DM you via a bot). Values are saved to your instance <code>.env</code>. Leave blank to disable.
+        </p>
+        <div class="row">
+          <label for="discord-webhook-url">Webhook URL — channel posts</label>
+          <input id="discord-webhook-url" type="password" placeholder="https://discord.com/api/webhooks/..." autocomplete="off" />
+        </div>
+        <div class="row">
+          <label for="discord-bot-token">Bot token — DMs</label>
+          <input id="discord-bot-token" type="password" placeholder="Bot token" autocomplete="off" />
+        </div>
+        <div class="row">
+          <label for="discord-user-id">Your Discord user ID — DMs</label>
+          <input id="discord-user-id" type="text" placeholder="e.g. 123456789012345678" autocomplete="off" />
+        </div>
+        <div class="actions">
+          <button id="save-discord-btn">Save Discord config</button>
+          <p id="discord-status" class="status" role="status" aria-live="polite" aria-atomic="true"></p>
+        </div>
+      </div>
     </div>
 
     <script src="/static/main.js"></script>

--- a/src/reachy_mini_conversation_app/static/main.js
+++ b/src/reachy_mini_conversation_app/static/main.js
@@ -127,6 +127,29 @@ async function saveBackendConfig(backend, key = "") {
   return await resp.json();
 }
 
+async function getDiscordConfig() {
+  try {
+    const resp = await fetchWithTimeout("/discord_config", {}, 3000);
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch (e) {
+    return null;
+  }
+}
+
+async function saveDiscordConfig(payload) {
+  const resp = await fetch("/discord_config", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!resp.ok) {
+    const data = await resp.json().catch(() => ({}));
+    throw new Error(data.error || "save_failed");
+  }
+  return await resp.json();
+}
+
 // ---------- Personalities API ----------
 async function loadPersonality(name) {
   const url = new URL("/personalities/load", window.location.origin);
@@ -283,6 +306,15 @@ async function init() {
   const pApplyVoice = document.getElementById("apply-voice");
   const pAvail = document.getElementById("tools-available");
 
+  // Discord elements
+  const discordPanel = document.getElementById("discord-panel");
+  const discordChip = document.getElementById("discord-chip");
+  const discordWebhookInput = document.getElementById("discord-webhook-url");
+  const discordBotTokenInput = document.getElementById("discord-bot-token");
+  const discordUserIdInput = document.getElementById("discord-user-id");
+  const saveDiscordBtn = document.getElementById("save-discord-btn");
+  const discordStatus = document.getElementById("discord-status");
+
   const AUTO_WITH = {
     dance: ["stop_dance"],
     play_emotion: ["stop_emotion"],
@@ -354,6 +386,7 @@ async function init() {
   show(formPanel, false);
   show(configuredPanel, false);
   show(personalityPanel, false);
+  show(discordPanel, false);
 
   const st = (await waitForStatus()) || {
     active_backend: OPENAI_BACKEND,
@@ -580,6 +613,52 @@ async function init() {
       setStatusMessage(pStatus, "Voices unavailable. The backend default voice will be used.", "warn");
     }
     show(personalityPanel, true);
+
+    // Discord config panel
+    function applyDiscordStatus(status) {
+      if (!status) {
+        discordChip.textContent = "Optional";
+        discordChip.classList.remove("chip-ok");
+        return;
+      }
+      const webhookSet = !!status.has_webhook_url;
+      const dmSet = !!status.has_bot_token && !!status.has_user_id;
+      if (webhookSet && dmSet) {
+        discordChip.textContent = "Configured";
+        discordChip.classList.add("chip-ok");
+      } else if (webhookSet || dmSet) {
+        discordChip.textContent = "Partially configured";
+        discordChip.classList.remove("chip-ok");
+      } else {
+        discordChip.textContent = "Optional";
+        discordChip.classList.remove("chip-ok");
+      }
+    }
+    applyDiscordStatus(await getDiscordConfig());
+    show(discordPanel, true);
+
+    saveDiscordBtn.addEventListener("click", async () => {
+      const payload = {
+        webhook_url: discordWebhookInput.value,
+        bot_token: discordBotTokenInput.value,
+        user_id: discordUserIdInput.value,
+      };
+      if (!payload.webhook_url.trim() && !payload.bot_token.trim() && !payload.user_id.trim()) {
+        setStatusMessage(discordStatus, "Enter at least one value to save.", "warn");
+        return;
+      }
+      setStatusMessage(discordStatus, "Saving Discord config...");
+      try {
+        const resp = await saveDiscordConfig(payload);
+        applyDiscordStatus(resp);
+        discordWebhookInput.value = "";
+        discordBotTokenInput.value = "";
+        discordUserIdInput.value = "";
+        setStatusMessage(discordStatus, "Saved. Restart Reachy Mini Conversation to enable the tools.", "ok");
+      } catch (e) {
+        setStatusMessage(discordStatus, "Failed to save Discord config. Please try again.", "error");
+      }
+    });
 
     pApplyVoice.addEventListener("click", async () => {
       const voice = pVoice.value;

--- a/src/reachy_mini_conversation_app/tools/_discord_common.py
+++ b/src/reachy_mini_conversation_app/tools/_discord_common.py
@@ -1,0 +1,45 @@
+"""Shared helpers for the Discord tools (webhook channel post and bot DM)."""
+
+import json
+
+import httpx
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.camera_frame_encoding import encode_bgr_frame_as_jpeg
+
+
+MAX_DISCORD_CONTENT_LEN = 2000
+
+
+def capture_jpeg(deps: ToolDependencies) -> tuple[bytes | None, str | None]:
+    """Grab the latest camera frame and JPEG-encode it; return (bytes, skip_reason)."""
+    if deps.camera_worker is None:
+        return None, "camera worker not available"
+    frame = deps.camera_worker.get_latest_frame()
+    if frame is None:
+        return None, "no camera frame available"
+    try:
+        return encode_bgr_frame_as_jpeg(frame), None
+    except RuntimeError as exc:
+        return None, f"failed to encode frame as JPEG: {exc}"
+
+
+async def post_discord_message(
+    client: httpx.AsyncClient,
+    url: str,
+    message: str,
+    jpeg_bytes: bytes | None,
+    *,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """POST a Discord message (text + optional JPEG) to the given endpoint.
+
+    Webhooks and bot `channels/{id}/messages` accept the same payload shape,
+    so callers just pass the URL (and an `Authorization: Bot …` header for
+    the bot path).
+    """
+    if jpeg_bytes is not None:
+        files = {"files[0]": ("reachy_view.jpg", jpeg_bytes, "image/jpeg")}
+        data = {"payload_json": json.dumps({"content": message})}
+        return await client.post(url, data=data, files=files, headers=headers)
+    return await client.post(url, json={"content": message}, headers=headers)

--- a/src/reachy_mini_conversation_app/tools/_discord_common.py
+++ b/src/reachy_mini_conversation_app/tools/_discord_common.py
@@ -1,14 +1,25 @@
 """Shared helpers for the Discord tools (webhook channel post and bot DM)."""
 
+from __future__ import annotations
 import json
+from typing import TYPE_CHECKING
 
 import httpx
 
-from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.camera_frame_encoding import encode_bgr_frame_as_jpeg
 
 
+if TYPE_CHECKING:
+    from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+
+
 MAX_DISCORD_CONTENT_LEN = 2000
+DISCORD_API_BASE = "https://discord.com/api/v10"
+
+
+def bot_auth_header(token: str) -> dict[str, str]:
+    """Build the Authorization header for Discord bot API calls."""
+    return {"Authorization": f"Bot {token}"}
 
 
 def capture_jpeg(deps: ToolDependencies) -> tuple[bytes | None, str | None]:

--- a/src/reachy_mini_conversation_app/tools/send_discord.py
+++ b/src/reachy_mini_conversation_app/tools/send_discord.py
@@ -1,16 +1,18 @@
-import json
 import logging
 from typing import Any, Dict
 
+import httpx
+
 from reachy_mini_conversation_app.config import config
 from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
-from reachy_mini_conversation_app.camera_frame_encoding import encode_bgr_frame_as_jpeg
+from reachy_mini_conversation_app.tools._discord_common import (
+    MAX_DISCORD_CONTENT_LEN,
+    capture_jpeg,
+    post_discord_message,
+)
 
 
 logger = logging.getLogger(__name__)
-
-
-_MAX_DISCORD_CONTENT_LEN = 2000
 
 
 class SendDiscord(Tool):
@@ -48,14 +50,14 @@ class SendDiscord(Tool):
         message = (kwargs.get("message") or "").strip()
         if not message:
             return {"status": "error", "reason": "message must be a non-empty string"}
-        message = message[:_MAX_DISCORD_CONTENT_LEN]
+        message = message[:MAX_DISCORD_CONTENT_LEN]
 
         include_picture = bool(kwargs.get("include_picture", False))
         jpeg_bytes: bytes | None = None
         picture_skipped_reason: str | None = None
 
         if include_picture:
-            jpeg_bytes, picture_skipped_reason = _capture_jpeg(deps)
+            jpeg_bytes, picture_skipped_reason = capture_jpeg(deps)
 
         logger.info(
             "Tool call: send_discord len(message)=%d include_picture=%s sent_picture=%s",
@@ -64,17 +66,9 @@ class SendDiscord(Tool):
             jpeg_bytes is not None,
         )
 
-        # Deferred import: httpx ships transitively via openai; mirrors console.py.
-        import httpx
-
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
-                if jpeg_bytes is not None:
-                    files = {"files[0]": ("reachy_view.jpg", jpeg_bytes, "image/jpeg")}
-                    data = {"payload_json": json.dumps({"content": message})}
-                    response = await client.post(webhook_url, data=data, files=files)
-                else:
-                    response = await client.post(webhook_url, json={"content": message})
+                response = await post_discord_message(client, webhook_url, message, jpeg_bytes)
         except httpx.HTTPError as exc:
             logger.exception("send_discord: HTTP request failed")
             return {"status": "error", "reason": f"HTTP error: {exc}"}
@@ -100,16 +94,3 @@ class SendDiscord(Tool):
             "status": "error",
             "reason": f"Discord returned HTTP {response.status_code}: {response.text[:200]}",
         }
-
-
-def _capture_jpeg(deps: ToolDependencies) -> tuple[bytes | None, str | None]:
-    """Grab the latest camera frame and JPEG-encode it; return (bytes, skip_reason)."""
-    if deps.camera_worker is None:
-        return None, "camera worker not available"
-    frame = deps.camera_worker.get_latest_frame()
-    if frame is None:
-        return None, "no camera frame available"
-    try:
-        return encode_bgr_frame_as_jpeg(frame), None
-    except RuntimeError as exc:
-        return None, f"failed to encode frame as JPEG: {exc}"

--- a/src/reachy_mini_conversation_app/tools/send_discord.py
+++ b/src/reachy_mini_conversation_app/tools/send_discord.py
@@ -1,0 +1,115 @@
+import json
+import logging
+from typing import Any, Dict
+
+from reachy_mini_conversation_app.config import config
+from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
+from reachy_mini_conversation_app.camera_frame_encoding import encode_bgr_frame_as_jpeg
+
+
+logger = logging.getLogger(__name__)
+
+
+_MAX_DISCORD_CONTENT_LEN = 2000
+
+
+class SendDiscord(Tool):
+    """Send a notification to the user via a configured Discord webhook."""
+
+    name = "send_discord"
+    description = (
+        "Send a text notification to the user via Discord. "
+        "Optionally attach the current camera view as an image. "
+        "Use this when the user asks you to send them a message or a picture."
+    )
+    parameters_schema = {
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": "Text content of the message (max 2000 chars; will be truncated).",
+            },
+            "include_picture": {
+                "type": "boolean",
+                "description": "If true, attach the current camera frame as a JPEG image.",
+                "default": False,
+            },
+        },
+        "required": ["message"],
+    }
+
+    async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> Dict[str, Any]:
+        """Post the message (and optional camera frame) to the configured Discord webhook."""
+        webhook_url = (config.DISCORD_WEBHOOK_URL or "").strip()
+        if not webhook_url:
+            logger.warning("send_discord: DISCORD_WEBHOOK_URL not configured")
+            return {"status": "error", "reason": "Discord webhook URL not configured"}
+
+        message = (kwargs.get("message") or "").strip()
+        if not message:
+            return {"status": "error", "reason": "message must be a non-empty string"}
+        message = message[:_MAX_DISCORD_CONTENT_LEN]
+
+        include_picture = bool(kwargs.get("include_picture", False))
+        jpeg_bytes: bytes | None = None
+        picture_skipped_reason: str | None = None
+
+        if include_picture:
+            jpeg_bytes, picture_skipped_reason = _capture_jpeg(deps)
+
+        logger.info(
+            "Tool call: send_discord len(message)=%d include_picture=%s sent_picture=%s",
+            len(message),
+            include_picture,
+            jpeg_bytes is not None,
+        )
+
+        # Deferred import: httpx ships transitively via openai; mirrors console.py.
+        import httpx
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                if jpeg_bytes is not None:
+                    files = {"files[0]": ("reachy_view.jpg", jpeg_bytes, "image/jpeg")}
+                    data = {"payload_json": json.dumps({"content": message})}
+                    response = await client.post(webhook_url, data=data, files=files)
+                else:
+                    response = await client.post(webhook_url, json={"content": message})
+        except httpx.HTTPError as exc:
+            logger.exception("send_discord: HTTP request failed")
+            return {"status": "error", "reason": f"HTTP error: {exc}"}
+
+        if response.status_code in (200, 204):
+            result: Dict[str, Any] = {
+                "status": "sent",
+                "included_picture": jpeg_bytes is not None,
+            }
+            if picture_skipped_reason is not None:
+                result["picture_skipped_reason"] = picture_skipped_reason
+            return result
+
+        if response.status_code == 429:
+            retry_after: Any = None
+            try:
+                retry_after = response.json().get("retry_after")
+            except Exception:
+                pass
+            return {"status": "error", "reason": "rate limited", "retry_after": retry_after}
+
+        return {
+            "status": "error",
+            "reason": f"Discord returned HTTP {response.status_code}: {response.text[:200]}",
+        }
+
+
+def _capture_jpeg(deps: ToolDependencies) -> tuple[bytes | None, str | None]:
+    """Grab the latest camera frame and JPEG-encode it; return (bytes, skip_reason)."""
+    if deps.camera_worker is None:
+        return None, "camera worker not available"
+    frame = deps.camera_worker.get_latest_frame()
+    if frame is None:
+        return None, "no camera frame available"
+    try:
+        return encode_bgr_frame_as_jpeg(frame), None
+    except RuntimeError as exc:
+        return None, f"failed to encode frame as JPEG: {exc}"

--- a/src/reachy_mini_conversation_app/tools/send_discord_dm.py
+++ b/src/reachy_mini_conversation_app/tools/send_discord_dm.py
@@ -1,0 +1,145 @@
+import logging
+from typing import Any, Dict
+
+import httpx
+
+from reachy_mini_conversation_app.config import config
+from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
+from reachy_mini_conversation_app.tools._discord_common import (
+    MAX_DISCORD_CONTENT_LEN,
+    capture_jpeg,
+    post_discord_message,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+_DISCORD_API_BASE = "https://discord.com/api/v10"
+
+
+class SendDiscordDM(Tool):
+    """Send a direct message to the user via a configured Discord bot."""
+
+    name = "send_discord_dm"
+    description = (
+        "Send a private direct message to the user on Discord via a bot. "
+        "Optionally attach the current camera view as an image. "
+        "Use this when the user asks you to DM them on Discord."
+    )
+    parameters_schema = {
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": "Text content of the DM (max 2000 chars; will be truncated).",
+            },
+            "include_picture": {
+                "type": "boolean",
+                "description": "If true, attach the current camera frame as a JPEG image.",
+                "default": False,
+            },
+        },
+        "required": ["message"],
+    }
+
+    async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> Dict[str, Any]:
+        """Open (or reuse) a DM channel with the configured user and post the message."""
+        bot_token = (config.DISCORD_BOT_TOKEN or "").strip()
+        user_id = (config.DISCORD_USER_ID or "").strip()
+        if not bot_token or not user_id:
+            logger.warning("send_discord_dm: DISCORD_BOT_TOKEN and/or DISCORD_USER_ID not configured")
+            return {"status": "error", "reason": "Discord DM not configured"}
+
+        message = (kwargs.get("message") or "").strip()
+        if not message:
+            return {"status": "error", "reason": "message must be a non-empty string"}
+        message = message[:MAX_DISCORD_CONTENT_LEN]
+
+        include_picture = bool(kwargs.get("include_picture", False))
+        jpeg_bytes: bytes | None = None
+        picture_skipped_reason: str | None = None
+        if include_picture:
+            jpeg_bytes, picture_skipped_reason = capture_jpeg(deps)
+
+        logger.info(
+            "Tool call: send_discord_dm len(message)=%d include_picture=%s sent_picture=%s",
+            len(message),
+            include_picture,
+            jpeg_bytes is not None,
+        )
+
+        headers = {"Authorization": f"Bot {bot_token}"}
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                # Step 1: open/get DM channel (idempotent — returns existing if any).
+                dm_resp = await client.post(
+                    f"{_DISCORD_API_BASE}/users/@me/channels",
+                    json={"recipient_id": user_id},
+                    headers=headers,
+                )
+                if dm_resp.status_code != 200:
+                    return _interpret_dm_open_error(dm_resp)
+
+                try:
+                    channel_id = dm_resp.json()["id"]
+                except (KeyError, ValueError):
+                    return {"status": "error", "reason": "malformed DM channel response"}
+
+                # Step 2: post the message into that DM channel.
+                msg_resp = await post_discord_message(
+                    client,
+                    f"{_DISCORD_API_BASE}/channels/{channel_id}/messages",
+                    message,
+                    jpeg_bytes,
+                    headers=headers,
+                )
+        except httpx.HTTPError as exc:
+            logger.exception("send_discord_dm: HTTP request failed")
+            return {"status": "error", "reason": f"HTTP error: {exc}"}
+
+        if msg_resp.status_code == 200:
+            result: Dict[str, Any] = {
+                "status": "sent",
+                "included_picture": jpeg_bytes is not None,
+            }
+            if picture_skipped_reason is not None:
+                result["picture_skipped_reason"] = picture_skipped_reason
+            return result
+
+        return _interpret_message_error(msg_resp)
+
+
+def _interpret_dm_open_error(response: httpx.Response) -> Dict[str, Any]:
+    """Translate a failed POST /users/@me/channels response to a tool error."""
+    if response.status_code == 401:
+        return {"status": "error", "reason": "invalid Discord bot token"}
+    if response.status_code == 403:
+        return {
+            "status": "error",
+            "reason": "bot is not allowed to DM this user (not sharing a server, or user has DMs closed)",
+        }
+    if response.status_code == 404:
+        return {"status": "error", "reason": "Discord user ID not found"}
+    return {
+        "status": "error",
+        "reason": f"Failed to open DM channel: HTTP {response.status_code}: {response.text[:200]}",
+    }
+
+
+def _interpret_message_error(response: httpx.Response) -> Dict[str, Any]:
+    """Translate a failed POST /channels/.../messages response to a tool error."""
+    if response.status_code == 429:
+        retry_after: Any = None
+        try:
+            retry_after = response.json().get("retry_after")
+        except Exception:
+            pass
+        return {"status": "error", "reason": "rate limited", "retry_after": retry_after}
+    if response.status_code == 403:
+        return {"status": "error", "reason": "bot is not allowed to DM this user"}
+    return {
+        "status": "error",
+        "reason": f"Discord returned HTTP {response.status_code}: {response.text[:200]}",
+    }

--- a/src/reachy_mini_conversation_app/tools/send_discord_dm.py
+++ b/src/reachy_mini_conversation_app/tools/send_discord_dm.py
@@ -6,16 +6,15 @@ import httpx
 from reachy_mini_conversation_app.config import config
 from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
 from reachy_mini_conversation_app.tools._discord_common import (
+    DISCORD_API_BASE,
     MAX_DISCORD_CONTENT_LEN,
     capture_jpeg,
+    bot_auth_header,
     post_discord_message,
 )
 
 
 logger = logging.getLogger(__name__)
-
-
-_DISCORD_API_BASE = "https://discord.com/api/v10"
 
 
 class SendDiscordDM(Tool):
@@ -69,13 +68,13 @@ class SendDiscordDM(Tool):
             jpeg_bytes is not None,
         )
 
-        headers = {"Authorization": f"Bot {bot_token}"}
+        headers = bot_auth_header(bot_token)
 
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 # Step 1: open/get DM channel (idempotent — returns existing if any).
                 dm_resp = await client.post(
-                    f"{_DISCORD_API_BASE}/users/@me/channels",
+                    f"{DISCORD_API_BASE}/users/@me/channels",
                     json={"recipient_id": user_id},
                     headers=headers,
                 )
@@ -90,7 +89,7 @@ class SendDiscordDM(Tool):
                 # Step 2: post the message into that DM channel.
                 msg_resp = await post_discord_message(
                     client,
-                    f"{_DISCORD_API_BASE}/channels/{channel_id}/messages",
+                    f"{DISCORD_API_BASE}/channels/{channel_id}/messages",
                     message,
                     jpeg_bytes,
                     headers=headers,


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
Adds discord as a tool so the robot can publish image and text in a channel or in DM via a bot.

## Category
- [ ] Fix
- [X] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [X] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [X] Code is clear (types, docs, comments where needed)
- [X] `.env.example` updated (if new config vars were added)
- [X] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [X] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
The creation of the discord token is explained in the `.env.example`. These variables are also exposed in the desktop app UI.
