### PR TITLE
Add uv dependency cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,19 @@ dev = [
 reachy-mini-conversation-app = "reachy_mini_conversation_app.main:main"
 
 [tool.uv]
+exclude-newer = "7 days"
 dependency-metadata = [
     # Upstream metadata currently marks `gstreamer-msvc-runtime` as unconditional.
     # It should only be required on Windows. Temp fix.
     { name = "gstreamer-libs", version = "1.28.1", requires-dist = ["gstreamer-msvc-runtime; sys_platform == 'win32'", "setuptools"] },
 ]
+
+[tool.uv.exclude-newer-package]
+"reachy-mini" = false
+"reachy-mini-dances-library" = false
+"reachy-mini-toolbox" = false
+"gradio-client" = false
+"huggingface-hub" = false
 
 [project.entry-points."reachy_mini_apps"]
 reachy_mini_conversation_app = "reachy_mini_conversation_app.main:ReachyMiniConversationApp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
 reachy-mini-conversation-app = "reachy_mini_conversation_app.main:main"
 
 [tool.uv]
-exclude-newer = "3 days"
+exclude-newer = "7 days"
 dependency-metadata = [
     # Upstream metadata currently marks `gstreamer-msvc-runtime` as unconditional.
     # It should only be required on Windows. Temp fix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
 reachy-mini-conversation-app = "reachy_mini_conversation_app.main:main"
 
 [tool.uv]
-exclude-newer = "7 days"
+exclude-newer = "3 days"
 dependency-metadata = [
     # Upstream metadata currently marks `gstreamer-msvc-runtime` as unconditional.
     # It should only be required on Windows. Temp fix.

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,17 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+reachy-mini = false
+gradio-client = false
+reachy-mini-dances-library = false
+huggingface-hub = false
+reachy-mini-toolbox = false
+
 [manifest]
 
 [[manifest.dependency-metadata]]

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P3D"
+exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 reachy-mini = false

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
 reachy-mini = false


### PR DESCRIPTION
## Summary
Adds a 7-day exclude-newer cooldown, exempting the whitelisted packages. Closes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/364

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [x] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [x] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
We can add the same rule to `reachy_mini`
