### PR TITLE
Centralize headless backend restarts

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -120,7 +120,6 @@ class LocalStream:
         - ``instance_path``: directory where per-instance ``.env`` should be stored.
         - ``handler_factory``: builds a fresh handler for the currently selected backend.
         """
-        self.handler = handler
         self._robot = robot
         self._stop_event = asyncio.Event()
         self._restart_requested = asyncio.Event()
@@ -223,7 +222,6 @@ class LocalStream:
 
     async def request_backend_restart(self, reason: str) -> None:
         """Ask the startup loop to rebuild the backend and stop the current handler."""
-        logger.info("Backend restart requested: %s", reason)
         self._set_backend_connection_state("connecting")
         self._restart_requested.set()
         await self._shutdown_active_handler()
@@ -449,14 +447,14 @@ class LocalStream:
             except BaseException:
                 set_custom_profile(previous_profile)
                 raise
-            await self.request_backend_restart("personality_changed")
-            return "Applied personality and restarting backend."
         except Exception as e:
             logger.error("Error applying personality '%s': %s", profile, e)
             return f"Failed to apply personality: {e}"
         except BaseException as e:
             logger.error("Failed to resolve personality content: %s", e)
             return f"Failed to apply personality: {e}"
+        await self.request_backend_restart("personality_changed")
+        return "Applied personality and restarting backend."
 
     async def get_available_voices(self) -> list[str]:
         """Return voices available for the currently selected backend."""

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -15,7 +15,7 @@ import sys
 import time
 import asyncio
 import logging
-from typing import List, Optional
+from typing import List, Callable, Optional
 from pathlib import Path
 
 from fastrtc import AdditionalOutputs, audio_to_float32
@@ -41,7 +41,9 @@ from reachy_mini_conversation_app.config import (
     parse_hf_direct_target,
     get_model_name_for_backend,
     get_hf_connection_selection,
+    get_default_voice_for_backend,
     refresh_runtime_config_from_env,
+    get_available_voices_for_backend,
 )
 from reachy_mini_conversation_app.startup_settings import read_startup_settings, write_startup_settings
 from reachy_mini_conversation_app.audio.startup_config import apply_audio_startup_config
@@ -64,6 +66,7 @@ except Exception:  # pragma: no cover - only loaded when settings_app is used
 
 
 logger = logging.getLogger(__name__)
+HandlerFactory = Callable[[Optional[str]], ConversationHandler]
 
 LOCAL_PLAYER_BACKEND = (
     getattr(MediaBackend, "LOCAL", None)
@@ -108,18 +111,22 @@ class LocalStream:
         *,
         settings_app: Optional[FastAPI] = None,
         instance_path: Optional[str] = None,
+        handler_factory: HandlerFactory | None = None,
+        startup_voice: Optional[str] = None,
     ):
         """Initialize the stream with a realtime handler and pipelines.
 
         - ``settings_app``: the Reachy Mini Apps FastAPI to attach settings endpoints.
         - ``instance_path``: directory where per-instance ``.env`` should be stored.
+        - ``handler_factory``: builds a fresh handler for the currently selected backend.
         """
         self.handler = handler
         self._robot = robot
         self._stop_event = asyncio.Event()
+        self._restart_requested = asyncio.Event()
         self._tasks: List[asyncio.Task[None]] = []
-        # Allow the handler to flush the player queue when appropriate.
-        self.handler._clear_queue = self.clear_audio_queue
+        self._handler_factory = handler_factory
+        self._voice_override = startup_voice
         self._settings_app: Optional[FastAPI] = settings_app
         self._instance_path: Optional[str] = instance_path
         self._settings_initialized = False
@@ -128,6 +135,12 @@ class LocalStream:
         self._backend_connection_state = "not_started"
         self._backend_error: str | None = None
         self._backend_retry_delay = BACKEND_RETRY_DELAY_SECONDS
+        self._install_handler(handler)
+
+    def _install_handler(self, handler: ConversationHandler) -> None:
+        """Set the active handler and wire LocalStream-owned helpers into it."""
+        self.handler = handler
+        self.handler._clear_queue = self.clear_audio_queue
 
     # ---- Settings UI ----
     def _read_env_lines(self, env_path: Path) -> list[str]:
@@ -170,7 +183,59 @@ class LocalStream:
 
     def _backend_connected(self) -> bool:
         """Return whether the active handler currently has a realtime connection."""
-        return getattr(self.handler, "connection", None) is not None
+        try:
+            handler_state = vars(self.handler)
+        except TypeError:
+            handler_state = {}
+        return any(handler_state.get(attr) is not None for attr in ("connection", "session"))
+
+    def _can_rebuild_handler(self) -> bool:
+        """Return whether LocalStream can construct handlers for backend changes."""
+        return self._handler_factory is not None
+
+    def _build_handler_for_current_backend(self) -> ConversationHandler:
+        """Create and install a fresh handler for the current runtime backend config."""
+        if self._handler_factory is None:
+            return self.handler
+        handler = self._handler_factory(self._voice_override)
+        self._install_handler(handler)
+        self._active_backend_name = get_backend_choice()
+        return handler
+
+    async def _shutdown_active_handler(self) -> None:
+        """Best-effort shutdown for the currently active handler."""
+        try:
+            await self.handler.shutdown()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.debug("Active handler shutdown ignored during restart: %s", e)
+
+    def _mark_restart_requested(self, reason: str) -> None:
+        """Request a backend restart from a synchronous route handler."""
+        logger.info("Backend restart requested: %s", reason)
+        self._set_backend_connection_state("connecting")
+        loop = self._asyncio_loop
+        if loop is not None and loop.is_running():
+            asyncio.run_coroutine_threadsafe(self.request_backend_restart(reason), loop)
+            return
+        self._restart_requested.set()
+
+    async def request_backend_restart(self, reason: str) -> None:
+        """Ask the startup loop to rebuild the backend and stop the current handler."""
+        logger.info("Backend restart requested: %s", reason)
+        self._set_backend_connection_state("connecting")
+        self._restart_requested.set()
+        await self._shutdown_active_handler()
+
+    async def _sleep_or_restart_requested(self, delay: float) -> None:
+        """Sleep for a retry interval, waking early if a restart is requested."""
+        if self._restart_requested.is_set():
+            return
+        try:
+            await asyncio.wait_for(self._restart_requested.wait(), timeout=delay)
+        except asyncio.TimeoutError:
+            pass
 
     @staticmethod
     def _format_backend_error(error: BaseException | str) -> str:
@@ -370,6 +435,60 @@ class LocalStream:
         """Read the saved startup personality from instance-local UI settings."""
         return read_startup_settings(self._instance_path).profile
 
+    async def apply_personality(self, profile: Optional[str]) -> str:
+        """Apply a personality by updating config and restarting the active backend."""
+        try:
+            from reachy_mini_conversation_app.config import set_custom_profile
+            from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
+
+            previous_profile = getattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+            set_custom_profile(profile)
+            try:
+                get_session_instructions()
+                get_session_voice(default=get_default_voice_for_backend(get_backend_choice()))
+            except BaseException:
+                set_custom_profile(previous_profile)
+                raise
+            await self.request_backend_restart("personality_changed")
+            return "Applied personality and restarting backend."
+        except Exception as e:
+            logger.error("Error applying personality '%s': %s", profile, e)
+            return f"Failed to apply personality: {e}"
+        except BaseException as e:
+            logger.error("Failed to resolve personality content: %s", e)
+            return f"Failed to apply personality: {e}"
+
+    async def get_available_voices(self) -> list[str]:
+        """Return voices available for the currently selected backend."""
+        return get_available_voices_for_backend(get_backend_choice())
+
+    def get_current_voice(self) -> str:
+        """Return the currently selected voice override or backend profile voice."""
+        if self._voice_override:
+            return self._voice_override
+        try:
+            from reachy_mini_conversation_app.prompts import get_session_voice
+
+            return get_session_voice(default=get_default_voice_for_backend(get_backend_choice()))
+        except Exception:
+            return get_default_voice_for_backend(get_backend_choice())
+
+    async def change_voice(self, voice: str) -> str:
+        """Change the voice by rebuilding the active backend from LocalStream."""
+        available_voices = get_available_voices_for_backend(get_backend_choice())
+        default_voice = get_default_voice_for_backend(get_backend_choice())
+        resolved_voice = voice if voice in available_voices else default_voice
+        if resolved_voice != voice:
+            logger.warning(
+                "Ignoring unsupported voice %r for backend=%r; using %r",
+                voice,
+                get_backend_choice(),
+                resolved_voice,
+            )
+        self._voice_override = resolved_voice
+        await self.request_backend_restart("voice_changed")
+        return f"Voice changed to {resolved_voice}."
+
     def _init_settings_ui_if_needed(self) -> None:
         """Attach minimal settings UI to the settings app.
 
@@ -417,8 +536,9 @@ class LocalStream:
             can_proceed_with_openai = has_openai_key
             can_proceed_with_gemini = has_gemini_key
             can_proceed_with_hf = has_hf_connection
-            can_proceed = self._has_required_key(active_backend)
-            requires_restart = backend_provider != active_backend
+            readiness_backend = backend_provider if self._can_rebuild_handler() else active_backend
+            can_proceed = self._has_required_key(readiness_backend)
+            requires_restart = backend_provider != active_backend and not self._can_rebuild_handler()
             backend_connection = self._backend_connection_status()
             return {
                 "active_backend": active_backend,
@@ -512,10 +632,14 @@ class LocalStream:
                     return JSONResponse({"ok": False, "error": "invalid_hf_mode"}, status_code=400)
 
             self._persist_backend_choice(backend)
+            if self._can_rebuild_handler():
+                self._mark_restart_requested("backend_config_changed")
             payload_data = _status_payload()
             message = "Backend saved."
             if payload_data["requires_restart"]:
                 message = "Backend saved. Restart Reachy Mini Conversation from the desktop app to apply it."
+            elif self._can_rebuild_handler():
+                message = "Backend saved. Reconnecting backend."
             return JSONResponse(
                 {
                     "ok": True,
@@ -555,16 +679,34 @@ class LocalStream:
     async def _run_handler_startup_loop(self) -> None:
         """Start the realtime handler and keep settings UI alive after backend failures."""
         while not self._stop_event.is_set():
-            active_backend = self._active_backend()
-            if get_backend_choice() != active_backend:
-                self._set_backend_connection_state("restart_required")
-                await asyncio.sleep(0.5)
-                continue
+            selected_backend = get_backend_choice()
+            if selected_backend != self._active_backend() or self._restart_requested.is_set():
+                await self._shutdown_active_handler()
+                if not self._can_rebuild_handler():
+                    self._restart_requested.clear()
+                    self._set_backend_connection_state("restart_required")
+                    await self._sleep_or_restart_requested(0.5)
+                    continue
+                self._restart_requested.clear()
+                try:
+                    self._build_handler_for_current_backend()
+                except Exception as e:
+                    self._set_backend_connection_state("disconnected", e)
+                    logger.warning(
+                        "%s backend handler failed to initialize: %s. Retrying in %.1f seconds.",
+                        selected_backend,
+                        e,
+                        self._backend_retry_delay,
+                        exc_info=logger.isEnabledFor(logging.DEBUG),
+                    )
+                    await self._sleep_or_restart_requested(self._backend_retry_delay)
+                    continue
 
+            active_backend = self._active_backend()
             if not self._has_required_key(active_backend):
                 requirement_name = self._requirement_name(active_backend)
                 self._set_backend_connection_state("waiting_for_config", f"{requirement_name} is not configured.")
-                await asyncio.sleep(0.5)
+                await self._sleep_or_restart_requested(0.5)
                 continue
 
             self._set_backend_connection_state("connecting")
@@ -585,13 +727,16 @@ class LocalStream:
                 if self._stop_event.is_set():
                     return
                 self._set_backend_connection_state("disconnected")
+                if self._restart_requested.is_set():
+                    logger.info("%s backend stopped for requested restart.", active_backend)
+                    continue
                 logger.info(
                     "%s backend session ended. Settings UI remains available; retrying in %.1f seconds.",
                     active_backend,
                     self._backend_retry_delay,
                 )
 
-            await asyncio.sleep(self._backend_retry_delay)
+            await self._sleep_or_restart_requested(self._backend_retry_delay)
 
     def launch(self) -> None:
         """Start the recorder/player and run the async processing loops.
@@ -633,8 +778,15 @@ class LocalStream:
             # Poll until the key becomes available (set via the settings UI)
             try:
                 while not self._stop_event.is_set() and not self._has_required_key(active_backend):
-                    if get_backend_choice() != active_backend:
-                        self._set_backend_connection_state("restart_required")
+                    selected_backend = get_backend_choice()
+                    if selected_backend != active_backend:
+                        if self._can_rebuild_handler():
+                            active_backend = selected_backend
+                            self._active_backend_name = selected_backend
+                            self._restart_requested.set()
+                            self._set_backend_connection_state("waiting_for_config")
+                        else:
+                            self._set_backend_connection_state("restart_required")
                     time.sleep(0.2)
             except KeyboardInterrupt:
                 logger.info("Interrupted while waiting for API key.")
@@ -662,6 +814,10 @@ class LocalStream:
                         lambda: self._asyncio_loop,
                         persist_personality=self._persist_personality,
                         get_persisted_personality=self._read_persisted_personality,
+                        apply_personality=self.apply_personality,
+                        get_available_voices=self.get_available_voices,
+                        get_current_voice=self.get_current_voice,
+                        change_voice=self.change_voice,
                     )
             except Exception:
                 pass
@@ -749,7 +905,11 @@ class LocalStream:
     async def play_loop(self) -> None:
         """Fetch outputs from the handler: log text and play audio frames."""
         while not self._stop_event.is_set():
-            handler_output = await self.handler.emit()
+            handler = self.handler
+            try:
+                handler_output = await asyncio.wait_for(handler.emit(), timeout=0.5)
+            except asyncio.TimeoutError:
+                continue
 
             if isinstance(handler_output, AdditionalOutputs):
                 for msg in handler_output.args:

--- a/src/reachy_mini_conversation_app/headless_personality_ui.py
+++ b/src/reachy_mini_conversation_app/headless_personality_ui.py
@@ -9,7 +9,7 @@ callable to avoid cross-thread issues.
 from __future__ import annotations
 import asyncio
 import logging
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Awaitable
 
 from fastapi import Query, FastAPI, Request
 
@@ -42,6 +42,10 @@ def mount_personality_routes(
     *,
     persist_personality: Callable[[Optional[str], Optional[str]], None] | None = None,
     get_persisted_personality: Callable[[], Optional[str]] | None = None,
+    apply_personality: Callable[[Optional[str]], Awaitable[str]] | None = None,
+    get_available_voices: Callable[[], Awaitable[list[str]]] | None = None,
+    get_current_voice: Callable[[], str] | None = None,
+    change_voice: Callable[[str], Awaitable[str]] | None = None,
 ) -> None:
     """Register personality management endpoints on a FastAPI app."""
     try:
@@ -254,9 +258,12 @@ def mount_personality_routes(
 
         async def _do_apply() -> tuple[str, Optional[str]]:
             sel = None if sel_name == DEFAULT_OPTION else sel_name
-            status = await handler.apply_personality(sel)
-            get_current_voice = getattr(handler, "get_current_voice", None)
-            voice_override = get_current_voice() if callable(get_current_voice) else None
+            if apply_personality is not None:
+                status = await apply_personality(sel)
+            else:
+                status = await handler.apply_personality(sel)
+            current_voice_callback = get_current_voice or getattr(handler, "get_current_voice", None)
+            voice_override = current_voice_callback() if callable(current_voice_callback) else None
             return status, voice_override
 
         try:
@@ -282,6 +289,8 @@ def mount_personality_routes(
 
         async def _get_v() -> list[str]:
             try:
+                if get_available_voices is not None:
+                    return await get_available_voices()
                 return await handler.get_available_voices()
             except Exception:
                 return get_available_voices_for_backend()
@@ -301,6 +310,8 @@ def mount_personality_routes(
 
         def _get_current() -> str:
             try:
+                if get_current_voice is not None:
+                    return get_current_voice()
                 return handler.get_current_voice()
             except Exception:
                 return fallback_voice
@@ -327,6 +338,8 @@ def mount_personality_routes(
             return JSONResponse({"ok": False, "error": "loop_unavailable"}, status_code=503)  # type: ignore
 
         async def _do() -> str:
+            if change_voice is not None:
+                return await change_voice(voice)
             return await handler.change_voice(voice)
 
         try:

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -101,6 +101,7 @@ def run(
     from reachy_mini_conversation_app.console import LocalStream
     from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
     from reachy_mini_conversation_app.audio.head_wobbler import HeadWobbler
+    from reachy_mini_conversation_app.conversation_handler import ConversationHandler
 
     if args.no_camera and args.head_tracker is not None:
         logger.warning("Head tracking disabled: --no-camera flag is set. Remove --no-camera to enable head tracking.")
@@ -176,52 +177,56 @@ def run(
     )
     logger.debug(f"Chatbot avatar images: {chatbot.avatar_images}")
 
-    if is_gemini_model():
-        from reachy_mini_conversation_app.gemini_live import GeminiLiveHandler
+    def build_handler(startup_voice: Optional[str] = None) -> ConversationHandler:
+        """Build a realtime handler for the current runtime backend config."""
+        if is_gemini_model():
+            from reachy_mini_conversation_app.gemini_live import GeminiLiveHandler
 
-        logger.info(
-            "Using %s via GeminiLiveHandler",
-            get_backend_label(config.BACKEND_PROVIDER),
-        )
-        handler = GeminiLiveHandler(
-            deps,
-            gradio_mode=args.gradio,
-            instance_path=instance_path,
-            startup_voice=startup_settings.voice,
-        )
-    elif config.BACKEND_PROVIDER == HF_BACKEND:
-        from reachy_mini_conversation_app.huggingface_realtime import HuggingFaceRealtimeHandler
+            logger.info(
+                "Using %s via GeminiLiveHandler",
+                get_backend_label(config.BACKEND_PROVIDER),
+            )
+            return GeminiLiveHandler(
+                deps,
+                gradio_mode=args.gradio,
+                instance_path=instance_path,
+                startup_voice=startup_voice,
+            )
+        if config.BACKEND_PROVIDER == HF_BACKEND:
+            from reachy_mini_conversation_app.huggingface_realtime import HuggingFaceRealtimeHandler
 
-        hf_connection_selection = get_hf_connection_selection()
-        transport_label = (
-            "Hugging Face direct websocket"
-            if hf_connection_selection.mode == HF_LOCAL_CONNECTION_MODE and hf_connection_selection.has_target
-            else "Hugging Face session proxy"
-        )
-        logger.info(
-            "Using %s via Hugging Face realtime handler (%s)",
-            get_backend_label(config.BACKEND_PROVIDER),
-            transport_label,
-        )
-        handler = HuggingFaceRealtimeHandler(
-            deps,
-            gradio_mode=args.gradio,
-            instance_path=instance_path,
-            startup_voice=startup_settings.voice,
-        )  # type: ignore[assignment]
-    else:
+            hf_connection_selection = get_hf_connection_selection()
+            transport_label = (
+                "Hugging Face direct websocket"
+                if hf_connection_selection.mode == HF_LOCAL_CONNECTION_MODE and hf_connection_selection.has_target
+                else "Hugging Face session proxy"
+            )
+            logger.info(
+                "Using %s via Hugging Face realtime handler (%s)",
+                get_backend_label(config.BACKEND_PROVIDER),
+                transport_label,
+            )
+            return HuggingFaceRealtimeHandler(
+                deps,
+                gradio_mode=args.gradio,
+                instance_path=instance_path,
+                startup_voice=startup_voice,
+            )
+
         from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
 
         logger.info(
             "Using %s via OpenAI realtime handler (OpenAI Realtime API)",
             get_backend_label(config.BACKEND_PROVIDER),
         )
-        handler = OpenaiRealtimeHandler(
+        return OpenaiRealtimeHandler(
             deps,
             gradio_mode=args.gradio,
             instance_path=instance_path,
-            startup_voice=startup_settings.voice,
-        )  # type: ignore[assignment]
+            startup_voice=startup_voice,
+        )
+
+    handler = build_handler(startup_settings.voice)
 
     stream_manager: gr.Blocks | LocalStream | None = None
 
@@ -268,6 +273,8 @@ def run(
             robot,
             settings_app=settings_app,
             instance_path=instance_path,
+            handler_factory=build_handler,
+            startup_voice=startup_settings.voice,
         )
 
     # Each async service → its own thread/loop

--- a/src/reachy_mini_conversation_app/static/main.js
+++ b/src/reachy_mini_conversation_app/static/main.js
@@ -296,7 +296,9 @@ function describeHFConfiguration(status) {
 }
 
 function describeActiveBackendTarget(status) {
-  const activeBackend = status.active_backend || status.backend_provider || DEFAULT_BACKEND;
+  const activeBackend = status.backend_connected
+    ? (status.active_backend || status.backend_provider || DEFAULT_BACKEND)
+    : (status.backend_provider || status.active_backend || DEFAULT_BACKEND);
   if (activeBackend === HF_BACKEND) {
     if (status.hf_connection_mode === "local") {
       const host = status.hf_direct_host || HF_DEFAULT_HOST;
@@ -426,7 +428,9 @@ async function init() {
 
   function renderBackendConnectionStatus(status) {
     const state = backendConnectionState(status);
-    const activeBackend = status.active_backend || status.backend_provider || DEFAULT_BACKEND;
+    const activeBackend = status.backend_connected
+      ? (status.active_backend || status.backend_provider || DEFAULT_BACKEND)
+      : (status.backend_provider || status.active_backend || DEFAULT_BACKEND);
     const activeLabel = backendMeta(activeBackend).label;
     const target = describeActiveBackendTarget(status);
     const errorDetails = status.backend_error ? ` Last error: ${status.backend_error}` : "";
@@ -645,18 +649,23 @@ async function init() {
             return;
           }
 
-          await saveBackendConfig(selectedBackend, {
+          const saved = await saveBackendConfig(selectedBackend, {
             hfMode: "local",
             hfHost: host,
             hfPort: port,
           });
+          setStatusMessage(statusEl, saved.message || "Saved. Reconnecting…", "ok");
         } else {
-          await saveBackendConfig(selectedBackend, {
+          const saved = await saveBackendConfig(selectedBackend, {
             hfMode: "deployed",
           });
+          setStatusMessage(statusEl, saved.message || "Saved. Reconnecting…", "ok");
         }
-        setStatusMessage(statusEl, "Saved. Reloading…", "ok");
-        window.location.reload();
+        const latest = await fetchStatusSnapshot();
+        if (latest) {
+          st = latest;
+          renderCredentialPanels(st);
+        }
       } catch (e) {
         if (e.message === "missing_hf_session_url") {
           setStatusMessage(
@@ -697,9 +706,13 @@ async function init() {
       } else {
         setStatusMessage(statusEl, "Saving Gemini token...", "ok");
       }
-      await saveBackendConfig(selectedBackend, { key });
-      setStatusMessage(statusEl, "Saved. Reloading…", "ok");
-      window.location.reload();
+      const saved = await saveBackendConfig(selectedBackend, { key });
+      setStatusMessage(statusEl, saved.message || "Saved. Reconnecting…", "ok");
+      const latest = await fetchStatusSnapshot();
+      if (latest) {
+        st = latest;
+        renderCredentialPanels(st);
+      }
     } catch (e) {
       input.classList.add("error");
       if (selectedBackend === OPENAI_BACKEND && e.message === "invalid_api_key") {

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -781,6 +781,24 @@ def test_headless_personality_routes_can_use_stream_callbacks() -> None:
         loop.close()
 
 
+@pytest.mark.asyncio
+async def test_apply_personality_propagates_restart_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cancellation during backend restart should not be converted into a status string."""
+    monkeypatch.setattr("reachy_mini_conversation_app.config.set_custom_profile", lambda _profile: None)
+    monkeypatch.setattr("reachy_mini_conversation_app.prompts.get_session_instructions", lambda: "instructions")
+    monkeypatch.setattr("reachy_mini_conversation_app.prompts.get_session_voice", lambda default: default)
+
+    stream = LocalStream(MagicMock(), MagicMock())
+
+    async def cancel_restart(_reason: str) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(stream, "request_backend_restart", cancel_restart)
+
+    with pytest.raises(asyncio.CancelledError):
+        await stream.apply_personality("sorry_bro")
+
+
 def test_local_stream_persist_personality_stores_voice_override(tmp_path) -> None:
     """Persisting startup settings should write both profile and voice override."""
     stream = LocalStream(MagicMock(), MagicMock(), instance_path=str(tmp_path))

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -24,6 +24,16 @@ from reachy_mini_conversation_app.startup_settings import (
 from reachy_mini_conversation_app.headless_personality_ui import mount_personality_routes
 
 
+async def _wait_until(predicate: Any, timeout: float = 1.0) -> None:
+    """Wait until a test predicate becomes true."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("Timed out waiting for condition")
+
+
 def test_clear_audio_queue_prefers_clear_player_when_available() -> None:
     """Local GStreamer audio should use the lower-level player flush when available."""
     handler = MagicMock()
@@ -176,6 +186,49 @@ def test_backend_config_persists_gemini_selection_and_status(
     assert "BACKEND_PROVIDER=gemini" in env_text
     assert "MODEL_NAME=gemini-3.1-flash-live-preview" in env_text
     assert "GEMINI_API_KEY=gem-test-token" in env_text
+
+
+def test_backend_config_requests_in_process_restart_with_handler_factory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rebuild-capable LocalStream should reconnect in process after backend changes."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "openai")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime-2")
+    monkeypatch.setattr(config, "OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setattr(config, "GEMINI_API_KEY", None)
+    monkeypatch.setenv("BACKEND_PROVIDER", "openai")
+    monkeypatch.setenv("MODEL_NAME", "gpt-realtime-2")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    app = FastAPI()
+    handler = MagicMock()
+    handler.shutdown = AsyncMock()
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    stream = LocalStream(
+        handler,
+        robot,
+        settings_app=app,
+        instance_path=str(tmp_path),
+        handler_factory=lambda _voice: handler,
+    )
+    stream._init_settings_ui_if_needed()
+
+    response = TestClient(app).post(
+        "/backend_config",
+        json={"backend": "gemini", "api_key": "gem-test-token"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["message"] == "Backend saved. Reconnecting backend."
+    assert data["backend_provider"] == "gemini"
+    assert data["requires_restart"] is False
+    assert data["can_proceed"] is True
+    assert data["backend_connection_state"] == "connecting"
+    assert stream._restart_requested.is_set()
 
 
 def test_backend_config_preserves_explicit_model_override_when_saving_key(
@@ -509,6 +562,81 @@ def test_backend_startup_failure_is_recorded_without_raising(
     assert data["backend_error"] == "RuntimeError: local server unavailable"
 
 
+@pytest.mark.asyncio
+async def test_startup_loop_rebuilds_handler_for_backend_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LocalStream should own backend swaps by shutting down and rebuilding the handler."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "openai")
+    monkeypatch.setattr(config, "MODEL_NAME", "gpt-realtime-2")
+    monkeypatch.setattr(config, "OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setattr(config, "GEMINI_API_KEY", "gem-test-key")
+
+    class FakeHandler:
+        def __init__(self, backend: str) -> None:
+            self.backend = backend
+            self.connection = None
+            self.session = None
+            self.output_queue = asyncio.Queue()
+            self.started = asyncio.Event()
+            self.stopped = asyncio.Event()
+            self.shutdown_calls = 0
+
+        async def start_up(self) -> None:
+            if self.backend == "gemini":
+                self.session = object()
+            else:
+                self.connection = object()
+            self.started.set()
+            await self.stopped.wait()
+            self.connection = None
+            self.session = None
+
+        async def shutdown(self) -> None:
+            self.shutdown_calls += 1
+            self.stopped.set()
+
+        async def receive(self, _frame: Any) -> None:
+            return None
+
+        async def emit(self) -> None:
+            return None
+
+    handlers: list[FakeHandler] = []
+
+    def handler_factory(_voice: str | None) -> FakeHandler:
+        handler = FakeHandler(config.BACKEND_PROVIDER)
+        handlers.append(handler)
+        return handler
+
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    initial_handler = handler_factory(None)
+    stream = LocalStream(initial_handler, robot, handler_factory=handler_factory)
+    stream._backend_retry_delay = 0.01
+
+    startup_task = asyncio.create_task(stream._run_handler_startup_loop())
+    try:
+        await _wait_until(lambda: initial_handler.started.is_set())
+
+        monkeypatch.setattr(config, "BACKEND_PROVIDER", "gemini")
+        monkeypatch.setattr(config, "MODEL_NAME", "gemini-3.1-flash-live-preview")
+        await stream.request_backend_restart("backend_config_changed")
+
+        await _wait_until(lambda: len(handlers) == 2 and handlers[1].started.is_set())
+
+        assert initial_handler.shutdown_calls >= 1
+        assert handlers[1].backend == "gemini"
+        assert stream.handler is handlers[1]
+        assert stream._active_backend_name == "gemini"
+        assert stream._backend_connected() is True
+    finally:
+        stream._stop_event.set()
+        await stream._shutdown_active_handler()
+        startup_task.cancel()
+        try:
+            await startup_task
+        except asyncio.CancelledError:
+            pass
+
+
 def test_headless_personality_routes_return_gemini_voices_when_backend_selected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -606,6 +734,47 @@ def test_headless_personality_routes_persist_startup_with_voice_override() -> No
         assert response.json()["ok"] is True
         handler.apply_personality.assert_awaited_once_with("sorry_bro")
         persist_personality.assert_called_once_with("sorry_bro", "shimmer")
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=1.0)
+        loop.close()
+
+
+def test_headless_personality_routes_can_use_stream_callbacks() -> None:
+    """Headless personality routes can delegate apply/restart ownership to LocalStream."""
+    app = FastAPI()
+    handler = MagicMock()
+    handler.apply_personality = AsyncMock(return_value="handler should not be called")
+    apply_personality = AsyncMock(return_value="Applied personality and restarting backend.")
+    get_current_voice = MagicMock(return_value="cedar")
+
+    loop = asyncio.new_event_loop()
+    started = threading.Event()
+
+    def _run_loop() -> None:
+        asyncio.set_event_loop(loop)
+        started.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=_run_loop, daemon=True)
+    thread.start()
+    started.wait(timeout=1.0)
+
+    try:
+        mount_personality_routes(
+            app,
+            handler,
+            lambda: loop,
+            apply_personality=apply_personality,
+            get_current_voice=get_current_voice,
+        )
+
+        response = TestClient(app).post("/personalities/apply?name=sorry_bro")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "Applied personality and restarting backend."
+        apply_personality.assert_awaited_once_with("sorry_bro")
+        handler.apply_personality.assert_not_awaited()
     finally:
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=1.0)


### PR DESCRIPTION
## Summary
- move headless backend rebuild/retry ownership into LocalStream using a handler factory
- let backend config, personality, and voice changes request an in-process backend restart instead of requiring app restart or backend-owned reconnects
- update the settings UI to show reconnecting status without reloading, and add LocalStream-level regression coverage

## Verification
- uv run ruff format --check
- uv run ruff check
- uv run mypy
- node --check src/reachy_mini_conversation_app/static/main.js
- uv run pytest -q