### PR TITLE
Fix personality settings responsive layout

### DIFF
--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -381,6 +381,7 @@ button.ghost:hover { border-color: rgba(94, 240, 193, 0.4); }
   align-items: center;
   margin-top: 12px;
 }
+.row > * { min-width: 0; }
 .row > label { margin: 0; }
 .row > button { margin: 0; }
 
@@ -457,13 +458,30 @@ button.ghost:hover { border-color: rgba(94, 240, 193, 0.4); }
   margin: 0; font-size: 13px; color: var(--text);
 }
 
+@media (max-width: 900px) {
+  #personality-panel .row-top,
+  #personality-panel .row-voice {
+    grid-template-columns: 1fr;
+  }
+
+  #personality-panel .row-top button,
+  #personality-panel .row-voice button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .section-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
 @media (max-width: 760px) {
   .hero h1 { font-size: 26px; }
   .privacy-notice { padding: 10px 12px; }
   .backend-choice-grid { grid-template-columns: 1fr; }
   .hf-config-grid { grid-template-columns: 1fr; }
   .row { grid-template-columns: 1fr; }
-  #personality-panel .row:first-of-type { grid-template-columns: 1fr; }
   button { width: 100%; justify-content: center; }
   .actions { flex-direction: column; align-items: flex-start; }
 }


### PR DESCRIPTION
## What changed

- Let settings form grid children shrink with `min-width: 0`.
- Stack the personality selector and voice rows at desktop-app-friendly widths (`max-width: 900px`).
- Remove the fragile `#personality-panel .row:first-of-type` mobile override and use explicit row classes instead.

## Why

In the Reachy Mini desktop app webview, the settings panel can be tighter than a normal browser window. The personality selector row was still using a five-column grid there, so the select could collapse or disappear while the action buttons overflowed.

## Validation

- Ran `git diff --check`.
- Reviewed the scoped CSS diff.
- Attempted a headless browser layout check, but Playwright is not installed in this workspace.