### PR TITLE
Fix realtime tool result ordering

### DIFF
--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -180,6 +180,20 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         """Return a valid persisted startup voice for this backend, or None."""
         return self._resolve_backend_voice(voice, source="persisted startup voice")
 
+    async def _wait_for_response_done_before_tool_result(self) -> bool:
+        """Return whether the function-call response finished before sending tool output."""
+        if self._response_done_event.is_set():
+            return True
+
+        try:
+            await asyncio.wait_for(
+                self._response_done_event.wait(),
+                timeout=self._response_done_timeout(),
+            )
+            return True
+        except asyncio.TimeoutError:
+            return False
+
     def _resolve_backend_voice(
         self,
         voice: str | None,
@@ -592,14 +606,32 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         try:
             self._mark_activity("tool_result_ready")
             send_result_to_model = not bg_tool.is_idle_tool_call
+            model_result_submitted = False
             if send_result_to_model and isinstance(bg_tool.id, str):
-                await self.connection.conversation.item.create(
-                    item={
-                        "type": "function_call_output",
-                        "call_id": bg_tool.id,
-                        "output": json.dumps(tool_result_for_model),
-                    },
-                )
+                if not await self._wait_for_response_done_before_tool_result():
+                    send_result_to_model = False
+                if not send_result_to_model:
+                    logger.warning(
+                        "Dropping realtime model result for tool '%s' (id=%s) because response.done was not observed",
+                        bg_tool.tool_name,
+                        bg_tool.id,
+                    )
+                elif not self.connection:
+                    logger.warning(
+                        "Connection closed before sending tool '%s' (id=%s) result back",
+                        bg_tool.tool_name,
+                        bg_tool.id,
+                    )
+                    return
+                else:
+                    await self.connection.conversation.item.create(
+                        item={
+                            "type": "function_call_output",
+                            "call_id": bg_tool.id,
+                            "output": json.dumps(tool_result_for_model),
+                        },
+                    )
+                    model_result_submitted = True
 
             await self.output_queue.put(
                 AdditionalOutputs(
@@ -615,7 +647,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                 ),
             )
 
-            if send_result_to_model and bg_tool.tool_name == "camera" and "b64_im" in tool_result:
+            if model_result_submitted and bg_tool.tool_name == "camera" and "b64_im" in tool_result:
                 # use raw base64, don't json.dumps (which adds quotes)
                 b64_im = tool_result["b64_im"]
                 if not isinstance(b64_im, str):
@@ -670,7 +702,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
 
             tool = core_tools.ALL_TOOLS.get(bg_tool.tool_name)
             # Always surface errors, skip the spoken follow-up for tools that opt out.
-            if send_result_to_model and (bg_tool.error is not None or tool is None or tool.needs_response):
+            if model_result_submitted and (bg_tool.error is not None or tool is None or tool.needs_response):
                 await self._safe_response_create()
 
         except self._connection_closed_errors():
@@ -904,7 +936,10 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                             self.deps.movement_manager.set_listening(False)
 
                         # Only show user-facing errors, not internal state errors.
-                        if code not in ("input_audio_buffer_commit_empty", "conversation_already_has_active_response"):
+                        if code not in (
+                            "input_audio_buffer_commit_empty",
+                            "conversation_already_has_active_response",
+                        ):
                             await self.output_queue.put(
                                 AdditionalOutputs({"role": "assistant", "content": f"[error] {msg}"})
                             )

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -336,6 +336,69 @@ async def test_tool_result_followup_uses_bare_response_create(monkeypatch: Any) 
 
 
 @pytest.mark.asyncio
+async def test_tool_result_waits_for_response_done_before_model_output(monkeypatch: Any) -> None:
+    """Tool output should wait until the function-call item is committed by response.done."""
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = OpenaiRealtimeHandler(deps)
+
+    fake_item = SimpleNamespace(create=AsyncMock())
+    handler.connection = SimpleNamespace(conversation=SimpleNamespace(item=fake_item))
+    handler._response_done_event.clear()
+    safe_response_create = AsyncMock()
+    monkeypatch.setattr(handler, "_safe_response_create", safe_response_create)
+
+    task = asyncio.create_task(
+        handler._handle_tool_result(
+            ToolNotification(
+                id="call_weather",
+                tool_name="weather",
+                is_idle_tool_call=False,
+                status=ToolState.COMPLETED,
+                result={"forecast": "sunny"},
+            )
+        )
+    )
+    await asyncio.sleep(0)
+
+    fake_item.create.assert_not_awaited()
+
+    handler._response_done_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    fake_item.create.assert_awaited_once()
+    safe_response_create.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_tool_result_timeout_does_not_force_response_done(monkeypatch: Any) -> None:
+    """A tool-result wait timeout should not lie about response lifecycle state."""
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    handler = OpenaiRealtimeHandler(deps)
+
+    fake_item = SimpleNamespace(create=AsyncMock())
+    handler.connection = SimpleNamespace(conversation=SimpleNamespace(item=fake_item))
+    handler._response_done_event.clear()
+    safe_response_create = AsyncMock()
+    monkeypatch.setattr(handler, "_safe_response_create", safe_response_create)
+    monkeypatch.setattr(handler, "_response_done_timeout", lambda: 0.01)
+
+    await handler._handle_tool_result(
+        ToolNotification(
+            id="call_weather",
+            tool_name="weather",
+            is_idle_tool_call=False,
+            status=ToolState.COMPLETED,
+            result={"forecast": "sunny"},
+        )
+    )
+
+    assert not handler._response_done_event.is_set()
+    fake_item.create.assert_not_awaited()
+    safe_response_create.assert_not_awaited()
+    assert not handler.output_queue.empty()
+
+
+@pytest.mark.asyncio
 async def test_user_speech_events_reset_idle_timer(monkeypatch: Any) -> None:
     """User speech/transcription events should postpone idle behavior."""
     movement_manager = MagicMock()
@@ -881,7 +944,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
 
     # 400 near-simultaneous tool results coalesce into far fewer response.create sends.
     N_TOOL_RESULTS = 400
-    REJECT_EVERY = 4  # deterministically reject every 4th send to exercise retry
+    INTENTIONAL_REJECTIONS = 1  # deterministically exercise the retry path even when sends coalesce heavily
 
     response_create_log: list[tuple[int, dict[str, Any]]] = []
     handler_ref: list[rt_mod.OpenaiRealtimeHandler] = []
@@ -923,6 +986,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
         def __init__(self) -> None:
             self._call_count = 0
             self._serialization_violations: list[int] = []
+            self._intentional_rejections_remaining = INTENTIONAL_REJECTIONS
 
         async def create(self, **kwargs: Any) -> None:
             self._call_count += 1
@@ -951,9 +1015,12 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
                 await event_queue.put(FakeEvent("response.done", response=MagicMock()))
                 return
 
-            # Intentional rejections (simulating a race where another
-            # response sneaks in right after our check).
-            if n % REJECT_EVERY == 0:
+            # Intentional rejection (simulating a race where another response
+            # sneaks in right after our check). Rejecting the first eligible
+            # send keeps the retry assertion deterministic on event loops that
+            # coalesce the tool-result burst into only a few response.create calls.
+            if self._intentional_rejections_remaining > 0:
+                self._intentional_rejections_remaining -= 1
                 await event_queue.put(
                     FakeEvent(
                         "error",


### PR DESCRIPTION
## Summary

- Wait for `response.done` before submitting realtime `function_call_output`.
- Drop model-facing tool results when response completion times out, while still surfacing the tool result locally.
- Stabilize the active-response retry test so the rejection path is deterministic.

## Validation

- `.venv/bin/pytest tests/test_openai_realtime.py -q` (`28 passed`)
- `.venv/bin/ruff check src/reachy_mini_conversation_app/base_realtime.py tests/test_openai_realtime.py`
- `.venv/bin/mypy`