### PR TITLE
Add configurable realtime transcription language

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 # Hugging Face uses the server's model selection and ignores MODEL_NAME.
 # MODEL_NAME="gpt-realtime-2"
 
+# Optional realtime input transcription language.
+# Defaults to "en". Set to a backend-supported code such as "zh" for Chinese.
+# REALTIME_TRANSCRIPTION_LANGUAGE="en"
+
 # Set up your API key according to your backend
 OPENAI_API_KEY=
 # GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Copy `.env.example` to `.env` when you want to switch backends, provide API keys
 | `GEMINI_API_KEY` | Required for Gemini mode. Also accepts `GOOGLE_API_KEY`. Get one at [aistudio.google.com](https://aistudio.google.com/apikey). |
 | `BACKEND_PROVIDER` | Realtime backend to use: `huggingface` (default), `openai`, or `gemini`. |
 | `MODEL_NAME` | Optional model override for OpenAI Realtime or Gemini Live. Defaults to `gpt-realtime-2` for OpenAI and `gemini-3.1-flash-live-preview` for Gemini. Hugging Face uses the server's model selection. |
+| `REALTIME_TRANSCRIPTION_LANGUAGE` | Optional input transcription language for realtime backends. Defaults to `en`; set to a backend-supported code such as `zh` for Chinese. |
 | `HF_REALTIME_CONNECTION_MODE` | Hugging Face connection selector: `deployed` uses the built-in Hugging Face server; `local` uses `HF_REALTIME_WS_URL`. Defaults to `deployed`. |
 | `HF_REALTIME_WS_URL` | Direct websocket endpoint for your own Hugging Face backend. Accepts either a base URL like `ws://127.0.0.1:8765/v1` or the full websocket URL `ws://127.0.0.1:8765/v1/realtime`. Used when `HF_REALTIME_CONNECTION_MODE=local`. |
 | `HF_HOME` | Cache directory for local Hugging Face downloads (only used with `--local-vision` flag, defaults to `./cache`). |

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -474,7 +474,9 @@ def refresh_runtime_config_from_env() -> None:
     # Deliberately ignore HF_REALTIME_SESSION_URL from the environment; the app-managed proxy is HF_DEFAULTS.session_url.
     config.HF_REALTIME_SESSION_URL = HF_DEFAULTS.session_url
     config.HF_REALTIME_WS_URL = os.getenv(HF_REALTIME_WS_URL_ENV)
-    config.REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV))
+    config.REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(
+        os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV)
+    )
     config.HF_HOME = os.getenv("HF_HOME", "./cache")
     config.LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     config.HF_TOKEN = os.getenv("HF_TOKEN")

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -370,9 +370,7 @@ class Config:
     # Deliberately ignore HF_REALTIME_SESSION_URL from the environment; the app-managed proxy is HF_DEFAULTS.session_url.
     HF_REALTIME_SESSION_URL = HF_DEFAULTS.session_url
     HF_REALTIME_WS_URL = os.getenv(HF_REALTIME_WS_URL_ENV)
-    REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(
-        os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV)
-    )
+    REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV))
     HF_HOME = os.getenv("HF_HOME", "./cache")
     LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     HF_TOKEN = os.getenv("HF_TOKEN")  # Optional, falls back to hf auth login if not set
@@ -476,9 +474,7 @@ def refresh_runtime_config_from_env() -> None:
     # Deliberately ignore HF_REALTIME_SESSION_URL from the environment; the app-managed proxy is HF_DEFAULTS.session_url.
     config.HF_REALTIME_SESSION_URL = HF_DEFAULTS.session_url
     config.HF_REALTIME_WS_URL = os.getenv(HF_REALTIME_WS_URL_ENV)
-    config.REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(
-        os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV)
-    )
+    config.REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV))
     config.HF_HOME = os.getenv("HF_HOME", "./cache")
     config.LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     config.HF_TOKEN = os.getenv("HF_TOKEN")

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -91,6 +91,7 @@ HF_BACKEND = "huggingface"
 DEFAULT_BACKEND_PROVIDER = HF_BACKEND
 HF_REALTIME_CONNECTION_MODE_ENV = "HF_REALTIME_CONNECTION_MODE"
 HF_REALTIME_WS_URL_ENV = "HF_REALTIME_WS_URL"
+REALTIME_TRANSCRIPTION_LANGUAGE_ENV = "REALTIME_TRANSCRIPTION_LANGUAGE"
 HF_LOCAL_CONNECTION_MODE = "local"
 HF_DEPLOYED_CONNECTION_MODE = "deployed"
 HF_REALTIME_SESSION_PROXY_URL = "https://pollen-robotics-reachy-mini-realtime-url.hf.space/session"
@@ -209,6 +210,12 @@ def _normalize_hf_connection_mode(value: str | None) -> str | None:
         )
         return None
     return candidate
+
+
+def _normalize_transcription_language(value: str | None) -> str:
+    """Return the configured realtime transcription language."""
+    candidate = (value or "").strip()
+    return candidate or "en"
 
 
 @dataclass(frozen=True)
@@ -363,6 +370,9 @@ class Config:
     # Deliberately ignore HF_REALTIME_SESSION_URL from the environment; the app-managed proxy is HF_DEFAULTS.session_url.
     HF_REALTIME_SESSION_URL = HF_DEFAULTS.session_url
     HF_REALTIME_WS_URL = os.getenv(HF_REALTIME_WS_URL_ENV)
+    REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(
+        os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV)
+    )
     HF_HOME = os.getenv("HF_HOME", "./cache")
     LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     HF_TOKEN = os.getenv("HF_TOKEN")  # Optional, falls back to hf auth login if not set
@@ -466,6 +476,9 @@ def refresh_runtime_config_from_env() -> None:
     # Deliberately ignore HF_REALTIME_SESSION_URL from the environment; the app-managed proxy is HF_DEFAULTS.session_url.
     config.HF_REALTIME_SESSION_URL = HF_DEFAULTS.session_url
     config.HF_REALTIME_WS_URL = os.getenv(HF_REALTIME_WS_URL_ENV)
+    config.REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(
+        os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV)
+    )
     config.HF_HOME = os.getenv("HF_HOME", "./cache")
     config.LOCAL_VISION_MODEL = os.getenv("LOCAL_VISION_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")
     config.HF_TOKEN = os.getenv("HF_TOKEN")

--- a/src/reachy_mini_conversation_app/huggingface_realtime.py
+++ b/src/reachy_mini_conversation_app/huggingface_realtime.py
@@ -93,7 +93,10 @@ class HuggingFaceRealtimeHandler(BaseRealtimeHandler):
                     # The OpenAI SDK type only includes 24 kHz PCM, but the HF
                     # compatible server uses rate=None for native 16 kHz mode.
                     format=_native_rate_audio_pcm(),  # type: ignore[typeddict-item]
-                    transcription=AudioTranscriptionParam(model="gpt-4o-transcribe", language="en"),
+                    transcription=AudioTranscriptionParam(
+                        model="gpt-4o-transcribe",
+                        language=config.REALTIME_TRANSCRIPTION_LANGUAGE,
+                    ),
                     turn_detection=ServerVad(type="server_vad", interrupt_response=True),
                 ),
                 output=RealtimeAudioConfigOutputParam(

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -140,7 +140,10 @@ class OpenaiRealtimeHandler(BaseRealtimeHandler):
             audio=RealtimeAudioConfigParam(
                 input=RealtimeAudioConfigInputParam(
                     format=AudioPCM(type="audio/pcm", rate=24000),
-                    transcription=AudioTranscriptionParam(model="gpt-4o-transcribe", language="en"),
+                    transcription=AudioTranscriptionParam(
+                        model="gpt-4o-transcribe",
+                        language=config.REALTIME_TRANSCRIPTION_LANGUAGE,
+                    ),
                     turn_detection=ServerVad(type="server_vad", interrupt_response=True),
                 ),
                 output=RealtimeAudioConfigOutputParam(

--- a/tests/test_huggingface_realtime.py
+++ b/tests/test_huggingface_realtime.py
@@ -289,8 +289,19 @@ async def test_run_realtime_session_uses_default_voice_for_lb_allocated_sessions
     # HF at 16 kHz passes None so the backend uses its optimal default (16 kHz).
     assert session["audio"]["input"]["format"]["rate"] is None
     assert session["audio"]["output"]["format"]["rate"] is None
+    assert session["audio"]["input"]["transcription"]["language"] == "en"
     output = session["audio"]["output"]
     assert output["voice"] == HF_DEFAULT_VOICE
+
+
+def test_huggingface_session_uses_configured_transcription_language(monkeypatch: Any) -> None:
+    """Hugging Face realtime sessions should forward the configured transcription language."""
+    monkeypatch.setattr(config, "REALTIME_TRANSCRIPTION_LANGUAGE", "zh")
+    handler = HuggingFaceRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+
+    session = handler._get_session_config([])
+
+    assert session["audio"]["input"]["transcription"]["language"] == "zh"
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -408,6 +408,16 @@ def test_handler_uses_startup_voice_at_startup(monkeypatch: Any) -> None:
     assert handler.get_current_voice() == "shimmer"
 
 
+def test_openai_session_uses_configured_transcription_language(monkeypatch: Any) -> None:
+    """OpenAI realtime sessions should forward the configured transcription language."""
+    monkeypatch.setattr(config, "REALTIME_TRANSCRIPTION_LANGUAGE", "fr")
+    handler = OpenaiRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+
+    session = handler._get_session_config([])
+
+    assert session["audio"]["input"]["transcription"]["language"] == "fr"
+
+
 def test_copy_preserves_current_voice_override(monkeypatch: Any) -> None:
     """Copied OpenAI handlers should keep the current voice override."""
     monkeypatch.setattr(config, "BACKEND_PROVIDER", "openai")


### PR DESCRIPTION
## Summary

Thank you for maintaining the Reachy Mini conversation app.

This PR adds a small `REALTIME_TRANSCRIPTION_LANGUAGE` configuration option for realtime input transcription. The current session config hard-codes `language="en"` for OpenAI and Hugging Face realtime backends. This keeps that as the default, while allowing users running non-English realtime backends to pass a backend-supported language code such as `zh`.

This is useful when connecting the app to a local OpenAI-compatible Hugging Face realtime backend configured for another STT language.

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Changes

- Add `REALTIME_TRANSCRIPTION_LANGUAGE`, defaulting to `en`.
- Use the configured language in both Hugging Face and OpenAI realtime session input transcription config.
- Refresh the value in `refresh_runtime_config_from_env()`.
- Document the new variable in `.env.example` and `README.md`.
- Add tests for Hugging Face and OpenAI session config language forwarding.

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [x] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>

## Validation

Local syntax check passed:

```bash
python3 -m py_compile \
  src/reachy_mini_conversation_app/config.py \
  src/reachy_mini_conversation_app/huggingface_realtime.py \
  src/reachy_mini_conversation_app/openai_realtime.py \
  tests/test_huggingface_realtime.py \
  tests/test_openai_realtime.py
```

I attempted the targeted pytest run locally:

```bash
uv run --python python3.12 pytest tests/test_huggingface_realtime.py tests/test_openai_realtime.py -q
```

but dependency installation was blocked by a package-index mirror returning HTTP 403 for locked Reachy Mini packages. I did not bypass the lockfile for the PR. I expect the repository CI environment to run the full test suite normally.

## Notes

The default remains `en`, so existing English deployments should behave the same. This only changes behavior when users explicitly set `REALTIME_TRANSCRIPTION_LANGUAGE`.
