### PR TITLE
Update OpenAI realtime default to gpt-realtime-2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # BACKEND_PROVIDER="huggingface"
 # Optional model override for OpenAI Realtime or Gemini Live.
 # Hugging Face uses the server's model selection and ignores MODEL_NAME.
-# MODEL_NAME="gpt-realtime"
+# MODEL_NAME="gpt-realtime-2"
 
 # Set up your API key according to your backend
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Conversational app for the Reachy Mini robot combining realtime voice backends, 
 ## Overview
 - Real-time audio conversation loop with `fastrtc` for low-latency streaming. Supported backends:
   - **Hugging Face** - default, using the built-in Hugging Face server or your own local endpoint.
-  - **OpenAI Realtime** (`gpt-realtime`) - requires `OPENAI_API_KEY`.
+  - **OpenAI Realtime** (`gpt-realtime-2`) - requires `OPENAI_API_KEY`.
   - **Gemini Live** (`gemini-3.1-flash-live-preview`) - requires `GEMINI_API_KEY`.
 - Vision processing uses the selected realtime backend by default (when the camera tool is used), with optional on-device local vision using SmolVLM2 (CPU/GPU/MPS) via `--local-vision`.
 - Layered motion system queues primary moves (dances, emotions, goto poses, breathing) while blending speech-reactive wobble and head-tracking.
@@ -130,7 +130,7 @@ Copy `.env.example` to `.env` when you want to switch backends, provide API keys
 | `OPENAI_API_KEY` | Required for OpenAI Realtime mode. |
 | `GEMINI_API_KEY` | Required for Gemini mode. Also accepts `GOOGLE_API_KEY`. Get one at [aistudio.google.com](https://aistudio.google.com/apikey). |
 | `BACKEND_PROVIDER` | Realtime backend to use: `huggingface` (default), `openai`, or `gemini`. |
-| `MODEL_NAME` | Optional model override for OpenAI Realtime or Gemini Live. Defaults to `gpt-realtime` for OpenAI and `gemini-3.1-flash-live-preview` for Gemini. Hugging Face uses the server's model selection. |
+| `MODEL_NAME` | Optional model override for OpenAI Realtime or Gemini Live. Defaults to `gpt-realtime-2` for OpenAI and `gemini-3.1-flash-live-preview` for Gemini. Hugging Face uses the server's model selection. |
 | `HF_REALTIME_CONNECTION_MODE` | Hugging Face connection selector: `deployed` uses the built-in Hugging Face server; `local` uses `HF_REALTIME_WS_URL`. Defaults to `deployed`. |
 | `HF_REALTIME_WS_URL` | Direct websocket endpoint for your own Hugging Face backend. Accepts either a base URL like `ws://127.0.0.1:8765/v1` or the full websocket URL `ws://127.0.0.1:8765/v1/realtime`. Used when `HF_REALTIME_CONNECTION_MODE=local`. |
 | `HF_HOME` | Cache directory for local Hugging Face downloads (only used with `--local-vision` flag, defaults to `./cache`). |

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -45,7 +45,7 @@ DEFAULT_PROFILES_DIRECTORY = _resolve_default_profiles_directory()
 
 # Full list of voices supported by the OpenAI Realtime / TTS API.
 # Source: https://developers.openai.com/api/docs/guides/text-to-speech/#voice-options
-# "marin" and "cedar" are recommended for gpt-realtime.
+# "marin" and "cedar" are recommended for gpt-realtime-2.
 AVAILABLE_VOICES: list[str] = [
     "alloy",
     "ash",
@@ -113,7 +113,7 @@ class HFBackendDefaults:
 
 HF_DEFAULTS = HFBackendDefaults()
 DEFAULT_MODEL_NAME_BY_BACKEND = {
-    OPENAI_BACKEND: "gpt-realtime",
+    OPENAI_BACKEND: "gpt-realtime-2",
     GEMINI_BACKEND: "gemini-3.1-flash-live-preview",
     HF_BACKEND: HF_DEFAULTS.model_name,
 }

--- a/tests/test_config_name_collisions.py
+++ b/tests/test_config_name_collisions.py
@@ -65,7 +65,7 @@ def test_backend_provider_defaults_to_hf_when_unset() -> None:
     """Non-Gemini models should default to the Hugging Face backend."""
     assert config_mod._normalize_backend_provider(None, None) == config_mod.HF_BACKEND
     assert config_mod._normalize_backend_provider("", None) == config_mod.HF_BACKEND
-    assert config_mod._normalize_backend_provider(None, "gpt-realtime") == config_mod.HF_BACKEND
+    assert config_mod._normalize_backend_provider(None, "gpt-realtime-2") == config_mod.HF_BACKEND
     assert config_mod._normalize_backend_provider(None, "gemini-3.1-flash-live-preview") == config_mod.GEMINI_BACKEND
 
 
@@ -78,7 +78,7 @@ def test_backend_provider_rejects_explicit_unknown_backend() -> None:
 def test_huggingface_backend_does_not_resolve_model_name() -> None:
     """Hugging Face should rely on the server's model selection."""
     assert config_mod._resolve_model_name(config_mod.HF_BACKEND, None) == ""
-    assert config_mod._resolve_model_name(config_mod.HF_BACKEND, "gpt-realtime") == ""
+    assert config_mod._resolve_model_name(config_mod.HF_BACKEND, "gpt-realtime-2") == ""
 
 
 def test_hf_default_session_url_uses_stable_space_proxy() -> None:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -130,11 +130,11 @@ def test_backend_config_persists_gemini_selection_and_status(
 ) -> None:
     """Settings API should persist Gemini backend choice and token."""
     monkeypatch.setattr(config, "BACKEND_PROVIDER", "openai")
-    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime-2")
     monkeypatch.setattr(config, "OPENAI_API_KEY", None)
     monkeypatch.setattr(config, "GEMINI_API_KEY", None)
     monkeypatch.setenv("BACKEND_PROVIDER", "openai")
-    monkeypatch.setenv("MODEL_NAME", "gpt-realtime")
+    monkeypatch.setenv("MODEL_NAME", "gpt-realtime-2")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
 
@@ -215,7 +215,7 @@ def test_backend_config_preserves_explicit_model_override_when_saving_key(
     env_text = (tmp_path / ".env").read_text(encoding="utf-8")
     assert "BACKEND_PROVIDER=openai" in env_text
     assert f"MODEL_NAME={custom_model}" in env_text
-    assert "MODEL_NAME=gpt-realtime" not in env_text
+    assert "MODEL_NAME=gpt-realtime-2" not in env_text
     assert "OPENAI_API_KEY=openai-test-key" in env_text
 
 
@@ -225,12 +225,12 @@ def test_backend_config_persists_local_hf_selection_and_status(
 ) -> None:
     """Settings API should persist a direct Hugging Face websocket target."""
     monkeypatch.setattr(config, "BACKEND_PROVIDER", "openai")
-    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime-2")
     monkeypatch.setattr(config, "HF_REALTIME_CONNECTION_MODE", "deployed")
     monkeypatch.setattr(config, "HF_REALTIME_SESSION_URL", None)
     monkeypatch.setattr(config, "HF_REALTIME_WS_URL", None)
     monkeypatch.setenv("BACKEND_PROVIDER", "openai")
-    monkeypatch.setenv("MODEL_NAME", "gpt-realtime")
+    monkeypatch.setenv("MODEL_NAME", "gpt-realtime-2")
     monkeypatch.delenv("HF_REALTIME_CONNECTION_MODE", raising=False)
     monkeypatch.delenv("HF_REALTIME_SESSION_URL", raising=False)
     monkeypatch.delenv("HF_REALTIME_WS_URL", raising=False)
@@ -285,12 +285,12 @@ def test_backend_config_persists_deployed_mode_without_clearing_local_hf_ws_url(
     )
 
     monkeypatch.setattr(config, "BACKEND_PROVIDER", "huggingface")
-    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime-2")
     monkeypatch.setattr(config, "HF_REALTIME_CONNECTION_MODE", "deployed")
     monkeypatch.setattr(config, "HF_REALTIME_SESSION_URL", "https://lb.example.test/session")
     monkeypatch.setattr(config, "HF_REALTIME_WS_URL", "ws://localhost:8765/v1/realtime")
     monkeypatch.setenv("BACKEND_PROVIDER", "huggingface")
-    monkeypatch.setenv("MODEL_NAME", "gpt-realtime")
+    monkeypatch.setenv("MODEL_NAME", "gpt-realtime-2")
     monkeypatch.delenv("HF_REALTIME_CONNECTION_MODE", raising=False)
     monkeypatch.setenv("HF_REALTIME_SESSION_URL", "https://lb.example.test/session")
     monkeypatch.setenv("HF_REALTIME_WS_URL", "ws://localhost:8765/v1/realtime")
@@ -330,19 +330,19 @@ def test_backend_config_switches_to_saved_local_hf_connection_without_payload_ta
     env_path = tmp_path / ".env"
     env_path.write_text(
         "BACKEND_PROVIDER=openai\n"
-        "MODEL_NAME=gpt-realtime\n"
+        "MODEL_NAME=gpt-realtime-2\n"
         "HF_REALTIME_CONNECTION_MODE=local\n"
         "HF_REALTIME_WS_URL=ws://192.168.1.42:8766/v1/realtime\n",
         encoding="utf-8",
     )
 
     monkeypatch.setattr(config, "BACKEND_PROVIDER", "openai")
-    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime-2")
     monkeypatch.setattr(config, "HF_REALTIME_CONNECTION_MODE", "local")
     monkeypatch.setattr(config, "HF_REALTIME_SESSION_URL", None)
     monkeypatch.setattr(config, "HF_REALTIME_WS_URL", "ws://192.168.1.42:8766/v1/realtime")
     monkeypatch.setenv("BACKEND_PROVIDER", "openai")
-    monkeypatch.setenv("MODEL_NAME", "gpt-realtime")
+    monkeypatch.setenv("MODEL_NAME", "gpt-realtime-2")
     monkeypatch.setenv("HF_REALTIME_CONNECTION_MODE", "local")
     monkeypatch.setenv("HF_REALTIME_WS_URL", "ws://192.168.1.42:8766/v1/realtime")
 


### PR DESCRIPTION
## Summary
- Update the OpenAI Realtime default model from `gpt-realtime` to `gpt-realtime-2`.
- Refresh the sample environment, README, and config/settings tests that reference the OpenAI default.

## Validation
- `uv run pytest tests/test_config_name_collisions.py tests/test_console.py`
- `uv run pytest`
