### PR TITLE
Bump up huggingface-hub 1.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ local_vision = [
   "torch>=2.1",
   "transformers==5.3.0",
   "num2words",
-  "hf-xet",
 ]
 yolo_vision = [
   "ultralytics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "aiortc>=1.13.0",
     "fastrtc>=0.0.34",
     "gradio==5.50.1.dev1",
-    "huggingface-hub==1.3.0",
+    "huggingface-hub==1.17.0",
     "httpx",
 
     #Environment variables
@@ -40,6 +40,7 @@ local_vision = [
   "torch>=2.1",
   "transformers==5.3.0",
   "num2words",
+  "hf-xet",
 ]
 yolo_vision = [
   "ultralytics",


### PR DESCRIPTION
## Summary
Straightforward dependency bump. No code changes needed. Closes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/378

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [x] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
⚠️ Can't update the lock file and merge until `reachy_mini` includes [PR 1171](https://github.com/pollen-robotics/reachy_mini/pull/1171) into the new release