### PR TITLE
Add startup greeting prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ For normal usage, select a profile from the UI and save it for startup. That sel
 
 If no startup settings have been saved yet, you can still seed startup from the environment with `REACHY_MINI_CUSTOM_PROFILE=<name>` to load `profiles/<name>/`. If neither is set, the `default` profile is used.
 
-Each profile should include `instructions.txt` (prompt text). `tools.txt` (list of allowed tools) is recommended. If missing for a non-default profile, the app falls back to `profiles/default/tools.txt`. Profiles can optionally contain custom tool implementations.
+Each profile should include `instructions.txt` (prompt text). `greeting.txt` is optional and controls how the robot should start the conversation after the backend connects. `tools.txt` (list of allowed tools) is recommended. If missing for a non-default profile, the app falls back to `profiles/default/tools.txt`. Profiles can optionally contain custom tool implementations.
 
 **Custom instructions:**
 
@@ -271,6 +271,14 @@ Write plain-text prompts in `instructions.txt`. To reuse shared prompt pieces, a
 [behaviors/silent_robot]
 ```
 Each placeholder pulls the matching file under `src/reachy_mini_conversation_app/prompts/` (nested paths allowed).
+
+**Startup greeting:**
+
+On startup, once the realtime backend is connected and ready, the app sends the active profile's `greeting.txt` as an internal text turn so the model opens with a fresh spoken greeting. Keep this file as a short instruction, not a fixed script, for example:
+```
+Greet me warmly in one sentence, in character, and vary the wording each time.
+```
+If `greeting.txt` is missing, the app uses the built-in default greeting prompt.
 
 **Enabling tools:**
 
@@ -294,7 +302,7 @@ Custom tools must subclass `reachy_mini_conversation_app.tools.core_tools.Tool` 
 
 When running with `--ui`, the Home view lists available profiles (folders under `profiles/`) plus the built-in default:
 - Tap a card to apply that personality and start talking.
-- Tap "Custom" to create a new personality by entering a name and instructions. It copies `tools.txt` from the `default` profile and stores the files under `user_personalities/<name>/` in the app instance directory (next to `.env`/`startup_settings.json`).
+- Tap "Custom" to create a new personality by entering a name, instructions, and an optional startup greeting prompt. It copies `tools.txt` from the `default` profile and stores the files under `user_personalities/<name>/` in the app instance directory (next to `.env`/`startup_settings.json`).
 
 Note: switching a personality reloads its instructions and tools in place via a quick backend reconnect — no app restart. Editing the active profile's files on disk needs a re-select (or restart) to apply.
 
@@ -327,6 +335,7 @@ external_content/
 ├── external_profiles/
 │   └── my_profile/
 │       ├── instructions.txt
+│       ├── greeting.txt     # optional startup greeting prompt
 │       ├── tools.txt        # optional (see fallback behavior below)
 │       └── voice.txt        # optional
 ├── external_tools/

--- a/profiles/default/greeting.txt
+++ b/profiles/default/greeting.txt
@@ -1,1 +1,0 @@
-Start the conversation now with a brief, spontaneous greeting in character. Keep it to one sentence, invite the user in naturally, and vary the wording each time.

--- a/profiles/default/greeting.txt
+++ b/profiles/default/greeting.txt
@@ -1,0 +1,1 @@
+Start the conversation now with a brief, spontaneous greeting in character. Keep it to one sentence, invite the user in naturally, and vary the wording each time.

--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -31,6 +31,7 @@ from reachy_mini_conversation_app.config import (
     get_default_voice_for_backend,
     get_available_voices_for_backend,
 )
+from reachy_mini_conversation_app.prompts import get_session_greeting_prompt
 from reachy_mini_conversation_app.idle_policy import start_idle_tool_call
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.conversation_handler import ConversationHandler
@@ -163,6 +164,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         self._turn_user_done_at: float | None = None
         self._turn_response_created_at: float | None = None
         self._turn_first_audio_at: float | None = None
+        self._startup_greeting_sent = False
 
     @staticmethod
     def _sanitize_tool_result_for_model(tool_name: str, tool_result: dict[str, Any]) -> dict[str, Any]:
@@ -484,6 +486,36 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         """
         await self._pending_responses.put(kwargs)
 
+    async def _send_startup_greeting_prompt(self) -> None:
+        """Prompt the model to open the conversation once the session is ready."""
+        if self._startup_greeting_sent or not self.connection:
+            return
+
+        greeting_prompt = get_session_greeting_prompt(self.instance_path).strip()
+        if not greeting_prompt:
+            self._startup_greeting_sent = True
+            return
+
+        try:
+            await self.connection.conversation.item.create(
+                item={
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": greeting_prompt,
+                        },
+                    ],
+                },
+            )
+            self._startup_greeting_sent = True
+            self._mark_activity("startup_greeting_prompt")
+            await self._safe_response_create()
+            logger.info("Queued startup greeting prompt")
+        except Exception as e:
+            logger.warning("Failed to queue startup greeting prompt: %s", e)
+
     async def _response_sender_loop(self) -> None:
         """Dedicated worker that sends ``response.create()`` calls serially.
 
@@ -728,6 +760,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
 
                 # Start the response sender worker
                 response_sender_task = asyncio.create_task(self._response_sender_loop(), name="response-sender")
+                await self._send_startup_greeting_prompt()
 
                 async for event in self.connection:
                     logger.debug("Realtime event: %s", event.type)

--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -473,7 +473,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         if self._startup_greeting_sent or not self.connection:
             return
 
-        greeting_prompt = get_session_greeting_prompt(self.instance_path).strip()
+        greeting_prompt = get_session_greeting_prompt().strip()
         if not greeting_prompt:
             self._startup_greeting_sent = True
             return

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -31,7 +31,11 @@ from reachy_mini_conversation_app.config import (
     DEFAULT_VOICE_BY_BACKEND,
     config,
 )
-from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
+from reachy_mini_conversation_app.prompts import (
+    get_session_voice,
+    get_session_instructions,
+    get_session_greeting_prompt,
+)
 from reachy_mini_conversation_app.idle_policy import start_idle_tool_call
 from reachy_mini_conversation_app.tools.core_tools import (
     ToolDependencies,
@@ -182,6 +186,7 @@ class GeminiLiveHandler(ConversationHandler):
         self._pending_user_transcript_chunks: list[str] = []
         self._pending_assistant_transcript_chunks: list[str] = []
         self._listening_state = False
+        self._startup_greeting_sent = False
 
     def copy(self) -> "GeminiLiveHandler":
         """Return a fresh handler, preserving deps and voice override."""
@@ -437,6 +442,35 @@ class GeminiLiveHandler(ConversationHandler):
 
             logger.info("Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id)
 
+    async def _send_startup_greeting_prompt(self) -> None:
+        """Prompt Gemini to open the conversation once the live session is ready."""
+        if self._startup_greeting_sent or not self.session:
+            return
+
+        greeting_prompt = get_session_greeting_prompt(self.instance_path).strip()
+        if not greeting_prompt:
+            self._startup_greeting_sent = True
+            return
+
+        send_client_content = getattr(self.session, "send_client_content", None)
+        if not callable(send_client_content):
+            logger.warning("Gemini session does not support send_client_content; startup greeting skipped")
+            return
+
+        try:
+            await send_client_content(
+                turns=types.Content(
+                    role="user",
+                    parts=[types.Part(text=greeting_prompt)],
+                ),
+                turn_complete=True,
+            )
+            self._startup_greeting_sent = True
+            self.last_activity_time = time.monotonic()
+            logger.info("Queued Gemini startup greeting prompt")
+        except Exception as e:
+            logger.warning("Failed to queue Gemini startup greeting prompt: %s", e)
+
     async def _handle_tool_result(self, bg_tool: ToolNotification) -> None:
         """Process the result of a completed tool and send it back to Gemini."""
         if bg_tool.error is not None:
@@ -548,6 +582,8 @@ class GeminiLiveHandler(ConversationHandler):
                 # Start video sender if camera is available
                 if self.deps.camera_worker is not None:
                     video_task = asyncio.create_task(self._video_sender_loop(), name="gemini-video-sender")
+
+                await self._send_startup_greeting_prompt()
 
                 # session.receive() yields responses for the current turn then completes.
                 # We loop so the session stays alive across multiple conversation turns.

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -435,13 +435,14 @@ class GeminiLiveHandler(ConversationHandler):
         if self._startup_greeting_sent or not self.session:
             return
 
-        greeting_prompt = get_session_greeting_prompt(self.instance_path).strip()
+        greeting_prompt = get_session_greeting_prompt().strip()
         if not greeting_prompt:
             self._startup_greeting_sent = True
             return
 
         send_client_content = getattr(self.session, "send_client_content", None)
         if not callable(send_client_content):
+            self._startup_greeting_sent = True
             logger.warning("Gemini session does not support send_client_content; startup greeting skipped")
             return
 

--- a/src/reachy_mini_conversation_app/personality.py
+++ b/src/reachy_mini_conversation_app/personality.py
@@ -9,7 +9,6 @@ from typing import List
 from pathlib import Path
 
 from .config import USER_PERSONALITIES_DIRNAME, config, get_default_voice_for_backend
-from .prompts import DEFAULT_GREETING_PROMPT
 from .tools.tool_constants import SystemTool
 
 
@@ -93,9 +92,9 @@ def read_greeting_for(name: str) -> str:
             greeting = target.read_text(encoding="utf-8").strip()
             if greeting:
                 return greeting
-        return DEFAULT_GREETING_PROMPT
+        return ""
     except Exception:
-        return DEFAULT_GREETING_PROMPT
+        return ""
 
 
 def available_tools_for(selected: str) -> List[str]:
@@ -134,4 +133,9 @@ def _write_profile(
     (target_dir / "tools.txt").write_text((tools_text or "").strip() + "\n", encoding="utf-8")
     (target_dir / "voice.txt").write_text((voice or default_voice).strip() + "\n", encoding="utf-8")
     if greeting is not None:
-        (target_dir / "greeting.txt").write_text(greeting.strip() + "\n", encoding="utf-8")
+        greeting_file = target_dir / "greeting.txt"
+        greeting_text = greeting.strip()
+        if greeting_text:
+            greeting_file.write_text(greeting_text + "\n", encoding="utf-8")
+        elif greeting_file.exists():
+            greeting_file.unlink()

--- a/src/reachy_mini_conversation_app/personality.py
+++ b/src/reachy_mini_conversation_app/personality.py
@@ -9,6 +9,7 @@ from typing import List
 from pathlib import Path
 
 from .config import USER_PERSONALITIES_DIRNAME, config, get_default_voice_for_backend
+from .prompts import DEFAULT_GREETING_PROMPT
 from .tools.tool_constants import SystemTool
 
 
@@ -83,6 +84,20 @@ def read_tools_for(name: str) -> str:
         return ""
 
 
+def read_greeting_for(name: str) -> str:
+    """Read the greeting.txt content for the given profile name."""
+    try:
+        profile_name = "default" if name == DEFAULT_OPTION else name
+        target = resolve_profile_dir(profile_name) / "greeting.txt"
+        if target.exists():
+            greeting = target.read_text(encoding="utf-8").strip()
+            if greeting:
+                return greeting
+        return DEFAULT_GREETING_PROMPT
+    except Exception:
+        return DEFAULT_GREETING_PROMPT
+
+
 def available_tools_for(selected: str) -> List[str]:
     """List available tool modules for the given profile selection."""
     shared: List[str] = []
@@ -105,10 +120,18 @@ def available_tools_for(selected: str) -> List[str]:
     return sorted(set(shared + local))
 
 
-def _write_profile(sanitized_name: str, instructions: str, tools_text: str, voice: str | None = None) -> None:
+def _write_profile(
+    sanitized_name: str,
+    instructions: str,
+    tools_text: str,
+    voice: str | None = None,
+    greeting: str | None = None,
+) -> None:
     default_voice = get_default_voice_for_backend()
     target_dir = config.user_personalities_root() / sanitized_name
     target_dir.mkdir(parents=True, exist_ok=True)
     (target_dir / "instructions.txt").write_text(instructions.strip() + "\n", encoding="utf-8")
     (target_dir / "tools.txt").write_text((tools_text or "").strip() + "\n", encoding="utf-8")
     (target_dir / "voice.txt").write_text((voice or default_voice).strip() + "\n", encoding="utf-8")
+    if greeting is not None:
+        (target_dir / "greeting.txt").write_text(greeting.strip() + "\n", encoding="utf-8")

--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -24,6 +24,7 @@ from .personality import (
     _sanitize_name,
     _write_profile,
     read_tools_for,
+    read_greeting_for,
     list_personalities,
     available_tools_for,
     resolve_profile_dir,
@@ -97,6 +98,7 @@ def mount_personality_routes(
     def _load(name: str) -> dict:  # type: ignore
         instr = read_instructions_for(name)
         tools_txt = read_tools_for(name)
+        greeting = read_greeting_for(name)
         voice = get_default_voice_for_backend()
         uses_default_voice = True
         if name != DEFAULT_OPTION:
@@ -110,6 +112,7 @@ def mount_personality_routes(
         enabled = [ln.strip() for ln in tools_txt.splitlines() if ln.strip() and not ln.strip().startswith("#")]
         return {
             "instructions": instr,
+            "greeting": greeting,
             "tools_text": tools_txt,
             "voice": voice,
             "uses_default_voice": uses_default_voice,
@@ -126,6 +129,7 @@ def mount_personality_routes(
             raw = {}
         name = str(raw.get("name", ""))
         instructions = str(raw.get("instructions", ""))
+        greeting = str(raw["greeting"]) if raw.get("greeting") is not None else None
         tools_text = str(raw.get("tools_text", ""))
         voice = (
             str(raw.get("voice", get_default_voice_for_backend()))
@@ -138,13 +142,20 @@ def mount_personality_routes(
             return JSONResponse({"ok": False, "error": "invalid_name"}, status_code=400)  # type: ignore
         try:
             logger.info(
-                "save: name=%r voice=%r instr_len=%d tools_len=%d",
+                "save: name=%r voice=%r instr_len=%d greeting_len=%d tools_len=%d",
                 sanitized_name,
                 voice,
                 len(instructions),
+                len(greeting or ""),
                 len(tools_text),
             )
-            _write_profile(sanitized_name, instructions, tools_text, voice or get_default_voice_for_backend())
+            _write_profile(
+                sanitized_name,
+                instructions,
+                tools_text,
+                voice or get_default_voice_for_backend(),
+                greeting,
+            )
             value = f"user_personalities/{sanitized_name}"
             choices = [DEFAULT_OPTION, *list_personalities()]
             return {"ok": True, "value": value, "choices": choices}

--- a/src/reachy_mini_conversation_app/prompts.py
+++ b/src/reachy_mini_conversation_app/prompts.py
@@ -122,10 +122,12 @@ def get_session_voice(default: str | None = None) -> str:
     return fallback
 
 
-def get_session_greeting_prompt(instance_path: str | Path | None = None) -> str:
+def get_session_greeting_prompt() -> str:
     """Resolve the startup greeting prompt for the selected profile."""
-    _ = instance_path
-    profile = config.REACHY_MINI_CUSTOM_PROFILE or "default"
+    profile = config.REACHY_MINI_CUSTOM_PROFILE
+    if not profile:
+        return DEFAULT_GREETING_PROMPT
+
     try:
         greeting_file = config.resolve_profile_dir(profile) / GREETING_FILENAME
         if greeting_file.exists():

--- a/src/reachy_mini_conversation_app/prompts.py
+++ b/src/reachy_mini_conversation_app/prompts.py
@@ -13,6 +13,12 @@ logger = logging.getLogger(__name__)
 PROMPTS_LIBRARY_DIRECTORY = Path(__file__).parent / "prompts"
 INSTRUCTIONS_FILENAME = "instructions.txt"
 VOICE_FILENAME = "voice.txt"
+GREETING_FILENAME = "greeting.txt"
+
+DEFAULT_GREETING_PROMPT = (
+    "Start the conversation now with a brief, spontaneous greeting in character. "
+    "Keep it to one sentence, invite the user in naturally, and vary the wording each time."
+)
 
 
 def _expand_prompt_includes(content: str) -> str:
@@ -114,3 +120,18 @@ def get_session_voice(default: str | None = None) -> str:
     except Exception:
         pass
     return fallback
+
+
+def get_session_greeting_prompt(instance_path: str | Path | None = None) -> str:
+    """Resolve the startup greeting prompt for the selected profile."""
+    _ = instance_path
+    profile = config.REACHY_MINI_CUSTOM_PROFILE or "default"
+    try:
+        greeting_file = config.resolve_profile_dir(profile) / GREETING_FILENAME
+        if greeting_file.exists():
+            greeting = greeting_file.read_text(encoding="utf-8").strip()
+            if greeting:
+                return _expand_prompt_includes(greeting)
+    except Exception as e:
+        logger.warning("Failed to load greeting prompt from profile %r: %s", profile, e)
+    return DEFAULT_GREETING_PROMPT

--- a/src/reachy_mini_conversation_app/static/js/components/profile-modal.js
+++ b/src/reachy_mini_conversation_app/static/js/components/profile-modal.js
@@ -1,4 +1,4 @@
-/** Modal to collect name + instructions for a new custom personality. Returns { name, instructions } or null. */
+/** Modal to collect fields for a new custom personality. Returns { name, instructions, greeting } or null. */
 
 import { h } from "../ui.js";
 
@@ -6,7 +6,7 @@ const NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 /**
  * @param {{ signal?: AbortSignal }} [options]
- * @returns {Promise<{ name: string, instructions: string }|null>}
+ * @returns {Promise<{ name: string, instructions: string, greeting: string }|null>}
  */
 export function openCustomProfileModal({ signal } = {}) {
   return new Promise((resolve) => {
@@ -78,6 +78,7 @@ export function openCustomProfileModal({ signal } = {}) {
       const formData = new FormData(event.target);
       const name = String(formData.get("name") || "").trim();
       const instructions = String(formData.get("instructions") || "").trim();
+      const greeting = String(formData.get("greeting") || "").trim();
 
       if (!name) return showError(errorBox, "Please pick a name.");
       if (!NAME_PATTERN.test(name)) {
@@ -85,7 +86,7 @@ export function openCustomProfileModal({ signal } = {}) {
       }
       if (!instructions) return showError(errorBox, "Please write some instructions.");
 
-      close({ name, instructions });
+      close({ name, instructions, greeting });
     });
   });
 }
@@ -146,6 +147,21 @@ function buildDialog() {
             "You are a calm, slow-speaking zen guide. Pause between sentences. Encourage the user to breathe.",
           class: "modal__textarea",
         })
+      ),
+      h(
+        "label",
+        { class: "modal__field" },
+        h("span", { class: "modal__label" }, "Startup greeting prompt"),
+        h(
+          "textarea",
+          {
+            name: "greeting",
+            rows: "3",
+            placeholder: "Start the conversation with a short greeting in character.",
+            class: "modal__textarea",
+          },
+          "Start the conversation with one short greeting in character. Vary the wording each time."
+        )
       ),
       h("p", { class: "modal__error", role: "alert", "aria-live": "polite" }),
       h(

--- a/src/reachy_mini_conversation_app/static/js/components/profile-modal.js
+++ b/src/reachy_mini_conversation_app/static/js/components/profile-modal.js
@@ -193,7 +193,7 @@ function buildDialog({ isEdit, initial, toolChoices, isToolChecked }) {
             placeholder: "Start the conversation with a short greeting in character.",
             class: "modal__textarea",
           },
-          initial.greeting || "Start the conversation with one short greeting in character. Vary the wording each time."
+          initial.greeting || ""
         )
       ),
       buildToolsField(toolChoices, isToolChecked),

--- a/src/reachy_mini_conversation_app/static/js/views/home.js
+++ b/src/reachy_mini_conversation_app/static/js/views/home.js
@@ -122,7 +122,7 @@ export async function mountHomeView({ outlet, signal, navigate }) {
       const saveResult = await savePersonality({
         name: created.name,
         instructions: created.instructions,
-        greeting: created.greeting || defaults?.greeting || "",
+        greeting: created.greeting || null,
         tools_text: created.tools.join("\n"),
         voice: "", // falls back to backend default; user can change in Settings
       });

--- a/src/reachy_mini_conversation_app/static/js/views/home.js
+++ b/src/reachy_mini_conversation_app/static/js/views/home.js
@@ -99,6 +99,7 @@ export async function mountHomeView({ outlet, signal, navigate }) {
       const saveResult = await savePersonality({
         name: created.name,
         instructions: created.instructions,
+        greeting: created.greeting || defaults?.greeting || "",
         tools_text: defaults?.tools_text || "",
         voice: "", // falls back to backend default; user can change in Settings
       });

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -3,6 +3,7 @@
 import time
 import base64
 import asyncio
+import logging
 from types import SimpleNamespace
 from typing import Any, Callable, AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, call
@@ -193,9 +194,7 @@ async def test_gemini_live_session_queues_startup_greeting(monkeypatch: pytest.M
     monkeypatch.setattr(gemini_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(gemini_mod, "get_session_voice", lambda: "Kore")
     monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
-    monkeypatch.setattr(
-        gemini_mod, "get_session_greeting_prompt", lambda _instance_path=None: "Greet me like a tiny stage host."
-    )
+    monkeypatch.setattr(gemini_mod, "get_session_greeting_prompt", lambda: "Greet me like a tiny stage host.")
 
     deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
     handler = GeminiLiveHandler(deps)
@@ -215,6 +214,26 @@ async def test_gemini_live_session_queues_startup_greeting(monkeypatch: pytest.M
     assert sent["turns"].role == "user"
     assert sent["turns"].parts[0].text == "Greet me like a tiny stage host."
     assert handler._startup_greeting_sent is True
+
+
+@pytest.mark.asyncio
+async def test_gemini_startup_greeting_missing_client_content_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: Any,
+) -> None:
+    """Gemini sessions without text-turn support should not warn on every retry."""
+    monkeypatch.setattr(gemini_mod, "get_session_greeting_prompt", lambda: "Greet the user.")
+
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = GeminiLiveHandler(deps)
+    handler.session = SimpleNamespace()
+
+    with caplog.at_level(logging.WARNING):
+        await handler._send_startup_greeting_prompt()
+        await handler._send_startup_greeting_prompt()
+
+    assert handler._startup_greeting_sent is True
+    assert caplog.text.count("Gemini session does not support send_client_content") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -56,6 +56,7 @@ class _FakeSession:
         self._stop_event = stop_event
         self.realtime_inputs: list[dict[str, Any]] = []
         self.tool_responses: list[dict[str, Any]] = []
+        self.client_contents: list[dict[str, Any]] = []
 
     async def close(self) -> None:
         self._stop_event.set()
@@ -66,6 +67,10 @@ class _FakeSession:
 
     async def send_tool_response(self, **kwargs: Any) -> None:
         self.tool_responses.append(kwargs)
+        return None
+
+    async def send_client_content(self, **kwargs: Any) -> None:
+        self.client_contents.append(kwargs)
         return None
 
     async def receive(self) -> AsyncIterator[SimpleNamespace]:
@@ -179,6 +184,36 @@ async def test_gemini_turn_buffers_transcripts_and_schedules_motion_reset(
     assert any(isinstance(output, tuple) for output in outputs), "audio output was not emitted"
     movement_manager.set_listening.assert_has_calls([call(True), call(False)])
     assert movement_manager.set_listening.call_args_list[-1] == call(False)
+
+
+@pytest.mark.asyncio
+async def test_gemini_live_session_queues_startup_greeting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gemini sessions should send the profile greeting as the first text turn."""
+    monkeypatch.setattr(gemini_mod, "get_session_instructions", lambda _instance_path=None: "test")
+    monkeypatch.setattr(gemini_mod, "get_session_voice", lambda: "Kore")
+    monkeypatch.setattr(gemini_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(
+        gemini_mod, "get_session_greeting_prompt", lambda _instance_path=None: "Greet me like a tiny stage host."
+    )
+
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = GeminiLiveHandler(deps)
+    monkeypatch.setattr(type(handler.tool_manager), "start_up", MagicMock())
+    monkeypatch.setattr(type(handler.tool_manager), "shutdown", AsyncMock())
+    session = _FakeSession([], handler._stop_event)
+    handler.client = _FakeLiveClient(session)
+
+    task = asyncio.create_task(handler._run_live_session())
+    await _wait_for(lambda: len(session.client_contents) == 1)
+
+    handler._stop_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    sent = session.client_contents[0]
+    assert sent["turn_complete"] is True
+    assert sent["turns"].role == "user"
+    assert sent["turns"].parts[0].text == "Greet me like a tiny stage host."
+    assert handler._startup_greeting_sent is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -217,9 +217,7 @@ async def test_run_realtime_session_queues_startup_greeting(monkeypatch: Any) ->
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=OPENAI_DEFAULT_VOICE: "alloy")
     monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
-    monkeypatch.setattr(
-        base_rt_mod, "get_session_greeting_prompt", lambda _instance_path=None: "Greet the user as a comet captain."
-    )
+    monkeypatch.setattr(base_rt_mod, "get_session_greeting_prompt", lambda: "Greet the user as a comet captain.")
 
     created_items: list[dict[str, Any]] = []
 

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -199,6 +199,7 @@ async def test_non_idle_tool_call_does_not_queue_progress_response(monkeypatch: 
 
     deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
     handler = OpenaiRealtimeHandler(deps)
+    handler._startup_greeting_sent = True
     fake_client = FakeClient()
     handler.client = fake_client
     safe_response_create = AsyncMock()
@@ -237,6 +238,92 @@ async def test_completed_user_transcript_resets_idle_state(monkeypatch: Any) -> 
 
     assert handler.is_idle_tool_call is False
     assert handler.last_activity_time > 1.0
+
+
+@pytest.mark.asyncio
+async def test_run_realtime_session_queues_startup_greeting(monkeypatch: Any) -> None:
+    """OpenAI-compatible sessions should inject a profile-driven first turn after connect."""
+    monkeypatch.setattr(rt_mod, "get_session_instructions", lambda _instance_path=None: "test")
+    monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=OPENAI_DEFAULT_VOICE: "alloy")
+    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(
+        base_rt_mod, "get_session_greeting_prompt", lambda _instance_path=None: "Greet the user as a comet captain."
+    )
+
+    created_items: list[dict[str, Any]] = []
+
+    class FakeSession:
+        async def update(self, **_kw: Any) -> None:
+            pass
+
+    class FakeInputAudioBuffer:
+        async def append(self, **_kw: Any) -> None:
+            pass
+
+    class FakeItem:
+        async def create(self, **kwargs: Any) -> None:
+            created_items.append(kwargs["item"])
+
+    class FakeConversation:
+        item = FakeItem()
+
+    class FakeResponse:
+        async def create(self, **_kw: Any) -> None:
+            pass
+
+        async def cancel(self, **_kw: Any) -> None:
+            pass
+
+    class FakeConn:
+        session = FakeSession()
+        input_audio_buffer = FakeInputAudioBuffer()
+        conversation = FakeConversation()
+        response = FakeResponse()
+
+        async def __aenter__(self) -> "FakeConn":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> bool:
+            return False
+
+        async def close(self) -> None:
+            pass
+
+        def __aiter__(self) -> "FakeConn":
+            return self
+
+        async def __anext__(self) -> Any:
+            raise StopAsyncIteration
+
+    class FakeRealtime:
+        def connect(self, **_kw: Any) -> FakeConn:
+            return FakeConn()
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.realtime = FakeRealtime()
+
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = OpenaiRealtimeHandler(deps)
+    handler.client = FakeClient()
+    monkeypatch.setattr(type(handler.tool_manager), "start_up", MagicMock())
+    monkeypatch.setattr(type(handler.tool_manager), "shutdown", AsyncMock())
+
+    await handler._run_realtime_session()
+
+    assert handler._startup_greeting_sent is True
+    assert created_items == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": "Greet the user as a comet captain.",
+                }
+            ],
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -703,6 +790,7 @@ async def test_run_realtime_session_propagates_session_update_failure(monkeypatc
             self.realtime = FakeRealtime()
 
     handler = rt_mod.OpenaiRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+    handler._startup_greeting_sent = True
     handler.client = FakeClient()
 
     with pytest.raises(RuntimeError, match="invalid session config"):
@@ -887,6 +975,7 @@ async def test_response_sender_retries_when_active_response_error_uses_type_only
             self.realtime = FakeRealtime()
 
     handler = rt_mod.OpenaiRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+    handler._startup_greeting_sent = True
     handler.client = FakeClient()
 
     session_task = asyncio.create_task(handler._run_realtime_session())
@@ -1110,6 +1199,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
 
     deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
     handler = rt_mod.OpenaiRealtimeHandler(deps)
+    handler._startup_greeting_sent = True
     handler_ref.append(handler)
 
     asyncio.create_task(handler.start_up())

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -118,6 +118,35 @@ def test_session_greeting_prompt_loads_from_selected_profile(
     assert prompts_mod.get_session_greeting_prompt() == "Greet me like a tiny stage host."
 
 
+def test_session_greeting_prompt_uses_builtin_default_without_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The no-profile greeting should come from the built-in constant only."""
+    default_dir = tmp_path / "default"
+    default_dir.mkdir()
+    (default_dir / "greeting.txt").write_text("Do not use this default file.\n", encoding="utf-8")
+
+    monkeypatch.setattr(config, "PROFILES_DIRECTORY", tmp_path)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
+    assert prompts_mod.get_session_greeting_prompt() == prompts_mod.DEFAULT_GREETING_PROMPT
+
+
+def test_read_greeting_for_missing_file_returns_empty_for_ui(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The profile editor should show only explicitly saved greeting text."""
+    profile_dir = tmp_path / "friendly"
+    profile_dir.mkdir()
+    (profile_dir / "instructions.txt").write_text("test instructions\n", encoding="utf-8")
+
+    monkeypatch.setattr(config, "PROFILES_DIRECTORY", tmp_path)
+
+    assert read_greeting_for("friendly") == ""
+
+
 def test_headless_profile_write_can_store_greeting(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -135,6 +164,19 @@ def test_headless_profile_write_can_store_greeting(
     greeting_file = tmp_path / "user_personalities" / "with_greeting" / "greeting.txt"
     assert greeting_file.read_text(encoding="utf-8") == "Open with a quick astronomy joke.\n"
     assert read_greeting_for("user_personalities/with_greeting") == "Open with a quick astronomy joke."
+
+
+def test_headless_profile_write_skips_empty_greeting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty custom greetings should fall back without creating greeting.txt."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+
+    headless_mod._write_profile("without_greeting", "test instructions", "", greeting="")
+
+    greeting_file = tmp_path / "user_personalities" / "without_greeting" / "greeting.txt"
+    assert not greeting_file.exists()
 
 
 def test_headless_profile_write_defaults_voice_at_call_time(

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -12,6 +12,7 @@ from reachy_mini_conversation_app.config import DEFAULT_PROFILES_DIRECTORY, conf
 from reachy_mini_conversation_app.personality import (
     DEFAULT_OPTION,
     read_tools_for,
+    read_greeting_for,
     list_personalities,
     resolve_profile_dir,
     read_instructions_for,
@@ -99,6 +100,41 @@ def test_session_voice_defaults_follow_selected_backend(monkeypatch: pytest.Monk
     monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
 
     assert prompts_mod.get_session_voice() == "Kore"
+
+
+def test_session_greeting_prompt_loads_from_selected_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Profile greeting.txt should steer the startup greeting prompt."""
+    profile_dir = tmp_path / "friendly"
+    profile_dir.mkdir()
+    (profile_dir / "instructions.txt").write_text("test instructions\n", encoding="utf-8")
+    (profile_dir / "greeting.txt").write_text("Greet me like a tiny stage host.\n", encoding="utf-8")
+
+    monkeypatch.setattr(config, "PROFILES_DIRECTORY", tmp_path)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "friendly")
+
+    assert prompts_mod.get_session_greeting_prompt() == "Greet me like a tiny stage host."
+
+
+def test_headless_profile_write_can_store_greeting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """New headless profiles can persist a greeting prompt next to instructions/tools/voice."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+
+    headless_mod._write_profile(
+        "with_greeting",
+        "test instructions",
+        "",
+        greeting="Open with a quick astronomy joke.",
+    )
+
+    greeting_file = tmp_path / "user_personalities" / "with_greeting" / "greeting.txt"
+    assert greeting_file.read_text(encoding="utf-8") == "Open with a quick astronomy joke.\n"
+    assert read_greeting_for("user_personalities/with_greeting") == "Open with a quick astronomy joke."
 
 
 def test_headless_profile_write_defaults_voice_at_call_time(


### PR DESCRIPTION
## Summary

Adds a profile-driven startup greeting so Reachy opens the conversation once the realtime backend is connected and ready.

## Changes

- Adds optional `greeting.txt` profile support with a default prompt.
- Queues a first internal text turn for OpenAI-compatible realtime sessions and Gemini Live.
- Adds greeting load/save support to Gradio and headless personality UIs.
- Documents the new profile file and covers the behavior in tests.

## Validation

- `.venv/bin/pytest tests/test_openai_realtime.py tests/test_huggingface_realtime.py tests/test_gemini_live.py tests/test_profile_paths.py`
- `.venv/bin/ruff check src/reachy_mini_conversation_app/prompts.py src/reachy_mini_conversation_app/base_realtime.py src/reachy_mini_conversation_app/gemini_live.py src/reachy_mini_conversation_app/headless_personality.py src/reachy_mini_conversation_app/headless_personality_ui.py src/reachy_mini_conversation_app/gradio_personality.py tests/test_profile_paths.py tests/test_openai_realtime.py tests/test_gemini_live.py`