### PR TITLE
Make YOLO timeout recovery deterministic across platforms

### DIFF
--- a/src/reachy_mini_conversation_app/vision/head_tracking/yolo_process.py
+++ b/src/reachy_mini_conversation_app/vision/head_tracking/yolo_process.py
@@ -137,6 +137,7 @@ class YoloHeadTrackerProcess:
         self._messages: queue.Queue[tuple[str, object | None]] = queue.Queue()
         self._next_request_id = 0
         self._timed_out_request_id: int | None = None
+        self._recovery_call_pending = False
         self._tracker_name = "yolo"
 
         module_path = "reachy_mini_conversation_app.vision.head_tracking.yolo_process"
@@ -304,8 +305,14 @@ class YoloHeadTrackerProcess:
         request_id: int | None = None
         try:
             with self._send_lock:
-                # Avoid writing another frame while the child is still finishing a timed-out one.
-                if not self._drain_timed_out_reply():
+                # Reserve the immediate next call after a timeout for recovery
+                # only. Later calls may drain a delayed reply and continue with
+                # a fresh request in the same turn.
+                if self._recovery_call_pending:
+                    self._recovery_call_pending = False
+                    self._drain_timed_out_reply()
+                    return None, None
+                if self._timed_out_request_id is not None and not self._drain_timed_out_reply():
                     return None, None
 
                 request_id = self._next_request_id
@@ -315,6 +322,7 @@ class YoloHeadTrackerProcess:
         except TimeoutError as exc:
             if request_id is not None:
                 self._timed_out_request_id = request_id
+                self._recovery_call_pending = True
             logger.warning("Head tracker %s communication timed out: %s", self._tracker_name, exc)
             return None, None
         except Exception as exc:

--- a/tests/vision/test_yolo_process.py
+++ b/tests/vision/test_yolo_process.py
@@ -81,7 +81,7 @@ def test_head_tracker_skips_new_frame_until_timed_out_reply_is_drained(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A timed-out request should not let the next frame block on the worker pipe."""
+    """A timed-out request should reserve the next call for recovery, even if the delayed reply has arrived."""
     _patch_fake_worker(
         monkeypatch,
         tmp_path,
@@ -116,6 +116,7 @@ def test_head_tracker_skips_new_frame_until_timed_out_reply_is_drained(
         assert eye_center is None
         assert roll is None
 
+        time.sleep(0.15)
         blocked_started = time.monotonic()
         eye_center, roll = tracker.get_head_position(frame)
         blocked_elapsed = time.monotonic() - blocked_started
@@ -123,10 +124,6 @@ def test_head_tracker_skips_new_frame_until_timed_out_reply_is_drained(
         assert roll is None
         assert blocked_elapsed < 0.05
 
-        time.sleep(0.15)
-        # The behavior under test is that once the delayed reply is drained, the
-        # next request succeeds. Give that recovery request a less scheduler-
-        # sensitive timeout so macOS/Windows process wakeups do not flap the test.
         tracker.request_timeout = 0.2
         eye_center, roll = tracker.get_head_position(frame)
         assert eye_center is not None


### PR DESCRIPTION
## Summary
This PR makes YOLO head-tracker timeout recovery deterministic by reserving the next call for recovery instead of mixing recovery with a new request. It also clarifies the recovery-state naming and stabilizes the Windows test path.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
