### PR TITLE
Guard backend voice selection

### DIFF
--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -177,17 +177,35 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
 
     def _normalize_startup_voice(self, voice: str | None) -> str | None:
         """Return a valid persisted startup voice for this backend, or None."""
+        return self._resolve_backend_voice(voice, source="persisted startup voice")
+
+    def _resolve_backend_voice(
+        self,
+        voice: str | None,
+        *,
+        source: str,
+        fallback: str | None = None,
+    ) -> str | None:
+        """Return a backend-supported voice, optionally falling back when unsupported."""
         available_voices = get_available_voices_for_backend(self.BACKEND_PROVIDER)
-        if voice in available_voices:
-            return voice
+        voice_value = (voice or "").strip()
+        if not voice_value:
+            return fallback
+
+        voice_by_lowercase = {candidate.lower(): candidate for candidate in available_voices}
+        normalized_voice = voice_by_lowercase.get(voice_value.lower())
+        if normalized_voice is not None:
+            return normalized_voice
+
         if voice:
             logger.warning(
-                "Ignoring persisted startup voice %r for backend=%r; expected one of %s",
+                "Ignoring unsupported %s %r for backend=%r; expected one of %s",
+                source,
                 voice,
                 self.BACKEND_PROVIDER,
                 available_voices,
             )
-        return None
+        return fallback
 
     def _response_done_timeout(self) -> float:
         """Return the response completion timeout."""
@@ -233,11 +251,13 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
 
     async def change_voice(self, voice: str) -> str:
         """Change only the voice and restart the session."""
-        self._voice_override = voice
+        default_voice = get_default_voice_for_backend(self.BACKEND_PROVIDER)
+        resolved_voice = self._resolve_backend_voice(voice, source="requested voice", fallback=default_voice)
+        self._voice_override = resolved_voice
         if getattr(self, "client", None) is not None:
             try:
                 await self._restart_session()
-                return f"Voice changed to {voice}."
+                return f"Voice changed to {resolved_voice}."
             except Exception as e:
                 logger.warning("Failed to restart session for voice change: %s", e)
                 return "Voice change failed. Will take effect on next connection."
@@ -246,7 +266,8 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
     def get_current_voice(self) -> str:
         """Return the voice currently selected for this handler."""
         default_voice = get_default_voice_for_backend(self.BACKEND_PROVIDER)
-        return self._voice_override or self._get_session_voice(default=default_voice)
+        voice = self._voice_override or self._get_session_voice(default=default_voice)
+        return self._resolve_backend_voice(voice, source="session voice", fallback=default_voice) or default_voice
 
     async def apply_personality(self, profile: str | None) -> str:
         """Apply a new personality (profile) at runtime if possible.

--- a/tests/test_huggingface_realtime.py
+++ b/tests/test_huggingface_realtime.py
@@ -270,6 +270,28 @@ def test_handler_uses_hf_startup_voice_at_startup(monkeypatch: Any) -> None:
     assert handler.get_current_voice() == "Aiden"
 
 
+def test_handler_ignores_unsupported_hf_profile_voice(monkeypatch: Any) -> None:
+    """OpenAI/Gemini profile voices should not be sent to the Hugging Face backend."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "huggingface")
+    monkeypatch.setattr(hf_mod, "get_session_voice", lambda default=HF_DEFAULT_VOICE: "cedar")
+
+    handler = HuggingFaceRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+
+    assert handler.get_current_voice() == HF_DEFAULT_VOICE
+    session = handler._get_session_config([])
+    assert session["audio"]["output"]["voice"] == HF_DEFAULT_VOICE
+
+
+def test_handler_normalizes_hf_voice_case(monkeypatch: Any) -> None:
+    """Lowercase Hugging Face speaker names should resolve to the curated UI value."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "huggingface")
+    monkeypatch.setattr(hf_mod, "get_session_voice", lambda default=HF_DEFAULT_VOICE: "serena")
+
+    handler = HuggingFaceRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+
+    assert handler.get_current_voice() == "Serena"
+
+
 @pytest.mark.asyncio
 async def test_start_up_hf_gradio_does_not_wait_for_api_key(monkeypatch: Any) -> None:
     """Hugging Face backend should not wait for gradio key input."""


### PR DESCRIPTION
## Summary
- Validate resolved voices against the active backend before sending session config.
- Fall back to the backend default voice when a saved/profile voice is unsupported.
- Normalize voice names case-insensitively so lowercase Hugging Face speaker names still resolve.

## Validation
- `uv run ruff check src/reachy_mini_conversation_app/base_realtime.py tests/test_huggingface_realtime.py`
- `uv run mypy`
- `uv run pytest tests/test_huggingface_realtime.py::test_handler_ignores_unsupported_hf_profile_voice tests/test_huggingface_realtime.py::test_handler_normalizes_hf_voice_case tests/test_huggingface_realtime.py::test_apply_personality_uses_selected_voice_for_lb_allocated_sessions`
