### PR TITLE
Add Hermes delegation tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,11 @@ REACHY_MINI_CUSTOM_PROFILE="example"
 # even if they are not listed in the selected profile's tools.txt.
 # This is convenient for downloaded tools used with built-in/default profiles.
 # AUTOLOAD_EXTERNAL_TOOLS=1
+
+# Hermes delegation (optional; no real token is included here)
+# HERMES_DELEGATION_ENABLED=0
+# HERMES_DELEGATION_BASE_URL=http://<hermes-tailscale-ip>:8080
+# HERMES_DELEGATION_API_TOKEN=replace-with-hermes-api-server-key
+# HERMES_DELEGATION_TIMEOUT_SECONDS=45
+# HERMES_DELEGATION_MODEL=hermes-agent
+# HERMES_DELEGATION_SESSION_NAME=reachy-mini

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Some wheels (like PyTorch) are large and require compatible CUDA or CPU buildsâ€
 | `HF_HOME` | Cache directory for local Hugging Face downloads (only used with `--local-vision` flag, defaults to `./cache`). |
 | `HF_TOKEN` | Optional token for Hugging Face access (for gated/private assets). |
 | `LOCAL_VISION_MODEL` | Hugging Face model path for local vision processing (only used with `--local-vision` flag, defaults to `HuggingFaceTB/SmolVLM2-2.2B-Instruct`). |
+| `HERMES_DELEGATION_ENABLED` | Optional. Set to `1` to expose `delegate_to_hermes` with a configured Hermes API client. Defaults to disabled. |
+| `HERMES_DELEGATION_BASE_URL` / `HERMES_BASE_URL` | Optional. Hermes API Server base URL, for example a Tailscale-only `http://<hermes-tailscale-ip>:8080`. |
+| `HERMES_DELEGATION_API_TOKEN` / `HERMES_API_TOKEN` | Optional secret. Bearer token matching Hermes `API_SERVER_KEY`. Do not commit real values. |
+| `HERMES_DELEGATION_TIMEOUT_SECONDS` / `HERMES_TIMEOUT_SECONDS` | Optional. Interactive delegation timeout, default `45`. |
+| `HERMES_DELEGATION_MODEL` / `HERMES_MODEL_NAME` | Optional. Hermes API model label, default `hermes-agent`. |
 
 ## Running the app
 

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -2,6 +2,7 @@ import os
 import sys
 import logging
 from pathlib import Path
+from dataclasses import dataclass
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -34,6 +35,22 @@ def _env_flag(name: str, default: bool = False) -> bool:
     return default
 
 
+def _env_float(name: str, default: float) -> float:
+    """Parse a positive float environment value."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Invalid float value for %s=%r, using default=%s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Non-positive float value for %s=%r, using default=%s", name, raw, default)
+        return default
+    return value
+
+
 def _collect_profile_names(profiles_root: Path) -> set[str]:
     """Return profile folder names from a profiles root directory."""
     if not profiles_root.exists() or not profiles_root.is_dir():
@@ -46,11 +63,7 @@ def _collect_tool_module_names(tools_root: Path) -> set[str]:
     if not tools_root.exists() or not tools_root.is_dir():
         return set()
     ignored = {"__init__", "core_tools"}
-    return {
-        p.stem
-        for p in tools_root.glob("*.py")
-        if p.is_file() and p.stem not in ignored
-    }
+    return {p.stem for p in tools_root.glob("*.py") if p.is_file() and p.stem not in ignored}
 
 
 def _raise_on_name_collisions(
@@ -71,6 +84,18 @@ def _raise_on_name_collisions(
         f"External {label} root: {external_root}. Built-in {label} root: {internal_root}. "
         f"Please rename the conflicting external {label}(s) to continue."
     )
+
+
+@dataclass(frozen=True)
+class HermesDelegationConfig:
+    """Settings for delegating conversation tasks to Hermes."""
+
+    enabled: bool
+    base_url: str
+    api_token: str
+    timeout_seconds: float
+    model: str
+    session_name: str
 
 
 # Validate LOCKED_PROFILE at startup
@@ -124,6 +149,15 @@ class Config:
     AUTOLOAD_EXTERNAL_TOOLS = _env_flag("AUTOLOAD_EXTERNAL_TOOLS", default=False)
     REACHY_MINI_CUSTOM_PROFILE = LOCKED_PROFILE or os.getenv("REACHY_MINI_CUSTOM_PROFILE")
 
+    HERMES_DELEGATION = HermesDelegationConfig(
+        enabled=_env_flag("HERMES_DELEGATION_ENABLED", default=False),
+        base_url=os.getenv("HERMES_DELEGATION_BASE_URL") or os.getenv("HERMES_BASE_URL", ""),
+        api_token=os.getenv("HERMES_DELEGATION_API_TOKEN") or os.getenv("HERMES_API_TOKEN", ""),
+        timeout_seconds=_env_float("HERMES_DELEGATION_TIMEOUT_SECONDS", _env_float("HERMES_TIMEOUT_SECONDS", 45.0)),
+        model=os.getenv("HERMES_DELEGATION_MODEL") or os.getenv("HERMES_MODEL_NAME", "hermes-agent"),
+        session_name=os.getenv("HERMES_DELEGATION_SESSION_NAME", "reachy-mini"),
+    )
+
     logger.debug(f"Custom Profile: {REACHY_MINI_CUSTOM_PROFILE}")
 
     def __init__(self) -> None:
@@ -172,8 +206,7 @@ class Config:
             )
         else:
             logger.info(
-                "'REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY' is not set. "
-                "Using built-in profiles from %s.",
+                "'REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY' is not set. Using built-in profiles from %s.",
                 DEFAULT_PROFILES_DIRECTORY,
             )
 
@@ -184,10 +217,7 @@ class Config:
                 self.TOOLS_DIRECTORY,
             )
         else:
-            logger.info(
-                "'REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY' is not set. "
-                "Using built-in shared tools only."
-            )
+            logger.info("'REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY' is not set. Using built-in shared tools only.")
 
 
 config = Config()

--- a/src/reachy_mini_conversation_app/hermes_client.py
+++ b/src/reachy_mini_conversation_app/hermes_client.py
@@ -1,0 +1,350 @@
+"""HTTP client for delegating conversation tasks to a Hermes API server."""
+
+from __future__ import annotations
+import json
+import asyncio
+import logging
+import urllib.error
+import urllib.request
+from typing import Any, Callable
+from dataclasses import field, asdict, dataclass
+
+
+logger = logging.getLogger(__name__)
+
+Transport = Callable[[str, dict[str, str], bytes, float], tuple[int, bytes]]
+
+
+@dataclass(frozen=True)
+class HermesDelegationResult:
+    """Normalized result returned by Hermes delegation calls."""
+
+    status: str
+    answer: str
+    details: dict[str, Any] = field(default_factory=dict)
+    actions_taken: list[dict[str, Any]] = field(default_factory=list)
+    citations: list[dict[str, Any]] = field(default_factory=list)
+    task_id: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+class HermesDelegationClient:
+    """Small async wrapper around Hermes' `/v1/responses` HTTP API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_token: str,
+        timeout_seconds: float = 45.0,
+        model: str = "hermes-agent",
+        session_name: str = "reachy-mini",
+        transport: Transport | None = None,
+    ) -> None:
+        """Initialize the client.
+
+        Args:
+            base_url: Base Hermes API URL, for example `http://100.79.161.14:8080`.
+            api_token: Bearer token for Hermes API auth. Never logged.
+            timeout_seconds: Interactive request timeout.
+            model: Hermes API model label to send in `/v1/responses` payloads.
+            session_name: Source/session label visible to Hermes.
+            transport: Optional test transport; defaults to stdlib urllib.
+
+        """
+        self.base_url = base_url.rstrip("/")
+        self.api_token = api_token
+        self.timeout_seconds = timeout_seconds
+        self.model = model
+        self.session_name = session_name
+        self._transport = transport or self._urllib_transport
+
+    @property
+    def configured(self) -> bool:
+        """Return whether the client has the minimum settings needed to call Hermes."""
+        return bool(self.base_url and self.api_token)
+
+    async def delegate(
+        self,
+        *,
+        task: str,
+        why_needed: str | None = None,
+        response_style: str = "brief",
+        allowed_domains: list[str] | None = None,
+        context: dict[str, Any] | None = None,
+        urgency: str = "interactive",
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Delegate a task to Hermes and return a normalized JSON dict."""
+        task = task.strip()
+        if not task:
+            return HermesDelegationResult(
+                status="error",
+                answer="I need a task before I can ask Hermes for help.",
+                error="empty_task",
+            ).to_dict()
+
+        if not self.configured:
+            return HermesDelegationResult(
+                status="unavailable",
+                answer="Hermes delegation is not configured on this Reachy Mini.",
+                error="missing_base_url_or_token",
+            ).to_dict()
+
+        payload = self._build_payload(
+            task=task,
+            why_needed=why_needed,
+            response_style=response_style,
+            allowed_domains=allowed_domains,
+            context=context or {},
+            urgency=urgency,
+            session_id=session_id,
+        )
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Authorization": f"Bearer {self.api_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "reachy-mini-conversation-app/hermes-delegation",
+        }
+        if session_id:
+            headers["X-Reachy-Session-Id"] = session_id
+
+        url = f"{self.base_url}/v1/responses"
+        logger.info("Delegating task to Hermes API at %s/v1/responses", self.base_url)
+        try:
+            status_code, response_body = await asyncio.wait_for(
+                asyncio.to_thread(self._transport, url, headers, body, self.timeout_seconds),
+                timeout=self.timeout_seconds,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            logger.warning("Hermes delegation timed out after %.1fs", self.timeout_seconds)
+            return HermesDelegationResult(
+                status="timeout",
+                answer="Hermes did not answer before the timeout.",
+                error="timeout",
+            ).to_dict()
+        except urllib.error.URLError as exc:
+            logger.warning(
+                "Hermes delegation unavailable: %s", exc.reason if hasattr(exc, "reason") else type(exc).__name__
+            )
+            return HermesDelegationResult(
+                status="unavailable",
+                answer="Hermes is unreachable right now.",
+                error="network_unavailable",
+            ).to_dict()
+        except Exception as exc:
+            logger.warning("Hermes delegation failed before receiving a response: %s", type(exc).__name__)
+            return HermesDelegationResult(
+                status="unavailable",
+                answer="Hermes is unavailable right now.",
+                error=type(exc).__name__,
+            ).to_dict()
+
+        if status_code >= 500:
+            logger.warning("Hermes API returned HTTP %s", status_code)
+            return HermesDelegationResult(
+                status="unavailable",
+                answer="Hermes returned a temporary server error.",
+                details={"http_status": status_code},
+                error="server_error",
+            ).to_dict()
+
+        if status_code >= 400:
+            logger.warning("Hermes API rejected the request with HTTP %s", status_code)
+            return HermesDelegationResult(
+                status="error",
+                answer="Hermes rejected the delegation request.",
+                details={"http_status": status_code},
+                error="http_error",
+            ).to_dict()
+
+        try:
+            data = json.loads(response_body.decode("utf-8")) if response_body else {}
+        except json.JSONDecodeError:
+            logger.warning("Hermes API returned non-JSON response")
+            return HermesDelegationResult(
+                status="error",
+                answer="Hermes returned a response I could not understand.",
+                error="invalid_json",
+            ).to_dict()
+
+        return self._normalize_response(data).to_dict()
+
+    def _build_payload(
+        self,
+        *,
+        task: str,
+        why_needed: str | None,
+        response_style: str,
+        allowed_domains: list[str] | None,
+        context: dict[str, Any],
+        urgency: str,
+        session_id: str | None,
+    ) -> dict[str, Any]:
+        """Build an OpenAI Responses-compatible Hermes request payload."""
+        delegation_envelope = {
+            "source": "reachy_mini_conversation_app",
+            "session_name": self.session_name,
+            "session_id": session_id,
+            "task": task,
+            "why_needed": why_needed,
+            "response_style": response_style,
+            "allowed_domains": allowed_domains or [],
+            "urgency": urgency,
+            "context": context,
+            "tool_policy": {
+                "preferred_toolset": "hermes-api-server",
+                "home_assistant": "deferred/unconfigured unless Hermes has HA credentials",
+            },
+        }
+        prompt = (
+            "You are Hermes, helping Reachy Mini's live conversation app. "
+            "Complete the delegated task using your available web, Codex, MCP, or long-running tools when helpful. "
+            "Home Assistant-specific work is deferred unless Hermes is explicitly configured for it. "
+            "Return a concise answer suitable for Reachy to speak aloud, with citations if you used current web information.\n\n"
+            f"Delegation request JSON:\n{json.dumps(delegation_envelope, ensure_ascii=False)}"
+        )
+        return {
+            "model": self.model,
+            "input": prompt,
+            "store": False,
+        }
+
+    def _normalize_response(self, data: Any) -> HermesDelegationResult:
+        """Normalize known Hermes/OpenAI-compatible response shapes."""
+        if not isinstance(data, dict):
+            return HermesDelegationResult(
+                status="error",
+                answer="Hermes returned an unexpected response shape.",
+                error="unexpected_response_shape",
+            )
+
+        answer = self._extract_answer(data)
+        citations = self._extract_citations(data)
+        hermes_status = data.get("status") if isinstance(data.get("status"), str) else None
+        task_id = data.get("id") if isinstance(data.get("id"), str) else None
+
+        if not answer:
+            answer = "Hermes completed the request but did not return a text answer."
+
+        raw_details = data.get("details")
+        details: dict[str, Any] = raw_details if isinstance(raw_details, dict) else {}
+        raw_actions_taken = data.get("actions_taken")
+        actions_taken: list[Any] = raw_actions_taken if isinstance(raw_actions_taken, list) else []
+
+        return HermesDelegationResult(
+            status="ok" if hermes_status in {None, "completed", "ok"} else "error",
+            answer=answer,
+            details={
+                **details,
+                "hermes_status": hermes_status,
+                "http_api": "/v1/responses",
+                "model": data.get("model") if isinstance(data.get("model"), str) else self.model,
+            },
+            actions_taken=[action for action in actions_taken if isinstance(action, dict)],
+            citations=citations,
+            task_id=task_id,
+            error=None if hermes_status in {None, "completed", "ok"} else str(hermes_status),
+        )
+
+    def _extract_answer(self, data: dict[str, Any]) -> str:
+        """Extract human-readable text from common response fields."""
+        for key in ("answer", "output_text", "final_response", "message", "content", "text"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+        choices = data.get("choices")
+        if isinstance(choices, list):
+            texts: list[str] = []
+            for choice in choices:
+                if not isinstance(choice, dict):
+                    continue
+                message = choice.get("message")
+                if isinstance(message, dict) and isinstance(message.get("content"), str):
+                    texts.append(message["content"])
+                elif isinstance(choice.get("text"), str):
+                    texts.append(choice["text"])
+            if texts:
+                return "\n".join(text.strip() for text in texts if text.strip())
+
+        output = data.get("output")
+        if isinstance(output, list):
+            texts = []
+            for item in output:
+                texts.extend(self._extract_text_parts(item))
+            if texts:
+                return "\n".join(text.strip() for text in texts if text.strip())
+
+        return ""
+
+    def _extract_text_parts(self, item: Any) -> list[str]:
+        """Extract text fragments from a nested Responses API output item."""
+        if isinstance(item, str):
+            return [item]
+        if not isinstance(item, dict):
+            return []
+
+        texts: list[str] = []
+        for key in ("text", "output_text", "content"):
+            value = item.get(key)
+            if isinstance(value, str):
+                texts.append(value)
+            elif isinstance(value, list):
+                for nested in value:
+                    texts.extend(self._extract_text_parts(nested))
+        return texts
+
+    def _extract_citations(self, data: dict[str, Any]) -> list[dict[str, Any]]:
+        """Extract lightweight citation metadata when present."""
+        citations = data.get("citations")
+        if isinstance(citations, list):
+            return [citation for citation in citations if isinstance(citation, dict)]
+
+        extracted: list[dict[str, Any]] = []
+        output = data.get("output")
+        if not isinstance(output, list):
+            return extracted
+
+        for item in output:
+            for part in self._iter_content_parts(item):
+                annotations = part.get("annotations")
+                if not isinstance(annotations, list):
+                    continue
+                for annotation in annotations:
+                    if isinstance(annotation, dict) and annotation.get("url"):
+                        extracted.append(
+                            {
+                                "title": annotation.get("title") or annotation.get("url"),
+                                "url": annotation.get("url"),
+                            }
+                        )
+        return extracted
+
+    def _iter_content_parts(self, item: Any) -> list[dict[str, Any]]:
+        """Return nested dict content parts from a response item."""
+        if not isinstance(item, dict):
+            return []
+        content = item.get("content")
+        if isinstance(content, list):
+            return [part for part in content if isinstance(part, dict)]
+        return [item]
+
+    def _urllib_transport(
+        self, url: str, headers: dict[str, str], body: bytes, timeout_seconds: float
+    ) -> tuple[int, bytes]:
+        """POST JSON with urllib and return `(status_code, response_body)`.
+
+        The Authorization header may contain a secret; never log it here.
+        """
+        request = urllib.request.Request(url=url, data=body, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310
+                return int(response.status), response.read()
+        except urllib.error.HTTPError as exc:
+            return int(exc.code), exc.read()

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -44,7 +44,9 @@ def run(
     """Run the Reachy Mini conversation app."""
     # Putting these dependencies here makes the dashboard faster to load when the conversation app is installed
     from reachy_mini_conversation_app.moves import MovementManager
+    from reachy_mini_conversation_app.config import config
     from reachy_mini_conversation_app.console import LocalStream
+    from reachy_mini_conversation_app.hermes_client import HermesDelegationClient
     from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
     from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
     from reachy_mini_conversation_app.audio.head_wobbler import HeadWobbler
@@ -53,10 +55,7 @@ def run(
     logger.info("Starting Reachy Mini Conversation App")
 
     if args.no_camera and args.head_tracker is not None:
-        logger.warning(
-            "Head tracking disabled: --no-camera flag is set. "
-            "Remove --no-camera to enable head tracking."
-        )
+        logger.warning("Head tracking disabled: --no-camera flag is set. Remove --no-camera to enable head tracking.")
 
     if robot is None:
         try:
@@ -68,25 +67,17 @@ def run(
             robot = ReachyMini(**robot_kwargs)
 
         except TimeoutError as e:
-            logger.error(
-                "Connection timeout: Failed to connect to Reachy Mini daemon. "
-                f"Details: {e}"
-            )
+            logger.error(f"Connection timeout: Failed to connect to Reachy Mini daemon. Details: {e}")
             log_connection_troubleshooting(logger, args.robot_name)
             sys.exit(1)
 
         except ConnectionError as e:
-            logger.error(
-                "Connection failed: Unable to establish connection to Reachy Mini. "
-                f"Details: {e}"
-            )
+            logger.error(f"Connection failed: Unable to establish connection to Reachy Mini. Details: {e}")
             log_connection_troubleshooting(logger, args.robot_name)
             sys.exit(1)
 
         except Exception as e:
-            logger.error(
-                f"Unexpected error during robot initialization: {type(e).__name__}: {e}"
-            )
+            logger.error(f"Unexpected error during robot initialization: {type(e).__name__}: {e}")
             logger.error("Please check your configuration and try again.")
             sys.exit(1)
 
@@ -114,12 +105,31 @@ def run(
 
     head_wobbler = HeadWobbler(set_speech_offsets=movement_manager.set_speech_offsets)
 
+    hermes_client: HermesDelegationClient | None = None
+    hermes_settings = config.HERMES_DELEGATION
+    if hermes_settings.enabled:
+        if hermes_settings.base_url and hermes_settings.api_token:
+            hermes_client = HermesDelegationClient(
+                base_url=hermes_settings.base_url,
+                api_token=hermes_settings.api_token,
+                timeout_seconds=hermes_settings.timeout_seconds,
+                model=hermes_settings.model,
+                session_name=hermes_settings.session_name,
+            )
+            logger.info("Hermes delegation enabled: %s", hermes_settings.base_url)
+        else:
+            logger.warning(
+                "Hermes delegation is enabled but HERMES_DELEGATION_BASE_URL/HERMES_BASE_URL "
+                "or HERMES_DELEGATION_API_TOKEN/HERMES_API_TOKEN is missing."
+            )
+
     deps = ToolDependencies(
         reachy_mini=robot,
         movement_manager=movement_manager,
         camera_worker=camera_worker,
         vision_manager=vision_manager,
         head_wobbler=head_wobbler,
+        hermes_client=hermes_client,
     )
     current_file_path = os.path.dirname(os.path.abspath(__file__))
     logger.debug(f"Current file absolute path: {current_file_path}")

--- a/src/reachy_mini_conversation_app/profiles/default/instructions.txt
+++ b/src/reachy_mini_conversation_app/profiles/default/instructions.txt
@@ -1,1 +1,8 @@
 [default_prompt]
+
+Hermes delegation:
+- Use `delegate_to_hermes` when the user asks for current information, web research, citations, coding/Codex help, MCP/browser/tool-heavy work, or anything likely to take longer than a simple local response.
+- Do not delegate ordinary conversation, personality banter, simple explanations from your existing knowledge, or local Reachy movement/emotion/dance requests.
+- Ask Hermes for a `brief` response by default so the final answer is easy to speak aloud. Use `detailed` or `step_by_step` only when the user asks for depth.
+- If Hermes returns `timeout`, `unavailable`, `disabled`, or another non-ok status, apologize briefly and offer to retry or answer locally.
+- Home Assistant-specific actions are planned for later and should only be delegated if Hermes reports that it is configured for Home Assistant.

--- a/src/reachy_mini_conversation_app/profiles/default/tools.txt
+++ b/src/reachy_mini_conversation_app/profiles/default/tools.txt
@@ -6,3 +6,4 @@ camera
 do_nothing
 head_tracking
 move_head
+delegate_to_hermes

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -43,7 +43,6 @@ ALL_TOOL_SPECS: List[Dict[str, Any]] = []
 _TOOLS_INITIALIZED = False
 
 
-
 def get_concrete_subclasses(base: type[Tool]) -> List[type[Tool]]:
     """Recursively find all concrete (non-abstract) subclasses of a base class."""
     result: List[type[Tool]] = []
@@ -66,6 +65,7 @@ class ToolDependencies:
     vision_manager: Any | None = None
     head_wobbler: Any | None = None  # HeadWobbler for audio-reactive motion
     motion_duration_s: float = 1.0
+    hermes_client: Any | None = None
 
 
 # Tool base class
@@ -265,7 +265,6 @@ def _load_profile_tools() -> None:
                 logger.error(f"  Module path: {shared_module_path}")
 
 
-
 def _initialize_tools() -> None:
     """Populate registry once, even if module is imported repeatedly."""
     global ALL_TOOLS, ALL_TOOL_SPECS, _TOOLS_INITIALIZED
@@ -323,7 +322,9 @@ async def dispatch_tool_call(tool_name: str, args_json: str, deps: ToolDependenc
     return await _dispatch_tool_call(tool_name, _safe_load_obj(args_json), deps)
 
 
-async def dispatch_tool_call_with_manager(tool_name: str, args_json: str, deps: ToolDependencies, tool_manager: "BackgroundToolManager") -> Dict[str, Any]:
+async def dispatch_tool_call_with_manager(
+    tool_name: str, args_json: str, deps: ToolDependencies, tool_manager: "BackgroundToolManager"
+) -> Dict[str, Any]:
     """Dispatch a tool call, injecting a BackgroundToolManager into the args."""
     args = _safe_load_obj(args_json)
     args["tool_manager"] = tool_manager

--- a/src/reachy_mini_conversation_app/tools/delegate_to_hermes.py
+++ b/src/reachy_mini_conversation_app/tools/delegate_to_hermes.py
@@ -1,0 +1,93 @@
+"""Conversation tool for delegating external tasks to Hermes."""
+
+from __future__ import annotations
+import logging
+from typing import Any, Dict, cast
+
+from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
+
+
+logger = logging.getLogger(__name__)
+
+
+class DelegateToHermes(Tool):
+    """Delegate current-info, web, coding, or long-running tool work to Hermes."""
+
+    name = "delegate_to_hermes"
+    description = (
+        "Delegate tasks that need current information, web research, Codex/code assistance, MCP tools, "
+        "or longer-running external tool work to the user's Hermes agent. Do not use this for ordinary "
+        "conversation or local Reachy movement. Home Assistant work is deferred unless Hermes is configured for it."
+    )
+    parameters_schema = {
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "string",
+                "description": "The concrete user-facing task Hermes should complete.",
+            },
+            "why_needed": {
+                "type": "string",
+                "description": "Briefly explain why this needs Hermes instead of local conversation.",
+            },
+            "response_style": {
+                "type": "string",
+                "enum": ["brief", "detailed", "step_by_step"],
+                "description": "Preferred style for the result. Use brief for spoken answers by default.",
+            },
+            "allowed_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional web domains Hermes should prefer or limit itself to.",
+            },
+        },
+        "required": ["task"],
+    }
+
+    async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> Dict[str, Any]:
+        """Run the Hermes delegation tool."""
+        task = str(kwargs.get("task", "")).strip()
+        why_needed_raw = kwargs.get("why_needed")
+        response_style = str(kwargs.get("response_style") or "brief")
+        allowed_domains = kwargs.get("allowed_domains")
+
+        if not task:
+            return {
+                "status": "error",
+                "answer": "No task was provided for Hermes delegation.",
+                "error_message": "empty_task",
+            }
+
+        if deps.hermes_client is None:
+            return {
+                "status": "disabled",
+                "answer": "Hermes delegation is not configured on this Reachy Mini.",
+                "error_message": "hermes_client_missing",
+            }
+
+        if response_style not in {"brief", "detailed", "step_by_step"}:
+            response_style = "brief"
+
+        if not isinstance(allowed_domains, list):
+            allowed_domains = []
+        allowed_domain_strings = [str(domain) for domain in allowed_domains if str(domain).strip()]
+
+        logger.info("Tool call: delegate_to_hermes response_style=%s", response_style)
+        result = await deps.hermes_client.delegate(
+            task=task,
+            why_needed=str(why_needed_raw).strip() if why_needed_raw else None,
+            response_style=response_style,
+            allowed_domains=allowed_domain_strings,
+            context={
+                "profile": "default",
+                "robot": "reachy_mini",
+                "local_tool": self.name,
+            },
+            urgency="interactive",
+        )
+
+        # BackgroundToolManager treats any non-None top-level `error` as a failed tool and drops
+        # the rest of the structured payload. Preserve normalized Hermes failure details for the LLM.
+        if result.get("error") is not None:
+            result["error_message"] = result.pop("error")
+        return cast(Dict[str, Any], result)

--- a/tests/test_hermes_client.py
+++ b/tests/test_hermes_client.py
@@ -1,0 +1,149 @@
+"""Tests for Hermes delegation HTTP client."""
+
+from __future__ import annotations
+import json
+import urllib.error
+from typing import Any
+
+import pytest
+
+from reachy_mini_conversation_app.hermes_client import HermesDelegationClient
+
+
+def _json_response(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload).encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_delegate_success_normalizes_responses_output_shape() -> None:
+    """Normalize a successful OpenAI Responses-style output payload."""
+    captured: dict[str, Any] = {}
+
+    def transport(url: str, headers: dict[str, str], body: bytes, timeout_seconds: float) -> tuple[int, bytes]:
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["body"] = json.loads(body.decode("utf-8"))
+        captured["timeout_seconds"] = timeout_seconds
+        return 200, _json_response(
+            {
+                "id": "resp_123",
+                "status": "completed",
+                "model": "hermes-agent",
+                "details": {"foo": "bar"},
+                "actions_taken": [{"tool": "firecrawl_search"}, "ignored"],
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Detroit is cold today.",
+                                "annotations": [{"title": "Forecast", "url": "https://example.test/weather"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+    client = HermesDelegationClient(
+        base_url="http://hermes.test:8080/",
+        api_token="secret-token",
+        timeout_seconds=12.0,
+        transport=transport,
+    )
+
+    result = await client.delegate(task="weather in Detroit", session_id="session-1")
+
+    assert result["status"] == "ok"
+    assert result["answer"] == "Detroit is cold today."
+    assert result["citations"] == [{"title": "Forecast", "url": "https://example.test/weather"}]
+    assert result["task_id"] == "resp_123"
+    assert result["details"]["foo"] == "bar"
+    assert result["actions_taken"] == [{"tool": "firecrawl_search"}]
+    assert captured["url"] == "http://hermes.test:8080/v1/responses"
+    assert captured["headers"]["Authorization"] == "Bearer secret-token"
+    assert captured["headers"]["X-Reachy-Session-Id"] == "session-1"
+    assert captured["body"]["model"] == "hermes-agent"
+    assert captured["body"]["store"] is False
+    assert "weather in Detroit" in captured["body"]["input"]
+
+
+@pytest.mark.asyncio
+async def test_delegate_timeout_returns_normalized_timeout() -> None:
+    """Convert transport timeouts to a structured timeout result."""
+
+    def transport(url: str, headers: dict[str, str], body: bytes, timeout_seconds: float) -> tuple[int, bytes]:
+        raise TimeoutError("slow")
+
+    client = HermesDelegationClient(
+        base_url="http://hermes.test:8080",
+        api_token="secret-token",
+        timeout_seconds=1.0,
+        transport=transport,
+    )
+
+    result = await client.delegate(task="look this up")
+
+    assert result["status"] == "timeout"
+    assert result["error"] == "timeout"
+    assert "timeout" in result["answer"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delegate_http_error_does_not_expose_response_body() -> None:
+    """Normalize HTTP auth/client errors without echoing raw response bodies."""
+
+    def transport(url: str, headers: dict[str, str], body: bytes, timeout_seconds: float) -> tuple[int, bytes]:
+        return 401, b'{"error":"token secret-token is invalid"}'
+
+    client = HermesDelegationClient(
+        base_url="http://hermes.test:8080",
+        api_token="secret-token",
+        transport=transport,
+    )
+
+    result = await client.delegate(task="web search")
+
+    assert result["status"] == "error"
+    assert result["error"] == "http_error"
+    assert result["details"] == {"http_status": 401}
+    assert "secret-token" not in json.dumps(result)
+
+
+@pytest.mark.asyncio
+async def test_delegate_unavailable_for_url_error() -> None:
+    """Normalize unreachable Hermes network errors."""
+
+    def transport(url: str, headers: dict[str, str], body: bytes, timeout_seconds: float) -> tuple[int, bytes]:
+        raise urllib.error.URLError("connection refused")
+
+    client = HermesDelegationClient(
+        base_url="http://hermes.test:8080",
+        api_token="secret-token",
+        transport=transport,
+    )
+
+    result = await client.delegate(task="web search")
+
+    assert result["status"] == "unavailable"
+    assert result["error"] == "network_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_delegate_missing_configuration_is_unavailable() -> None:
+    """Avoid network calls when base URL or token is missing."""
+    called = False
+
+    def transport(url: str, headers: dict[str, str], body: bytes, timeout_seconds: float) -> tuple[int, bytes]:
+        nonlocal called
+        called = True
+        return 200, b"{}"
+
+    client = HermesDelegationClient(base_url="", api_token="", transport=transport)
+
+    result = await client.delegate(task="web search")
+
+    assert result["status"] == "unavailable"
+    assert result["error"] == "missing_base_url_or_token"
+    assert called is False

--- a/tests/tools/test_delegate_to_hermes.py
+++ b/tests/tools/test_delegate_to_hermes.py
@@ -1,0 +1,60 @@
+"""Tests for the delegate_to_hermes conversation tool."""
+
+from __future__ import annotations
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from reachy_mini_conversation_app.tools.delegate_to_hermes import DelegateToHermes
+
+
+@pytest.mark.asyncio
+async def test_delegate_tool_disabled_without_client() -> None:
+    """Return a speakable disabled result when no Hermes client is injected."""
+    tool = DelegateToHermes()
+    deps = SimpleNamespace(hermes_client=None)
+
+    result = await tool(deps, task="search the web")  # type: ignore[arg-type]
+
+    assert result["status"] == "disabled"
+    assert result["error_message"] == "hermes_client_missing"
+    assert "not configured" in result["answer"]
+    assert "error" not in result
+
+
+@pytest.mark.asyncio
+async def test_delegate_tool_calls_client_and_preserves_structured_failure() -> None:
+    """Call the injected client and avoid a top-level `error` key for background manager compatibility."""
+    calls: list[dict[str, Any]] = []
+
+    class FakeHermesClient:
+        async def delegate(self, **kwargs: Any) -> dict[str, Any]:
+            calls.append(kwargs)
+            return {
+                "status": "timeout",
+                "answer": "Hermes timed out.",
+                "error": "timeout",
+            }
+
+    tool = DelegateToHermes()
+    deps = SimpleNamespace(hermes_client=FakeHermesClient())
+
+    result = await tool(
+        deps,  # type: ignore[arg-type]
+        task="find current news",
+        why_needed="needs current information",
+        response_style="detailed",
+        allowed_domains=["example.com", 123],
+    )
+
+    assert result == {
+        "status": "timeout",
+        "answer": "Hermes timed out.",
+        "error_message": "timeout",
+    }
+    assert calls[0]["task"] == "find current news"
+    assert calls[0]["why_needed"] == "needs current information"
+    assert calls[0]["response_style"] == "detailed"
+    assert calls[0]["allowed_domains"] == ["example.com", "123"]
+    assert calls[0]["urgency"] == "interactive"


### PR DESCRIPTION
## Summary
- add `HermesDelegationClient` for authenticated `/v1/responses` delegation with timeout and safe error normalization
- add `delegate_to_hermes` conversation tool and inject Hermes client through `ToolDependencies`
- document Hermes env placeholders and update default profile tools/instructions
- add mocked tests for client success/timeout/error paths and disabled/no-client tool behavior

## Scope notes
- Home Assistant-specific implementation is intentionally deferred/on hold
- no PWA code implemented
- no live network tests; HTTP transport is mocked in unit tests

## Verification
- `pnpm setup:workspace` -> not applicable: no `package.json` in this Python conversation-app checkout
- `pnpm dev:workspace` -> not applicable: no `package.json` in this Python conversation-app checkout
- `uv run ruff check src/reachy_mini_conversation_app/hermes_client.py src/reachy_mini_conversation_app/tools/delegate_to_hermes.py src/reachy_mini_conversation_app/tools/core_tools.py src/reachy_mini_conversation_app/config.py src/reachy_mini_conversation_app/main.py tests/test_hermes_client.py tests/tools/test_delegate_to_hermes.py` -> passed
- `uv run mypy --pretty --show-error-codes src/reachy_mini_conversation_app/hermes_client.py src/reachy_mini_conversation_app/tools/delegate_to_hermes.py src/reachy_mini_conversation_app/tools/core_tools.py tests/test_hermes_client.py tests/tools/test_delegate_to_hermes.py` -> passed
- `uv run pytest tests/test_hermes_client.py tests/tools/test_delegate_to_hermes.py -v` -> 7 passed
- `REACHY_MINI_SKIP_DOTENV=1 uv run python - <<'PY' ...` -> confirmed `delegate_to_hermes` registers
- `uv run pytest tests/ --ignore=tests/vision -v` -> 57 passed
- `uv run pytest tests/ -v` -> blocked by missing optional `torch` while collecting `tests/vision/test_processors.py`
