### PR TITLE
Replace print() with logger and log silent failures in set_custom_profile

### DIFF
--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -322,10 +322,10 @@ if LOCKED_PROFILE is not None:
     _profile_path = _profiles_dir / LOCKED_PROFILE
     _instructions_file = _profile_path / "instructions.txt"
     if not _profile_path.is_dir():
-        print(f"Error: LOCKED_PROFILE '{LOCKED_PROFILE}' does not exist in {_profiles_dir}", file=sys.stderr)
+        logger.critical("LOCKED_PROFILE %r does not exist in %s", LOCKED_PROFILE, _profiles_dir)
         sys.exit(1)
     if not _instructions_file.is_file():
-        print(f"Error: LOCKED_PROFILE '{LOCKED_PROFILE}' has no instructions.txt", file=sys.stderr)
+        logger.critical("LOCKED_PROFILE %r has no instructions.txt", LOCKED_PROFILE)
         sys.exit(1)
 
 _skip_dotenv = _env_flag("REACHY_MINI_SKIP_DOTENV", default=False)
@@ -556,8 +556,8 @@ def set_custom_profile(profile: str | None) -> None:
         return
     try:
         config.REACHY_MINI_CUSTOM_PROFILE = profile
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to update config profile: %s", e)
     try:
         import os as _os
 
@@ -566,5 +566,5 @@ def set_custom_profile(profile: str | None) -> None:
         else:
             # Remove to reflect default
             _os.environ.pop("REACHY_MINI_CUSTOM_PROFILE", None)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to sync profile to environment: %s", e)

--- a/src/reachy_mini_conversation_app/vision/head_tracking/yolo_process.py
+++ b/src/reachy_mini_conversation_app/vision/head_tracking/yolo_process.py
@@ -381,7 +381,7 @@ class YoloHeadTrackerProcess:
 def main() -> int:
     """CLI entrypoint for the head-tracker worker process."""
     if len(sys.argv) != 1:
-        logger.error("usage: python -m reachy_mini_conversation_app.vision.head_tracking.yolo_process")
+        logger.error("unexpected arguments: this process takes no arguments")
         return 2
     return _worker_main()
 

--- a/src/reachy_mini_conversation_app/vision/head_tracking/yolo_process.py
+++ b/src/reachy_mini_conversation_app/vision/head_tracking/yolo_process.py
@@ -381,10 +381,7 @@ class YoloHeadTrackerProcess:
 def main() -> int:
     """CLI entrypoint for the head-tracker worker process."""
     if len(sys.argv) != 1:
-        print(
-            "usage: python -m reachy_mini_conversation_app.vision.head_tracking.yolo_process",
-            file=sys.stderr,
-        )
+        logger.error("usage: python -m reachy_mini_conversation_app.vision.head_tracking.yolo_process")
         return 2
     return _worker_main()
 


### PR DESCRIPTION
## Summary
Replaces `print()` calls in `config.py` and `yolo_process.py` with the appropriate logger level calls. Also replaces two bare except: pass blocks in `set_custom_profile()` with `logger.warning` so profile update failures are visible in the logs. Closes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/368

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
