### PR TITLE
Fix Gemini data usage policy link

### DIFF
--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -27,7 +27,7 @@
             data usage policy
           </a>
           and Google's
-          <a href="https://ai.google.dev/gemini-api/docs/data-usage" target="_blank" rel="noopener">
+          <a href="https://ai.google.dev/gemini-api/terms#data-use-unpaid" target="_blank" rel="noopener">
             Gemini API data usage policy
           </a>
           for details.


### PR DESCRIPTION
## Summary
- Update the Gemini API data usage policy link in the privacy notice to the current Gemini API Terms data-use section.
- Remove the stale `docs/data-usage` URL that now returns 404.

## Validation
- `curl -I -L -s -o /dev/null -w '%{http_code} %{url_effective}\\n' 'https://ai.google.dev/gemini-api/terms#data-use-unpaid'`\n- `git diff --check`\n\nCloses #333