### PR TITLE
Preparing release 0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reachy_mini_conversation_app"
-version = "0.6.0"
+version = "0.6.1"
 authors = [{ name = "Pollen Robotics", email = "contact@pollen-robotics.com" }]
 description = ""
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4229,7 +4229,7 @@ wheels = [
 
 [[package]]
 name = "reachy-mini-conversation-app"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiortc" },


### PR DESCRIPTION
Preparing the release 0.6.1.

Supersedes #348 because the original PR head branch used `6.0.1` instead of `0.6.1`.