### PR TITLE
fix: correct the order of the chat transcript for gemini gradio ui

### DIFF
--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -402,6 +402,8 @@ class GeminiLiveHandler(AsyncStreamHandler):
         if not response.tool_call or not response.tool_call.function_calls:
             return
 
+        await self._flush_transcript_chunks("user", self._pending_user_transcript_chunks)
+
         for fc in response.tool_call.function_calls:
             tool_name = fc.name
             call_id = fc.id or str(uuid.uuid4())


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
<!-- What does this PR change and why? -->
- Fixes issue #327 
- Flushes user transcript before emitting tool call notification in Gemini backend (tool call itself is not delayed, just printing)

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [x] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
<!-- Optional: context, caveats, migration notes -->
