### PR TITLE
remove auto gradio mode for sim

### DIFF
--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -130,21 +130,6 @@ def run(
             logger.error("Please check your configuration and try again.")
             sys.exit(1)
 
-    # Auto-enable Gradio in simulation mode (both MuJoCo for daemon and mockup-sim for desktop app)
-    status = robot.client.get_status()
-    if isinstance(status, dict):
-        simulation_enabled = status.get("simulation_enabled", False)
-        mockup_sim_enabled = status.get("mockup_sim_enabled", False)
-    else:
-        simulation_enabled = getattr(status, "simulation_enabled", False)
-        mockup_sim_enabled = getattr(status, "mockup_sim_enabled", False)
-
-    is_simulation = simulation_enabled or mockup_sim_enabled
-
-    if is_simulation and not args.gradio:
-        logger.info("Simulation mode detected. Automatically enabling gradio flag.")
-        args.gradio = True
-
     try:
         camera_worker, vision_processor = initialize_camera_and_vision(args, robot)
     except CameraVisionInitializationError as e:


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
<!-- What does this PR change and why? -->

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [x] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Notes
<!-- Optional: context, caveats, migration notes -->
needs https://github.com/pollen-robotics/reachy_mini/pull/1189 to be merged