### PR TITLE
Reduce boilerplate in BaseRealtimeHandler

### DIFF
--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -231,9 +231,13 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
     def _get_session_config(self, tool_specs: list[dict[str, Any]]) -> RealtimeSessionCreateRequestParam:
         """Return the backend-specific realtime session config."""
 
-    async def _wait_for_output_item(self) -> Tuple[int, NDArray[np.int16]] | AdditionalOutputs | None:
-        """Wait for the next output item."""
-        return await wait_for_item(self.output_queue)  # type: ignore[no-any-return]
+    async def _cancel_partial_transcript_task(self) -> None:
+        if self.partial_transcript_task and not self.partial_transcript_task.done():
+            self.partial_transcript_task.cancel()
+            try:
+                await self.partial_transcript_task
+            except asyncio.CancelledError:
+                pass
 
     def _mark_activity(self, reason: str) -> None:
         """Record non-idle conversation activity for the idle timer."""
@@ -703,7 +707,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                         self._turn_user_done_at = None
                         self._turn_response_created_at = None
                         self._turn_first_audio_at = None
-                        if hasattr(self, "_clear_queue") and callable(self._clear_queue):
+                        if self._clear_queue:
                             self._clear_queue()
                         if self.deps.head_wobbler is not None:
                             self.deps.head_wobbler.reset()
@@ -759,13 +763,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                         current_partial = "".join(input_transcript.deltas)
                         sequence_counter = len(input_transcript.deltas) - 1
 
-                        # Cancel previous debounce task if it exists
-                        if self.partial_transcript_task and not self.partial_transcript_task.done():
-                            self.partial_transcript_task.cancel()
-                            try:
-                                await self.partial_transcript_task
-                            except asyncio.CancelledError:
-                                pass
+                        await self._cancel_partial_transcript_task()
 
                         # Start new debounce timer with the last delta
                         self.partial_transcript_task = asyncio.create_task(
@@ -780,13 +778,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                         logger.debug("User transcript: %s", raw_transcript)
                         self.deps.movement_manager.set_listening(False)
 
-                        # Cancel any pending partial emission
-                        if self.partial_transcript_task and not self.partial_transcript_task.done():
-                            self.partial_transcript_task.cancel()
-                            try:
-                                await self.partial_transcript_task
-                            except asyncio.CancelledError:
-                                pass
+                        await self._cancel_partial_transcript_task()
 
                         if not transcript:
                             logger.debug("Ignoring empty user transcript")
@@ -965,7 +957,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
 
             self.last_activity_time = asyncio.get_event_loop().time()  # avoid repeated resets
 
-        return await self._wait_for_output_item()
+        return await wait_for_item(self.output_queue)  # type: ignore[no-any-return]
 
     async def shutdown(self) -> None:
         """Shutdown the handler."""
@@ -975,13 +967,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         # Stop background tool manager tasks (listener + cleanup)
         await self.tool_manager.shutdown()
 
-        # Cancel any pending debounce task
-        if self.partial_transcript_task and not self.partial_transcript_task.done():
-            self.partial_transcript_task.cancel()
-            try:
-                await self.partial_transcript_task
-            except asyncio.CancelledError:
-                pass
+        await self._cancel_partial_transcript_task()
 
         if self.connection:
             try:

--- a/src/reachy_mini_conversation_app/conversation_handler.py
+++ b/src/reachy_mini_conversation_app/conversation_handler.py
@@ -21,7 +21,7 @@ class ConversationHandler(AsyncStreamHandler, ABC):
 
     deps: ToolDependencies
     output_queue: asyncio.Queue[QueueItem]
-    _clear_queue: Callable[[], None] | None
+    _clear_queue: Callable[[], None] | None = None
 
     @abstractmethod
     def copy(self) -> ConversationHandler:

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -220,7 +220,7 @@ class GeminiLiveHandler(ConversationHandler):
         """Stop current playback and preserve any transcript already spoken."""
         logger.debug("Gemini: user interrupted")
         await self._flush_transcript_chunks("assistant", self._pending_assistant_transcript_chunks)
-        if hasattr(self, "_clear_queue") and callable(self._clear_queue):
+        if self._clear_queue:
             self._clear_queue()
         if self.deps.head_wobbler is not None:
             self.deps.head_wobbler.reset()


### PR DESCRIPTION
## Summary
Closes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/372
- adds `= None` default to `_clear_queue` in `ConversationHandler`, removing `hasattr` guards in both subclasses
- extracts the repeated partial transcript cancel block into `_cancel_partial_transcript_task`
- inlines `wait_for_item` at its single call site, removing the one-line wrapper

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
