### PR TITLE
Feat/Audio fusion layer AudioManager

### DIFF
--- a/src/reachy_mini_conversation_app/audio/audio_manager.py
+++ b/src/reachy_mini_conversation_app/audio/audio_manager.py
@@ -198,7 +198,7 @@ class AudioManager:
         chunk_samples = max(1, int(out_rate * 0.032))
         chunk_duration = chunk_samples / out_rate
 
-        buf = np.empty(0, dtype=np.float32)
+        buf: NDArray[np.float32] = np.empty(0, dtype=np.float32)
         t_next = time.monotonic()
 
         while not self._stop_event.is_set():

--- a/src/reachy_mini_conversation_app/audio/audio_manager.py
+++ b/src/reachy_mini_conversation_app/audio/audio_manager.py
@@ -55,10 +55,7 @@ class AudioManager:
     Future sources can be added with a new entry point and behavior without changing existing callers.
     """
 
-    def __init__(
-            self, 
-            current_robot: ReachyMini
-    ):
+    def __init__(self, current_robot: ReachyMini):
         """Initialize audio manager."""
         self.current_robot = current_robot
 
@@ -84,7 +81,7 @@ class AudioManager:
                 return audio_frame
             n = len(audio_frame)
             end = min(self._clip_pos + n, len(self._clip_samples))
-            clip_chunk = self._clip_samples[self._clip_pos:end]
+            clip_chunk = self._clip_samples[self._clip_pos : end]
             mixed = audio_frame.copy()
             mix_len = len(clip_chunk)
             mixed[:mix_len] = np.clip(mixed[:mix_len] + clip_chunk, -1.0, 1.0)
@@ -100,7 +97,7 @@ class AudioManager:
                 self._clip_samples = None
                 return None
             end = min(self._clip_pos + chunk_samples, len(self._clip_samples))
-            chunk = self._clip_samples[self._clip_pos:end].copy()
+            chunk = self._clip_samples[self._clip_pos : end].copy()
             self._clip_pos = end
             return chunk
 
@@ -138,15 +135,16 @@ class AudioManager:
         out_rate = self._get_output_sample_rate()
         if file_rate != out_rate and len(data) > 0:
             from scipy.signal import resample as _resample
+
             n_out = int(len(data) * out_rate / file_rate)
             if n_out == 0:
                 return None
-            data = _resample(data, n_out).astype(np.float32)
+            data = np.asarray(_resample(data, n_out), dtype=np.float32)
 
         return data
 
     def _push_to_daemon(self, audio_frame: NDArray[np.float32]) -> None:
-        """The single call site for push_audio_sample."""
+        """Push audio frame via the single push_audio_sample call site."""
         try:
             self.current_robot.media.push_audio_sample(audio_frame)
         except Exception as exc:
@@ -167,7 +165,7 @@ class AudioManager:
         if self._thread is None or not self._thread.is_alive():
             logger.debug("Audio worker not running; stop() ignored")
             return
-        
+
         logger.info("Stopping audio manager...")
 
         self.clear_frame_queue()

--- a/src/reachy_mini_conversation_app/audio/audio_manager.py
+++ b/src/reachy_mini_conversation_app/audio/audio_manager.py
@@ -32,6 +32,7 @@ import logging
 import threading
 from queue import Empty, Queue
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -141,7 +142,7 @@ class AudioManager:
                 return None
             data = np.asarray(_resample(data, n_out), dtype=np.float32)
 
-        return data
+        return cast(NDArray[np.float32], data)
 
     def _push_to_daemon(self, audio_frame: NDArray[np.float32]) -> None:
         """Push audio frame via the single push_audio_sample call site."""

--- a/src/reachy_mini_conversation_app/audio/audio_manager.py
+++ b/src/reachy_mini_conversation_app/audio/audio_manager.py
@@ -1,0 +1,230 @@
+"""Single control point for all robot audio output.
+
+Design overview
+- There is a single output point to the robot: `mini.media.push_audio_sample`.
+- Audio comes from multiple sources (LLM conversation voice, emotion sounds from emotion library .wav file, future sources).
+- LLM conversation voice is the primary source. Emotion sounds is an additive secondary source fused
+  into audio frames at the sample level before pushing.
+- Mixing strategy is additive (fusion): clip samples are summed into continuous audio frames
+  and clipped to [-1, 1]. Additional mixing strategies may be introduced
+  in the future depending on new source requirements.
+
+Threading model
+- A dedicated worker thread owns all audio state and issues push_audio_sample
+  commands. It is the only thread that calls push_audio_sample.
+- External sources communicate via thread-safe entry points:
+    frames – queue_audio_frame() stages frames into the worker queue.
+    clips  – queue_audio_clip() loads a .wav clip for additive mixing.
+- Frames are staged in a queue; the worker drains it and fuses clip
+  samples in before pushing.
+- When the frame queue is empty and clip audio is active, the worker pushes
+  clip samples alone at the correct pacing (~32 ms chunks).
+
+Safety
+- The worker thread is the sole caller of push_audio_sample, preventing
+  any collision between sources.
+- push_audio_sample is never called while holding the clip lock.
+"""
+
+from __future__ import annotations
+import time
+import logging
+import threading
+from queue import Empty, Queue
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+from reachy_mini import ReachyMini
+
+
+logger = logging.getLogger(__name__)
+
+WORKER_IDLE_TIMEOUT: float = 0.005  # 5 ms block on empty frame queue before looping
+
+
+class AudioManager:
+    """Single output point for all robot audio.
+
+    Sources
+    -------
+    frames – queue_audio_frame() stages a continuous audio frame into the worker queue.
+    clips  – queue_audio_clip() loads and queues a .wav clip for additive mixing. Only .wav files are currently supported.
+
+    Future sources can be added with a new entry point and behavior without changing existing callers.
+    """
+
+    def __init__(
+            self, 
+            current_robot: ReachyMini
+    ):
+        """Initialize audio manager."""
+        self.current_robot = current_robot
+
+        # Audio queue
+        self.frame_queue: Queue[NDArray[np.float32]] = Queue()
+
+        # Clip source state (guarded by _clip_lock)
+        self._clip_lock = threading.Lock()
+        self._clip_samples: NDArray[np.float32] | None = None
+        self._clip_pos: int = 0
+
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+        # Cached robot output sample rate (resolved once on first use)
+        self._output_sample_rate: int | None = None
+
+    def _fuse_clip(self, audio_frame: NDArray[np.float32]) -> NDArray[np.float32]:
+        """Sum clip samples into the audio frame at the current position of the clip."""
+        with self._clip_lock:
+            if self._clip_samples is None or self._clip_pos >= len(self._clip_samples):
+                self._clip_samples = None
+                return audio_frame
+            n = len(audio_frame)
+            end = min(self._clip_pos + n, len(self._clip_samples))
+            clip_chunk = self._clip_samples[self._clip_pos:end]
+            mixed = audio_frame.copy()
+            mix_len = len(clip_chunk)
+            mixed[:mix_len] = np.clip(mixed[:mix_len] + clip_chunk, -1.0, 1.0)
+            self._clip_pos = end
+            if self._clip_pos >= len(self._clip_samples):
+                self._clip_samples = None
+            return mixed
+
+    def _next_clip_chunk(self, chunk_samples: int) -> NDArray[np.float32] | None:
+        """Return the next clip chunk for standalone playback, or None if done."""
+        with self._clip_lock:
+            if self._clip_samples is None or self._clip_pos >= len(self._clip_samples):
+                self._clip_samples = None
+                return None
+            end = min(self._clip_pos + chunk_samples, len(self._clip_samples))
+            chunk = self._clip_samples[self._clip_pos:end].copy()
+            self._clip_pos = end
+            return chunk
+
+    def _get_output_sample_rate(self) -> int:
+        if self._output_sample_rate is None:
+            self._output_sample_rate = int(self.current_robot.media.get_output_audio_samplerate())
+        return self._output_sample_rate
+
+    def _load_clip_and_resample(self, wav_path: Path) -> NDArray[np.float32] | None:
+        """Load a clip (e.g. .wav) file and resample to the robot output sample rate."""
+        try:
+            import scipy.io.wavfile as wavfile
+        except ImportError:
+            logger.warning("scipy unavailable; cannot load audio clip from %s", wav_path)
+            return None
+
+        try:
+            file_rate, data = wavfile.read(str(wav_path))
+        except Exception as exc:
+            logger.warning("Failed to read audio clip %s: %s", wav_path, exc)
+            return None
+
+        # Normalise integer PCM to float32 [-1, 1]
+        if data.dtype == np.int16:
+            data = data.astype(np.float32) / 32768.0
+        elif data.dtype == np.int32:
+            data = data.astype(np.float32) / 2147483648.0
+        else:
+            data = data.astype(np.float32)
+
+        # Collapse to mono
+        if data.ndim > 1:
+            data = data[:, 0]
+
+        out_rate = self._get_output_sample_rate()
+        if file_rate != out_rate and len(data) > 0:
+            from scipy.signal import resample as _resample
+            n_out = int(len(data) * out_rate / file_rate)
+            if n_out == 0:
+                return None
+            data = _resample(data, n_out).astype(np.float32)
+
+        return data
+
+    def _push_to_daemon(self, audio_frame: NDArray[np.float32]) -> None:
+        """The single call site for push_audio_sample."""
+        try:
+            self.current_robot.media.push_audio_sample(audio_frame)
+        except Exception as exc:
+            logger.debug("push_audio_sample failed: %s", exc)
+
+    def start(self) -> None:
+        """Start the worker thread."""
+        if self._thread is not None and self._thread.is_alive():
+            logger.warning("Audio worker already running; start() ignored")
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self.working_loop, daemon=True, name="audio-worker-thread")
+        self._thread.start()
+        logger.debug("Audio worker started")
+
+    def stop(self) -> None:
+        """Stop the worker thread."""
+        if self._thread is None or not self._thread.is_alive():
+            logger.debug("Audio worker not running; stop() ignored")
+            return
+        
+        logger.info("Stopping audio manager...")
+
+        self.clear_frame_queue()
+        self.stop_clip()
+
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+        logger.debug("Audio worker stopped")
+
+    def queue_audio_frame(self, audio_frame: NDArray[np.float32]) -> None:
+        """Stage a continuous audio frame for the worker to mix and push."""
+        self.frame_queue.put(audio_frame)
+
+    def clear_frame_queue(self) -> None:
+        """Discard all pending audio frames."""
+        while not self.frame_queue.empty():
+            try:
+                self.frame_queue.get_nowait()
+            except Empty:
+                break
+
+    def queue_audio_clip(self, wav_path: Path) -> None:
+        """Load and queue a .wav clip to mix into the audio output."""
+        samples = self._load_clip_and_resample(wav_path)
+        if samples is None:
+            return
+        with self._clip_lock:
+            self._clip_samples = samples
+            self._clip_pos = 0
+        logger.info("Queued audio clip: %s (%d samples)", wav_path.name, len(samples))
+
+    def stop_clip(self) -> None:
+        """Immediately stop the current audio clip."""
+        with self._clip_lock:
+            self._clip_samples = None
+            self._clip_pos = 0
+        logger.debug("Audio clip stopped")
+
+    def working_loop(self) -> None:
+        """Drain frame queue, mix clip, and push to daemon. Single push_audio_sample caller."""
+        out_rate = self._get_output_sample_rate()
+        clip_chunk_samples = max(1, int(out_rate * 0.032))  # ~32 ms
+        clip_chunk_duration = clip_chunk_samples / out_rate
+
+        while not self._stop_event.is_set():
+            try:
+                audio_frame = self.frame_queue.get(timeout=WORKER_IDLE_TIMEOUT)
+            except Empty:
+                audio_frame = None
+
+            if audio_frame is not None:
+                mixed = self._fuse_clip(audio_frame)
+                self._push_to_daemon(mixed)
+            else:
+                chunk = self._next_clip_chunk(clip_chunk_samples)
+                if chunk is not None:
+                    self._push_to_daemon(chunk)
+                    time.sleep(clip_chunk_duration)

--- a/src/reachy_mini_conversation_app/audio/audio_manager.py
+++ b/src/reachy_mini_conversation_app/audio/audio_manager.py
@@ -3,22 +3,18 @@
 Design overview
 - There is a single output point to the robot: `mini.media.push_audio_sample`.
 - Audio comes from multiple sources (LLM conversation voice, emotion sounds from emotion library .wav file, future sources).
-- LLM conversation voice is the primary source. Emotion sounds is an additive secondary source fused
-  into audio frames at the sample level before pushing.
-- Mixing strategy is additive (fusion): clip samples are summed into continuous audio frames
-  and clipped to [-1, 1]. Additional mixing strategies may be introduced
-  in the future depending on new source requirements.
+- Mixing strategy is additive (fusion): samples from all active sources are summed and clipped to [-1, 1].
 
 Threading model
-- A dedicated worker thread owns all audio state and issues push_audio_sample
-  commands. It is the only thread that calls push_audio_sample.
+- A dedicated worker thread runs a time-driven mix loop (~32 ms ticks) and is the
+  sole caller of push_audio_sample.
 - External sources communicate via thread-safe entry points:
-    frames – queue_audio_frame() stages frames into the worker queue.
+    frames – queue_audio_frame() stages incoming audio frames into the worker queue.
     clips  – queue_audio_clip() loads a .wav clip for additive mixing.
-- Frames are staged in a queue; the worker drains it and fuses clip
-  samples in before pushing.
-- When the frame queue is empty and clip audio is active, the worker pushes
-  clip samples alone at the correct pacing (~32 ms chunks).
+- Each tick the worker drains all queued frames into an internal sample buffer,
+  slices out one 32 ms chunk (zero-padded if the buffer is short), fuses in the
+  current clip position, and pushes the result. When the frame buffer is empty
+  and a clip is active, zeros are fused with the clip so it continues playing.
 
 Safety
 - The worker thread is the sole caller of push_audio_sample, preventing
@@ -31,8 +27,8 @@ import time
 import logging
 import threading
 from queue import Empty, Queue
-from pathlib import Path
 from typing import cast
+from pathlib import Path
 
 import numpy as np
 from numpy.typing import NDArray
@@ -42,7 +38,7 @@ from reachy_mini import ReachyMini
 
 logger = logging.getLogger(__name__)
 
-WORKER_IDLE_TIMEOUT: float = 0.005  # 5 ms block on empty frame queue before looping
+WORKER_IDLE_TIMEOUT: float = 0.005  # 5 ms idle sleep when no audio is active
 
 
 class AudioManager:
@@ -91,17 +87,6 @@ class AudioManager:
                 self._clip_samples = None
             return mixed
 
-    def _next_clip_chunk(self, chunk_samples: int) -> NDArray[np.float32] | None:
-        """Return the next clip chunk for standalone playback, or None if done."""
-        with self._clip_lock:
-            if self._clip_samples is None or self._clip_pos >= len(self._clip_samples):
-                self._clip_samples = None
-                return None
-            end = min(self._clip_pos + chunk_samples, len(self._clip_samples))
-            chunk = self._clip_samples[self._clip_pos : end].copy()
-            self._clip_pos = end
-            return chunk
-
     def _get_output_sample_rate(self) -> int:
         if self._output_sample_rate is None:
             self._output_sample_rate = int(self.current_robot.media.get_output_audio_samplerate())
@@ -135,12 +120,12 @@ class AudioManager:
 
         out_rate = self._get_output_sample_rate()
         if file_rate != out_rate and len(data) > 0:
-            from scipy.signal import resample as _resample
+            from scipy.signal import resample
 
             n_out = int(len(data) * out_rate / file_rate)
             if n_out == 0:
                 return None
-            data = np.asarray(_resample(data, n_out), dtype=np.float32)
+            data = np.asarray(resample(data, n_out), dtype=np.float32)
 
         return cast(NDArray[np.float32], data)
 
@@ -180,7 +165,7 @@ class AudioManager:
 
     def queue_audio_frame(self, audio_frame: NDArray[np.float32]) -> None:
         """Stage a continuous audio frame for the worker to mix and push."""
-        self.frame_queue.put(audio_frame)
+        self.frame_queue.put(audio_frame.reshape(-1))
 
     def clear_frame_queue(self) -> None:
         """Discard all pending audio frames."""
@@ -208,22 +193,44 @@ class AudioManager:
         logger.debug("Audio clip stopped")
 
     def working_loop(self) -> None:
-        """Drain frame queue, mix clip, and push to daemon. Single push_audio_sample caller."""
+        """Time-driven mixer: fixed 32 ms chunks at a steady rate, mixing all active sources."""
         out_rate = self._get_output_sample_rate()
-        clip_chunk_samples = max(1, int(out_rate * 0.032))  # ~32 ms
-        clip_chunk_duration = clip_chunk_samples / out_rate
+        chunk_samples = max(1, int(out_rate * 0.032))
+        chunk_duration = chunk_samples / out_rate
+
+        buf = np.empty(0, dtype=np.float32)
+        t_next = time.monotonic()
 
         while not self._stop_event.is_set():
-            try:
-                audio_frame = self.frame_queue.get(timeout=WORKER_IDLE_TIMEOUT)
-            except Empty:
-                audio_frame = None
+            drained = []
+            while True:
+                try:
+                    drained.append(self.frame_queue.get_nowait())
+                except Empty:
+                    break
+            if drained:
+                buf = np.concatenate([buf, *drained])
 
-            if audio_frame is not None:
-                mixed = self._fuse_clip(audio_frame)
-                self._push_to_daemon(mixed)
+            with self._clip_lock:
+                clip_live = self._clip_samples is not None
+
+            if len(buf) == 0 and not clip_live:
+                time.sleep(WORKER_IDLE_TIMEOUT)
+                t_next = time.monotonic()
+                continue
+
+            if len(buf) >= chunk_samples:
+                chunk, buf = buf[:chunk_samples], buf[chunk_samples:]
             else:
-                chunk = self._next_clip_chunk(clip_chunk_samples)
-                if chunk is not None:
-                    self._push_to_daemon(chunk)
-                    time.sleep(clip_chunk_duration)
+                chunk = np.zeros(chunk_samples, dtype=np.float32)
+                chunk[: len(buf)] = buf
+                buf = np.empty(0, dtype=np.float32)
+
+            self._push_to_daemon(self._fuse_clip(chunk))
+
+            t_next += chunk_duration
+            wait = t_next - time.monotonic()
+            if wait > 0:
+                time.sleep(wait)
+            else:
+                t_next = time.monotonic()

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -649,7 +649,8 @@ class LocalStream:
                 audio.clear_output_buffer()
             elif hasattr(audio, "clear_player") and callable(audio.clear_player):
                 audio.clear_player()
-        self.handler.deps.audio_manager.clear_frame_queue()
+        if self.handler.deps.audio_manager is not None:
+            self.handler.deps.audio_manager.clear_frame_queue()
         self.handler.output_queue = asyncio.Queue()
 
     async def record_loop(self) -> None:
@@ -713,7 +714,8 @@ class LocalStream:
                     playback_delay_s = _estimate_pending_playback_seconds(self._robot)
                     head_wobbler.feed_pcm(audio_data.reshape(1, -1), input_sample_rate, start_delay_s=playback_delay_s)
 
-                self.handler.deps.audio_manager.queue_audio_frame(audio_frame)
+                if self.handler.deps.audio_manager is not None:
+                    self.handler.deps.audio_manager.queue_audio_frame(audio_frame)
 
             else:
                 logger.debug("Ignoring output type=%s", type(handler_output).__name__)

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -649,6 +649,7 @@ class LocalStream:
                 audio.clear_output_buffer()
             elif hasattr(audio, "clear_player") and callable(audio.clear_player):
                 audio.clear_player()
+        self.handler.deps.audio_manager.clear_frame_queue()
         self.handler.output_queue = asyncio.Queue()
 
     async def record_loop(self) -> None:
@@ -712,7 +713,7 @@ class LocalStream:
                     playback_delay_s = _estimate_pending_playback_seconds(self._robot)
                     head_wobbler.feed_pcm(audio_data.reshape(1, -1), input_sample_rate, start_delay_s=playback_delay_s)
 
-                self._robot.media.push_audio_sample(audio_frame)
+                self.handler.deps.audio_manager.queue_audio_frame(audio_frame)
 
             else:
                 logger.debug("Ignoring output type=%s", type(handler_output).__name__)

--- a/src/reachy_mini_conversation_app/dance_emotion_moves.py
+++ b/src/reachy_mini_conversation_app/dance_emotion_moves.py
@@ -6,7 +6,8 @@ and executed sequentially by the MovementManager.
 
 from __future__ import annotations
 import logging
-from typing import Tuple
+from typing import Tuple, cast
+from pathlib import Path
 
 import numpy as np
 from numpy.typing import NDArray
@@ -60,6 +61,11 @@ class EmotionQueueMove(Move):  # type: ignore
         """Initialize an EmotionQueueMove."""
         self.emotion_move = recorded_moves.get(emotion_name)
         self.emotion_name = emotion_name
+
+    @property
+    def sound_path(self) -> Path | None:
+        """Sound path for emotion's audio clip."""
+        return cast(Path | None, self.emotion_move.sound_path)
 
     @property
     def duration(self) -> float:

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -151,11 +151,12 @@ def run(
         logger.error("Failed to initialize camera/vision: %s", e)
         sys.exit(1)
 
+    audio_manager = AudioManager(current_robot=robot)
     movement_manager = MovementManager(
         current_robot=robot,
         camera_worker=camera_worker,
+        audio_manager=audio_manager,
     )
-    audio_manager = AudioManager(current_robot=robot)
 
     head_wobbler = HeadWobbler(set_speech_offsets=movement_manager.set_speech_offsets)
 

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -61,6 +61,7 @@ def run(
         StartupSettings,
         load_startup_settings_into_runtime,
     )
+    from reachy_mini_conversation_app.audio.audio_manager import AudioManager
 
     logger = setup_logger(args.debug)
     logger.info("Starting Reachy Mini Conversation App")
@@ -154,12 +155,14 @@ def run(
         current_robot=robot,
         camera_worker=camera_worker,
     )
+    audio_manager = AudioManager(current_robot=robot)
 
     head_wobbler = HeadWobbler(set_speech_offsets=movement_manager.set_speech_offsets)
 
     deps = ToolDependencies(
         reachy_mini=robot,
         movement_manager=movement_manager,
+        audio_manager=audio_manager,
         camera_worker=camera_worker,
         vision_processor=vision_processor,
         head_wobbler=head_wobbler,
@@ -272,6 +275,7 @@ def run(
 
     # Each async service → its own thread/loop
     movement_manager.start()
+    audio_manager.start()
     head_wobbler.start()
     if camera_worker:
         camera_worker.start()
@@ -296,6 +300,7 @@ def run(
         logger.info("Keyboard interruption in main thread... closing server.")
     finally:
         movement_manager.stop()
+        audio_manager.stop()
         head_wobbler.stop()
         if camera_worker:
             camera_worker.stop()

--- a/src/reachy_mini_conversation_app/moves.py
+++ b/src/reachy_mini_conversation_app/moves.py
@@ -36,7 +36,11 @@ import time
 import logging
 import threading
 from queue import Empty, Queue
-from typing import Any, Dict, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Tuple
+
+
+if TYPE_CHECKING:
+    from reachy_mini_conversation_app.audio.audio_manager import AudioManager
 from collections import deque
 from dataclasses import dataclass
 
@@ -246,11 +250,13 @@ class MovementManager:
     def __init__(
         self,
         current_robot: ReachyMini,
+        audio_manager: "AudioManager",
         camera_worker: "Any" = None,
     ):
         """Initialize movement manager."""
         self.current_robot = current_robot
         self.camera_worker = camera_worker
+        self._audio_manager = audio_manager
 
         # Single timing source for durations
         self._now = time.monotonic
@@ -491,6 +497,9 @@ class MovementManager:
                 self.state.move_start_time = current_time
                 # Any real move cancels breathing mode flag
                 self._breathing_active = isinstance(self.state.current_move, BreathingMove)
+                sound_path = getattr(self.state.current_move, "sound_path", None)
+                if sound_path is not None:
+                    self._audio_manager.queue_audio_clip(sound_path)
                 logger.debug(f"Starting new move, duration: {self.state.current_move.duration}s")
 
     def _manage_breathing(self, current_time: float) -> None:

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -53,8 +53,8 @@ class ToolDependencies:
 
     reachy_mini: ReachyMini
     movement_manager: Any  # MovementManager from moves.py
-    audio_manager: Any  # AudioManager from audio/audio_manager.py
     # Optional deps
+    audio_manager: Any | None = None  # AudioManager from audio/audio_manager.py
     camera_worker: Any | None = None  # CameraWorker for frame buffering
     vision_processor: Any | None = None
     head_wobbler: Any | None = None  # HeadWobbler for audio-reactive motion

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -53,6 +53,7 @@ class ToolDependencies:
 
     reachy_mini: ReachyMini
     movement_manager: Any  # MovementManager from moves.py
+    audio_manager: Any  # AudioManager from audio/audio_manager.py
     # Optional deps
     camera_worker: Any | None = None  # CameraWorker for frame buffering
     vision_processor: Any | None = None

--- a/src/reachy_mini_conversation_app/tools/play_emotion.py
+++ b/src/reachy_mini_conversation_app/tools/play_emotion.py
@@ -86,6 +86,10 @@ class PlayEmotion(Tool):
             emotion_move = EmotionQueueMove(emotion_name, RECORDED_MOVES)
             movement_manager.queue_move(emotion_move)
 
+            recorded_move = RECORDED_MOVES.get(emotion_name)
+            if recorded_move.sound_path is not None:
+                deps.audio_manager.queue_audio_clip(recorded_move.sound_path)
+
             return {"status": "queued", "emotion": emotion_name}
 
         except Exception as e:

--- a/src/reachy_mini_conversation_app/tools/play_emotion.py
+++ b/src/reachy_mini_conversation_app/tools/play_emotion.py
@@ -81,14 +81,9 @@ class PlayEmotion(Tool):
             if emotion_name not in emotion_names:
                 return {"error": f"Unknown emotion '{emotion_name}'. Available: {emotion_names}"}
 
-            # Add emotion to queue
-            movement_manager = deps.movement_manager
+            # AudioManager plays the sound when MovementManager starts the move
             emotion_move = EmotionQueueMove(emotion_name, RECORDED_MOVES)
-            movement_manager.queue_move(emotion_move)
-
-            recorded_move = RECORDED_MOVES.get(emotion_name)
-            if recorded_move.sound_path is not None:
-                deps.audio_manager.queue_audio_clip(recorded_move.sound_path)
+            deps.movement_manager.queue_move(emotion_move)
 
             return {"status": "queued", "emotion": emotion_name}
 

--- a/src/reachy_mini_conversation_app/tools/stop_emotion.py
+++ b/src/reachy_mini_conversation_app/tools/stop_emotion.py
@@ -29,5 +29,6 @@ class StopEmotion(Tool):
         movement_manager = deps.movement_manager
         movement_manager.clear_move_queue()
         audio_manager = deps.audio_manager
-        audio_manager.stop_clip()
+        if audio_manager is not None:
+            audio_manager.stop_clip()
         return {"status": "stopped emotion and cleared queue"}

--- a/src/reachy_mini_conversation_app/tools/stop_emotion.py
+++ b/src/reachy_mini_conversation_app/tools/stop_emotion.py
@@ -28,4 +28,6 @@ class StopEmotion(Tool):
         logger.info("Tool call: stop_emotion")
         movement_manager = deps.movement_manager
         movement_manager.clear_move_queue()
+        audio_manager = deps.audio_manager
+        audio_manager.stop_clip()
         return {"status": "stopped emotion and cleared queue"}

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -82,7 +82,7 @@ async def test_play_loop_feeds_head_wobbler_with_local_playback_delay() -> None:
 
     class Handler:
         def __init__(self) -> None:
-            self.deps = SimpleNamespace(head_wobbler=head_wobbler)
+            self.deps = SimpleNamespace(head_wobbler=head_wobbler, audio_manager=MagicMock())
             self.output_queue: asyncio.Queue[Any] = asyncio.Queue()
             self._emitted = False
 
@@ -121,7 +121,7 @@ async def test_play_loop_feeds_head_wobbler_with_local_playback_delay() -> None:
     assert np.array_equal(args[0], chunk.reshape(1, -1))
     assert args[1] == 24000
     assert kwargs["start_delay_s"] == pytest.approx(1.0)
-    media.push_audio_sample.assert_called_once()
+    handler.deps.audio_manager.queue_audio_frame.assert_called_once()
 
 
 def test_backend_config_persists_gemini_selection_and_status(


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
<!-- What does this PR change and why? -->
Implementation for Part 1 described in issue #338 
- Introduces audio fusion layer `AudioManager` with a time-driven loop 
- `MovementManager` now signals `AudioManager` when an emotion move starts, syncing audio with movement across threads

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [x] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
<!-- Optional: context, caveats, migration notes -->
