### PR TITLE
Remove dead comments, phantom field docstrings, and trivial wrapper

### DIFF
--- a/src/reachy_mini_conversation_app/headless_personality.py
+++ b/src/reachy_mini_conversation_app/headless_personality.py
@@ -17,10 +17,6 @@ from .config import DEFAULT_PROFILES_DIRECTORY, get_default_voice_for_backend
 DEFAULT_OPTION = "(built-in default)"
 
 
-def _profiles_root() -> Path:
-    return DEFAULT_PROFILES_DIRECTORY
-
-
 def _prompts_dir() -> Path:
     return Path(__file__).parent / "prompts"
 
@@ -41,7 +37,7 @@ def _sanitize_name(name: str) -> str:
 def list_personalities() -> List[str]:
     """List available personality profile names."""
     names: List[str] = []
-    root = _profiles_root()
+    root = DEFAULT_PROFILES_DIRECTORY
     try:
         if root.exists():
             for p in sorted(root.iterdir()):
@@ -61,7 +57,7 @@ def list_personalities() -> List[str]:
 
 def resolve_profile_dir(selection: str) -> Path:
     """Resolve the directory path for the given profile selection."""
-    return _profiles_root() / selection
+    return DEFAULT_PROFILES_DIRECTORY / selection
 
 
 def read_instructions_for(name: str) -> str:
@@ -108,7 +104,7 @@ def available_tools_for(selected: str) -> List[str]:
 
 def _write_profile(name_s: str, instructions: str, tools_text: str, voice: str | None = None) -> None:
     default_voice = get_default_voice_for_backend()
-    target_dir = _profiles_root() / "user_personalities" / name_s
+    target_dir = DEFAULT_PROFILES_DIRECTORY / "user_personalities" / name_s
     target_dir.mkdir(parents=True, exist_ok=True)
     (target_dir / "instructions.txt").write_text(instructions.strip() + "\n", encoding="utf-8")
     (target_dir / "tools.txt").write_text((tools_text or "").strip() + "\n", encoding="utf-8")

--- a/src/reachy_mini_conversation_app/tools/__init__.py
+++ b/src/reachy_mini_conversation_app/tools/__init__.py
@@ -1,4 +1,1 @@
-"""Tools library for Reachy Mini conversation app.
-
-Tools are now loaded dynamically based on the profile's tools.txt file.
-"""
+"""Nothing (for ruff)."""

--- a/src/reachy_mini_conversation_app/tools/background_tool_manager.py
+++ b/src/reachy_mini_conversation_app/tools/background_tool_manager.py
@@ -29,10 +29,7 @@ _SYSTEM_TOOL_NAMES: set[str] = {t.value for t in SystemTool}
 class ToolProgress(BaseModel):
     """Progress of a background tool."""
 
-    """the progress of the tool"""
     progress: float = Field(..., ge=0.0, le=1.0)
-
-    """the message of the tool"""
     message: Optional[str] = None
 
 
@@ -41,13 +38,8 @@ class ToolCallRoutine(BaseModel):
 
     model_config = {"arbitrary_types_allowed": True}
 
-    """the name of the tool"""
     tool_name: str
-
-    """the JSON arguments for the tool call"""
     args_json_str: str
-
-    """the dependencies for the tool call"""
     deps: "ToolDependencies"
 
     async def __call__(self, tool_manager: BackgroundToolManager) -> Any:
@@ -63,43 +55,25 @@ class ToolCallRoutine(BaseModel):
 class ToolNotification(BaseModel):
     """Notification payload for completed tools."""
 
-    """the ID of the tool"""
     id: str
-
-    """the name of the tool"""
     tool_name: str
-
-    """whether the tool call was triggered by an idle signal"""
     is_idle_tool_call: bool
-
-    """the status of the tool"""
     status: ToolState
-
-    """the result of the tool"""
     result: Optional[Dict[str, Any]] = None
-
-    """the error of the tool"""
     error: Optional[str] = None
 
 
 class BackgroundTool(ToolNotification):
     """Represents a background tool."""
 
-    """the progress of the tool"""
     progress: Optional[ToolProgress] = None
-
-    """the start time of the tool"""
     started_at: float = Field(default_factory=time.monotonic)
-
-    """the completion time of the tool"""
     completed_at: Optional[float] = None
-
-    """the async tool execution task"""
     _task: Optional[asyncio.Task[None]] = PrivateAttr(default=None)
 
     @property
     def tool_id(self) -> str:
-        """Get the name of the tool."""
+        """Return a unique composite identifier for this tool instance."""
         return f"{self.tool_name}-{self.id}-{self.started_at}"
 
     def get_notification(self) -> ToolNotification:
@@ -124,23 +98,12 @@ class BackgroundToolManager(BaseModel):
 
     """
 
-    """the dictionary of tools"""
     _tools: Dict[str, BackgroundTool] = PrivateAttr(default_factory=dict)
-
-    """the async queue for notifications"""
     _notification_queue: asyncio.Queue[ToolNotification] = PrivateAttr(default_factory=asyncio.Queue)
-
-    """the event loop"""
     _loop: Optional[asyncio.AbstractEventLoop] = PrivateAttr(default=None)
-
-    """internal lifecycle tasks (notification listener, periodic cleanup)"""
     _lifecycle_tasks: list[asyncio.Task[None]] = PrivateAttr(default_factory=list)
-
-    """the maximum duration of a tool execution in seconds (default: 1 day)"""
-    _max_tool_duration_seconds: float = PrivateAttr(default=86400)
-
-    """the maximum time to keep a completed/failed/cancelled tool in memory (default: 1 hour)"""
-    _max_tool_memory_seconds: float = PrivateAttr(default=3600)
+    _max_tool_duration_seconds: float = PrivateAttr(default=86400)  # 1 day
+    _max_tool_memory_seconds: float = PrivateAttr(default=3600)  # 1 hour
 
     def set_loop(
         self,

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -13,10 +13,10 @@ from pathlib import Path
 from dataclasses import dataclass
 
 from reachy_mini import ReachyMini
-from reachy_mini_conversation_app.config import DEFAULT_PROFILES_DIRECTORY as DEFAULT_PROFILES_PATH  # noqa: F401
+from reachy_mini_conversation_app.config import DEFAULT_PROFILES_DIRECTORY as DEFAULT_PROFILES_PATH
 
 # Import config to ensure .env is loaded before reading REACHY_MINI_CUSTOM_PROFILE
-from reachy_mini_conversation_app.config import config  # noqa: F401
+from reachy_mini_conversation_app.config import config
 from reachy_mini_conversation_app.tools.tool_constants import SystemTool
 
 
@@ -42,7 +42,6 @@ def get_concrete_subclasses(base: type[Tool]) -> List[type[Tool]]:
     for cls in base.__subclasses__():
         if not inspect.isabstract(cls):
             result.append(cls)
-        # recurse into subclasses
         result.extend(get_concrete_subclasses(cls))
     return result
 
@@ -60,7 +59,6 @@ class ToolDependencies:
     motion_duration_s: float = 1.0
 
 
-# Tool base class
 class Tool(abc.ABC):
     """Base abstraction for tools used in function-calling.
 
@@ -139,12 +137,9 @@ def _format_error(error: Exception) -> str:
 # Registry & specs (dynamic)
 def _load_profile_tools() -> None:
     """Load tools based on profile's tools.txt file."""
-    # Determine which profile to use
     profile = config.REACHY_MINI_CUSTOM_PROFILE or "default"
     logger.info(f"Loading tools for profile: {profile}")
 
-    # Build path to tools.txt
-    # Get the profile directory path
     profile_dir = config.PROFILES_DIRECTORY / profile
     tools_txt_path = profile_dir / "tools.txt"
     default_tools_txt_path = DEFAULT_PROFILES_PATH / "default" / "tools.txt"
@@ -169,7 +164,6 @@ def _load_profile_tools() -> None:
             logger.error(f"✗ tools.txt not found at {tools_txt_path}")
             sys.exit(1)
 
-    # Read and parse tools.txt
     try:
         with open(tools_txt_path, "r") as f:
             lines = f.readlines()
@@ -177,16 +171,13 @@ def _load_profile_tools() -> None:
         logger.error(f"✗ Failed to read tools.txt: {e}")
         sys.exit(1)
 
-    # Parse tool names (skip comments and blank lines)
     tool_names = []
     for line in lines:
         line = line.strip()
-        # Skip blank lines and comments
         if not line or line.startswith("#"):
             continue
         tool_names.append(line)
 
-    # Add system tools
     tool_names.extend({tool.value for tool in SystemTool})
 
     logger.info(f"Found {len(tool_names)} tools to load: {tool_names}")

--- a/src/reachy_mini_conversation_app/tools/dance.py
+++ b/src/reachy_mini_conversation_app/tools/dance.py
@@ -24,7 +24,7 @@ def get_available_dances_and_descriptions() -> str:
     if not DANCE_AVAILABLE:
         return "Moves not available."
 
-    if not AVAILABLE_MOVES:  # if AVAILABLE_MOVES is empty
+    if not AVAILABLE_MOVES:
         return "Moves not available."
 
     output = ""
@@ -63,7 +63,7 @@ class Dance(Tool):
         if not DANCE_AVAILABLE:
             return {"error": "Dance system not available"}
 
-        if not AVAILABLE_MOVES:  # if AVAILABLE_MOVES is empty
+        if not AVAILABLE_MOVES:
             return {"error": "No moves currently available"}
 
         move_name = kwargs.get("move")
@@ -77,7 +77,6 @@ class Dance(Tool):
         if move_name not in AVAILABLE_MOVES:
             return {"error": f"Unknown dance move '{move_name}'. Available: {list(AVAILABLE_MOVES.keys())}"}
 
-        # Add dance moves to queue
         movement_manager = deps.movement_manager
         for _ in range(repeat):
             dance_move = DanceQueueMove(move_name)

--- a/src/reachy_mini_conversation_app/tools/play_emotion.py
+++ b/src/reachy_mini_conversation_app/tools/play_emotion.py
@@ -69,7 +69,6 @@ class PlayEmotion(Tool):
 
         logger.info("Tool call: play_emotion emotion=%s", emotion_name)
 
-        # Check if emotion exists
         try:
             emotion_names = RECORDED_MOVES.list_moves()
             if not emotion_names:
@@ -81,7 +80,6 @@ class PlayEmotion(Tool):
             if emotion_name not in emotion_names:
                 return {"error": f"Unknown emotion '{emotion_name}'. Available: {emotion_names}"}
 
-            # Add emotion to queue
             movement_manager = deps.movement_manager
             emotion_move = EmotionQueueMove(emotion_name, RECORDED_MOVES)
             movement_manager.queue_move(emotion_move)

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -124,7 +124,7 @@ def test_headless_profile_write_defaults_voice_at_call_time(
     """New headless profiles should use the currently selected backend default voice."""
     monkeypatch.setattr(config, "BACKEND_PROVIDER", "gemini")
     monkeypatch.setattr(config, "MODEL_NAME", "gemini-3.1-flash-live-preview")
-    monkeypatch.setattr(headless_mod, "_profiles_root", lambda: tmp_path)
+    monkeypatch.setattr(headless_mod, "DEFAULT_PROFILES_DIRECTORY", tmp_path)
 
     headless_mod._write_profile("runtime_voice_default", "test instructions", "")
 


### PR DESCRIPTION
## Summary
Cleans up noise found during a codebase audit. Removes redundant inline comments across several tool files, strips phantom string literals from Pydantic model definitions in `background_tool_manager.py`, and deletes a trivial wrapper function in `headless_personality.py` in favour of using the imported constant directly. One test updated to reflect the removed function. Closes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/366

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
