### PR TITLE
Feat/329 camera support for sim

### DIFF
--- a/src/reachy_mini_conversation_app/camera_worker.py
+++ b/src/reachy_mini_conversation_app/camera_worker.py
@@ -20,10 +20,27 @@ logger = logging.getLogger(__name__)
 class CameraWorker:
     """Thread-safe camera worker with frame buffering and optional head tracking."""
 
-    def __init__(self, reachy_mini: ReachyMini, head_tracker: HeadTracker | None = None) -> None:
+    def __init__(
+        self, reachy_mini: ReachyMini, head_tracker: HeadTracker | None = None, is_simulation: bool = False
+    ) -> None:
         """Initialize."""
         self.reachy_mini = reachy_mini
         self.head_tracker = head_tracker
+        self._webcam = None
+
+        if is_simulation:
+            try:
+                import cv2
+
+                cap = cv2.VideoCapture(0)
+                if cap.isOpened():
+                    self._webcam = cap
+                    logger.info("Simulation camera: using local webcam (index 0)")
+                else:
+                    cap.release()
+                    logger.warning("Simulation camera: no webcam found, running without camera")
+            except ImportError:
+                logger.warning("Simulation camera: opencv-python not installed, running without camera")
 
         self.latest_frame: NDArray[np.uint8] | None = None
         self.frame_lock = threading.Lock()
@@ -81,6 +98,8 @@ class CameraWorker:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join()
+        if self._webcam is not None:
+            self._webcam.release()
         head_tracker_close = getattr(self.head_tracker, "close", None)
         if callable(head_tracker_close):
             head_tracker_close()
@@ -97,7 +116,11 @@ class CameraWorker:
         while not self._stop_event.is_set():
             try:
                 current_time = time.time()
-                frame = self.reachy_mini.media.get_frame()
+                if self._webcam is not None:
+                    ret, bgr_frame = self._webcam.read()
+                    frame: NDArray[np.uint8] | None = np.asarray(bgr_frame, dtype=np.uint8) if ret else None
+                else:
+                    frame = self.reachy_mini.media.get_frame()
 
                 if frame is not None:
                     # Keep the latest frame available for tools and UI consumers

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -402,6 +402,8 @@ class GeminiLiveHandler(AsyncStreamHandler):
         if not response.tool_call or not response.tool_call.function_calls:
             return
 
+        await self._flush_transcript_chunks("user", self._pending_user_transcript_chunks)
+
         for fc in response.tool_call.function_calls:
             tool_name = fc.name
             call_id = fc.id or str(uuid.uuid4())

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -120,7 +120,7 @@ def run(
         args.gradio = True
 
     try:
-        camera_worker, vision_processor = initialize_camera_and_vision(args, robot)
+        camera_worker, vision_processor = initialize_camera_and_vision(args, robot, is_simulation=is_simulation)
     except CameraVisionInitializationError as e:
         logger.error("Failed to initialize camera/vision: %s", e)
         sys.exit(1)

--- a/src/reachy_mini_conversation_app/utils.py
+++ b/src/reachy_mini_conversation_app/utils.py
@@ -52,6 +52,7 @@ def parse_args() -> tuple[argparse.Namespace, list]:  # type: ignore
 def initialize_camera_and_vision(
     args: argparse.Namespace,
     current_robot: ReachyMini,
+    is_simulation: bool = False,
 ) -> tuple[CameraWorker | None, VisionProcessor | None]:
     """Initialize camera capture, optional head tracking, and optional local vision."""
     camera_worker: Optional[CameraWorker] = None
@@ -80,7 +81,7 @@ def initialize_camera_and_vision(
                     f"Failed to initialize {args.head_tracker} head tracker: {e}",
                 ) from e
 
-        camera_worker = CameraWorker(current_robot, head_tracker)
+        camera_worker = CameraWorker(current_robot, head_tracker, is_simulation=is_simulation)
 
         if args.local_vision:
             result = subprocess.run(

--- a/tests/test_camera_worker.py
+++ b/tests/test_camera_worker.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+
+from reachy_mini_conversation_app.camera_worker import CameraWorker
+
+
+def test_simulation_webcam_opens_successfully() -> None:
+    """CameraWorker should store the capture object when webcam is available in simulation."""
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+
+    with patch("cv2.VideoCapture", return_value=mock_cap):
+        worker = CameraWorker(MagicMock(), is_simulation=True)
+
+    assert worker._webcam is mock_cap
+
+
+def test_simulation_webcam_fails_to_open() -> None:
+    """CameraWorker should continue without camera when webcam cannot be opened."""
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = False
+
+    with patch("cv2.VideoCapture", return_value=mock_cap):
+        worker = CameraWorker(MagicMock(), is_simulation=True)
+
+    assert worker._webcam is None
+    mock_cap.release.assert_called_once()
+
+
+def test_simulation_cv2_not_installed() -> None:
+    """CameraWorker should continue without camera when opencv is not installed."""
+    with patch.dict("sys.modules", {"cv2": None}):
+        worker = CameraWorker(MagicMock(), is_simulation=True)
+
+    assert worker._webcam is None
+
+
+def test_real_robot_uses_media_get_frame() -> None:
+    """CameraWorker should read frames from the robot camera when not in simulation mode."""
+    mock_robot = MagicMock()
+    worker = CameraWorker(mock_robot, is_simulation=False)
+
+    def get_frame_and_stop():
+        worker._stop_event.set()
+        return None
+
+    mock_robot.media.get_frame.side_effect = get_frame_and_stop
+
+    with patch("time.sleep"):
+        worker.working_loop()
+
+    mock_robot.media.get_frame.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,4 +94,4 @@ def test_initialize_camera_and_vision_uses_mediapipe_head_tracker_in_process() -
     ):
         initialize_camera_and_vision(args, current_robot)
 
-    mock_camera_worker.assert_called_once_with(current_robot, mediapipe_head_tracker)
+    mock_camera_worker.assert_called_once_with(current_robot, mediapipe_head_tracker, is_simulation=False)


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
<!-- What does this PR change and why? -->
- Adds camera support for simulation mode conversations (issue #329) 
- Adds webcam camera support for simulation mode using OpenCV (`cv2.VideoCapture`)
- Falls back to no camera if no webcam is available or OpenCV is not installed (app continues as before)
- Passes `is_simulation` parameter through main.py in `initialize_camera_and_vision` and `CameraWorker` 
- updated existing `test_utils.py` to reflect new `is_simulation` parameter

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [x] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [x] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
<!-- Optional: context, caveats, migration notes -->
