### PR TITLE
Restore profile selector in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ HF_HOME=./cache
 # Hugging Face token for accessing datasets/models
 HF_TOKEN=
 
+# Optional built-in profile selector. Use a folder name from profiles/.
+# If unset, the app uses the default profile unless startup settings were saved from the UI.
+# REACHY_MINI_CUSTOM_PROFILE=mars_rover
+
 # Optional external profile/tool directories
 # REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY=external_content/external_profiles
 # REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY=external_content/external_tools


### PR DESCRIPTION
## Summary
`REACHY_MINI_CUSTOM_PROFILE` example back to `.env.example` so users can discover how to select a built-in profile from environment config.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>