### PR TITLE
Fix coalesce tool followup responses

### DIFF
--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -33,8 +33,8 @@ from reachy_mini_conversation_app.config import (
 )
 from reachy_mini_conversation_app.idle_policy import start_idle_tool_call
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
-from reachy_mini_conversation_app.tools.tool_constants import SILENT_TOOLS
 from reachy_mini_conversation_app.conversation_handler import ConversationHandler
+from reachy_mini_conversation_app.tools.tool_constants import SILENT_TOOLS
 from reachy_mini_conversation_app.tools.background_tool_manager import (
     ToolCallRoutine,
     ToolNotification,

--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -26,6 +26,7 @@ from openai.types.realtime import (
 from websockets.exceptions import ConnectionClosedError
 from openai.resources.realtime.realtime import AsyncRealtimeConnection
 
+from reachy_mini_conversation_app.tools import core_tools
 from reachy_mini_conversation_app.config import (
     config,
     get_default_voice_for_backend,
@@ -34,7 +35,6 @@ from reachy_mini_conversation_app.config import (
 from reachy_mini_conversation_app.idle_policy import start_idle_tool_call
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.conversation_handler import ConversationHandler
-from reachy_mini_conversation_app.tools.tool_constants import SILENT_TOOLS
 from reachy_mini_conversation_app.tools.background_tool_manager import (
     ToolCallRoutine,
     ToolNotification,
@@ -668,8 +668,9 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                         ),
                     )
 
-            # Always surface errors, skip the spoken follow-up for silent tools.
-            if send_result_to_model and (bg_tool.error is not None or bg_tool.tool_name not in SILENT_TOOLS):
+            tool = core_tools.ALL_TOOLS.get(bg_tool.tool_name)
+            # Always surface errors, skip the spoken follow-up for tools that opt out.
+            if send_result_to_model and (bg_tool.error is not None or tool is None or tool.needs_response):
                 await self._safe_response_create()
 
         except self._connection_closed_errors():

--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -33,6 +33,7 @@ from reachy_mini_conversation_app.config import (
 )
 from reachy_mini_conversation_app.idle_policy import start_idle_tool_call
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.tool_constants import SILENT_TOOLS
 from reachy_mini_conversation_app.conversation_handler import ConversationHandler
 from reachy_mini_conversation_app.tools.background_tool_manager import (
     ToolCallRoutine,
@@ -493,6 +494,13 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
             except asyncio.CancelledError:
                 return
 
+            # Parallel tool calls enqueue duplicate empty requests; coalesce to one.
+            while not kwargs and not self._pending_responses.empty():
+                try:
+                    self._pending_responses.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+
             sent = False
             max_retries = 5
             attempts = 0
@@ -660,7 +668,8 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                         ),
                     )
 
-            if send_result_to_model:
+            # Always surface errors, skip the spoken follow-up for silent tools.
+            if send_result_to_model and (bg_tool.error is not None or bg_tool.tool_name not in SILENT_TOOLS):
                 await self._safe_response_create()
 
         except self._connection_closed_errors():

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -53,9 +53,13 @@ class Tool(abc.ABC):
       - name: str
       - description: str
       - parameters_schema: Dict[str, Any]  # JSON Schema
+
+    Tools may override:
+      - needs_response: bool = True  # set False to skip the spoken follow-up after this tool runs
     """
 
     _auto_register: ClassVar[bool] = True
+    needs_response: ClassVar[bool] = True
 
     name: str
     description: str

--- a/src/reachy_mini_conversation_app/tools/dance.py
+++ b/src/reachy_mini_conversation_app/tools/dance.py
@@ -39,6 +39,7 @@ class Dance(Tool):
 
     name = "dance"
     description = "Play a named or random dance move once (or repeat). Non-blocking."
+    needs_response = False
     parameters_schema = {
         "type": "object",
         "properties": {

--- a/src/reachy_mini_conversation_app/tools/move_head.py
+++ b/src/reachy_mini_conversation_app/tools/move_head.py
@@ -16,6 +16,7 @@ class MoveHead(Tool):
 
     name = "move_head"
     description = "Move your head in a given direction: left, right, up, down or front."
+    needs_response = False
     parameters_schema = {
         "type": "object",
         "properties": {

--- a/src/reachy_mini_conversation_app/tools/play_emotion.py
+++ b/src/reachy_mini_conversation_app/tools/play_emotion.py
@@ -45,6 +45,7 @@ class PlayEmotion(Tool):
 
     name = "play_emotion"
     description = "Play a pre-recorded emotion"
+    needs_response = False
     parameters_schema = {
         "type": "object",
         "properties": {

--- a/src/reachy_mini_conversation_app/tools/stop_dance.py
+++ b/src/reachy_mini_conversation_app/tools/stop_dance.py
@@ -12,6 +12,7 @@ class StopDance(Tool):
 
     name = "stop_dance"
     description = "Stop the current dance move"
+    needs_response = False
     parameters_schema = {
         "type": "object",
         "properties": {

--- a/src/reachy_mini_conversation_app/tools/stop_emotion.py
+++ b/src/reachy_mini_conversation_app/tools/stop_emotion.py
@@ -12,6 +12,7 @@ class StopEmotion(Tool):
 
     name = "stop_emotion"
     description = "Stop the current emotion"
+    needs_response = False
     parameters_schema = {
         "type": "object",
         "properties": {

--- a/src/reachy_mini_conversation_app/tools/tool_constants.py
+++ b/src/reachy_mini_conversation_app/tools/tool_constants.py
@@ -15,15 +15,3 @@ class SystemTool(Enum):
 
     TASK_STATUS = "task_status"
     TASK_CANCEL = "task_cancel"
-
-
-# Pure side effects with nothing to narrate, skip the spoken follow-up.
-SILENT_TOOLS: frozenset[str] = frozenset(
-    {
-        "dance",
-        "stop_dance",
-        "play_emotion",
-        "stop_emotion",
-        "move_head",
-    }
-)

--- a/src/reachy_mini_conversation_app/tools/tool_constants.py
+++ b/src/reachy_mini_conversation_app/tools/tool_constants.py
@@ -15,3 +15,15 @@ class SystemTool(Enum):
 
     TASK_STATUS = "task_status"
     TASK_CANCEL = "task_cancel"
+
+
+# Pure side effects with nothing to narrate, skip the spoken follow-up.
+SILENT_TOOLS: frozenset[str] = frozenset(
+    {
+        "dance",
+        "stop_dance",
+        "play_emotion",
+        "stop_emotion",
+        "move_head",
+    }
+)

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -879,9 +879,9 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=OPENAI_DEFAULT_VOICE: "alloy")
     monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
 
+    # 400 near-simultaneous tool results coalesce into far fewer response.create sends.
     N_TOOL_RESULTS = 400
-    REJECT_CALL_NUMBERS = {1, 3, 5, 10, 25, 50, 75, 100, 150, 200, 300, 399}
-    EXPECTED_TOTAL_CALLS = N_TOOL_RESULTS + len(REJECT_CALL_NUMBERS)
+    REJECT_EVERY = 4  # deterministically reject every 4th send to exercise retry
 
     response_create_log: list[tuple[int, dict[str, Any]]] = []
     handler_ref: list[rt_mod.OpenaiRealtimeHandler] = []
@@ -953,7 +953,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
 
             # Intentional rejections (simulating a race where another
             # response sneaks in right after our check).
-            if n in REJECT_CALL_NUMBERS:
+            if n % REJECT_EVERY == 0:
                 await event_queue.put(
                     FakeEvent(
                         "error",
@@ -987,11 +987,16 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
             pass
 
     class FakeItem:
+        def __init__(self) -> None:
+            self.call_count = 0
+
         async def create(self, **_kw: Any) -> None:
-            pass
+            self.call_count += 1
+
+    fake_item = FakeItem()
 
     class FakeConversation:
-        item = FakeItem()
+        item = fake_item
 
     class FakeConn:
         session = FakeSession()
@@ -1058,11 +1063,11 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
         )
 
     # Wait until spawned tool tasks, the listener, and the sender have drained.
-    # This stress test queues hundreds of serialized response.create calls; a
-    # condition-based wait avoids racing slower CI runners while still failing
-    # promptly if the sender stops making progress.
+    # This stress test queues hundreds of tool results; a condition-based wait
+    # avoids racing slower CI runners while still failing promptly if the
+    # sender stops making progress.
     deadline = asyncio.get_event_loop().time() + 25.0
-    while fake_response_api._call_count < EXPECTED_TOTAL_CALLS and asyncio.get_event_loop().time() < deadline:
+    while fake_item.call_count < N_TOOL_RESULTS and asyncio.get_event_loop().time() < deadline:
         await asyncio.sleep(0.05)
 
     # ---- Tear down ----
@@ -1073,6 +1078,11 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
 
     # ---- Assertions ----
 
+    # Every tool result must still reach the model as function_call_output.
+    assert fake_item.call_count == N_TOOL_RESULTS, (
+        f"Expected {N_TOOL_RESULTS} function_call_output items, got {fake_item.call_count}"
+    )
+
     # Serialization: every response.create() must have been called only when
     # no response was in-flight (_response_done_event was set).  Any violation
     # means the sender fired a new request before the previous one finished.
@@ -1081,24 +1091,18 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
         f"call(s) {fake_response_api._serialization_violations}"
     )
 
-    # Total response.create() calls = tool results + retries for rejected ones
-    assert fake_response_api._call_count == EXPECTED_TOTAL_CALLS, (
-        f"Expected {EXPECTED_TOTAL_CALLS} response.create calls "
-        f"({N_TOOL_RESULTS} results + {len(REJECT_CALL_NUMBERS)} retries), "
+    # Coalescing means far fewer response.create sends than tool results.
+    assert 0 < fake_response_api._call_count < N_TOOL_RESULTS, (
+        f"Expected response.create calls to be coalesced below {N_TOOL_RESULTS}, "
         f"got {fake_response_api._call_count}"
     )
 
-    # The error event handler must have set _last_response_rejected for each
-    # rejection (the log message comes from the event handler code path).
+    # Every rejection from the error handler must have led to a retry.
     rejection_logs = [r for r in caplog.records if "worker will retry" in getattr(r, "msg", "")]
-    assert len(rejection_logs) == len(REJECT_CALL_NUMBERS), (
-        f"Expected {len(REJECT_CALL_NUMBERS)} rejection entries from error handler, got {len(rejection_logs)}"
-    )
-
-    # The sender loop must have retried after each rejection.
     retry_logs = [r for r in caplog.records if "response.create was rejected; retrying" in getattr(r, "msg", "")]
-    assert len(retry_logs) == len(REJECT_CALL_NUMBERS), (
-        f"Expected {len(REJECT_CALL_NUMBERS)} retry entries from sender loop, got {len(retry_logs)}"
+    assert len(rejection_logs) == len(retry_logs) > 0, (
+        f"Expected matching non-zero rejection/retry counts, got "
+        f"{len(rejection_logs)} rejections and {len(retry_logs)} retries"
     )
 
 

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -1093,8 +1093,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
 
     # Coalescing means far fewer response.create sends than tool results.
     assert 0 < fake_response_api._call_count < N_TOOL_RESULTS, (
-        f"Expected response.create calls to be coalesced below {N_TOOL_RESULTS}, "
-        f"got {fake_response_api._call_count}"
+        f"Expected response.create calls to be coalesced below {N_TOOL_RESULTS}, got {fake_response_api._call_count}"
     )
 
     # Every rejection from the error handler must have led to a retry.


### PR DESCRIPTION
## Summary
Fixes #343. Two related causes of duplicate/unwanted spoken assistant turns after tool calls:
- First problem: when a robot turn contains multiple parallel tool calls (for example, two calls to
  `remember`), each completed tool independently queued its own `response.create`, causing the assistant
  to repeat the same reply 2-3 times. `_response_sender_loop` now coalesces queued empty-kwargs follow-up
  requests into one
- Second problem: tools that are pure physical side effects (`dance`, `stop_dance`, `play_emotion`,
  `stop_emotion`, `move_head`) no longer trigger a spoken follow-up at all. For example, `stop_dance` no
  longer causes the model to add an unprompted "Got it!" after stopping. New `needs_response: ClassVar[bool]`
  on `Tool` (default `True`), set to `False` for these tools; `_handle_tool_result` checks it before
  calling `response.create`, while errors always still surface

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
