### PR TITLE
Remove stale type: ignore comments flagged as unused by mypy

### DIFF
--- a/src/reachy_mini_conversation_app/vision/head_tracking/yolo.py
+++ b/src/reachy_mini_conversation_app/vision/head_tracking/yolo.py
@@ -11,7 +11,7 @@ from reachy_mini_conversation_app.vision.head_tracking import HeadTrackerResult
 
 try:
     from supervision import Detections
-    from ultralytics import YOLO  # type: ignore[attr-defined]
+    from ultralytics import YOLO
 except ImportError as e:
     raise ImportError(
         "To use YOLO head tracker, please install the extra dependencies: pip install '.[yolo_vision]'",

--- a/src/reachy_mini_conversation_app/vision/local_vision.py
+++ b/src/reachy_mini_conversation_app/vision/local_vision.py
@@ -109,7 +109,7 @@ class VisionProcessor:
         logger.info("Loading SmolVLM2 model on %s (HF_HOME=%s)", self.device, config.HF_HOME)
         processor = cast(
             _VisionProcessor,
-            AutoProcessor.from_pretrained(self.vision_config.model_path),  # type: ignore[no-untyped-call]
+            AutoProcessor.from_pretrained(self.vision_config.model_path),
         )
 
         model_kwargs: dict[str, object] = {


### PR DESCRIPTION
## Summary
`transformers` and `ultralytics` now ship type information, making the `# type: ignore[no-untyped-call]` and `# type: ignore[attr-defined]` comments unused. Removed both stale ignores

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
