### PR TITLE
Update realtime voices in place

### DIFF
--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -274,16 +274,27 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         )
 
     async def change_voice(self, voice: str) -> str:
-        """Change only the voice and restart the session."""
+        """Change only the voice, updating the active session when possible."""
         default_voice = get_default_voice_for_backend(self.BACKEND_PROVIDER)
-        resolved_voice = self._resolve_backend_voice(voice, source="requested voice", fallback=default_voice)
+        resolved_voice = (
+            self._resolve_backend_voice(voice, source="requested voice", fallback=default_voice) or default_voice
+        )
         self._voice_override = resolved_voice
-        if getattr(self, "client", None) is not None:
+        if self.connection is not None:
             try:
-                await self._restart_session()
+                await self.connection.session.update(
+                    session=RealtimeSessionCreateRequestParam(
+                        type="realtime",
+                        audio=RealtimeAudioConfigParam(
+                            output=RealtimeAudioConfigOutputParam(
+                                voice=resolved_voice,
+                            ),
+                        ),
+                    ),
+                )
                 return f"Voice changed to {resolved_voice}."
             except Exception as e:
-                logger.warning("Failed to restart session for voice change: %s", e)
+                logger.warning("Failed to update live session for voice change: %s", e)
                 return "Voice change failed. Will take effect on next connection."
         return "Voice changed. Will take effect on next connection."
 

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -445,20 +445,22 @@ class LocalStream:
             return get_default_voice_for_backend(get_backend_choice())
 
     async def change_voice(self, voice: str) -> str:
-        """Change the voice by rebuilding the active backend from LocalStream."""
-        available_voices = get_available_voices_for_backend(get_backend_choice())
-        default_voice = get_default_voice_for_backend(get_backend_choice())
-        resolved_voice = voice if voice in available_voices else default_voice
-        if resolved_voice != voice:
-            logger.warning(
-                "Ignoring unsupported voice %r for backend=%r; using %r",
-                voice,
-                get_backend_choice(),
-                resolved_voice,
-            )
-        self._voice_override = resolved_voice
-        await self.request_backend_restart("voice_changed")
-        return f"Voice changed to {resolved_voice}."
+        """Change the voice through the active handler without rebuilding the backend."""
+        try:
+            status = await self.handler.change_voice(voice)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("Error changing voice to %r: %s", voice, e)
+            return f"Failed to change voice: {e}"
+
+        try:
+            current_voice = self.handler.get_current_voice()
+            if isinstance(current_voice, str) and current_voice.strip():
+                self._voice_override = current_voice
+        except Exception as e:
+            logger.debug("Could not sync LocalStream voice override after voice change: %s", e)
+        return status
 
     def _init_settings_ui_if_needed(self) -> None:
         """Attach minimal settings UI to the settings app.

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -749,6 +749,22 @@ async def test_apply_personality_propagates_restart_cancellation(monkeypatch: py
         await stream.apply_personality("sorry_bro")
 
 
+@pytest.mark.asyncio
+async def test_local_stream_change_voice_delegates_without_backend_restart() -> None:
+    """LocalStream voice changes should update the active handler without rebuilding it."""
+    handler = MagicMock()
+    handler.change_voice = AsyncMock(return_value="Voice changed to Serena.")
+    handler.get_current_voice = MagicMock(return_value="Serena")
+    stream = LocalStream(handler, MagicMock())
+
+    status = await stream.change_voice("Serena")
+
+    assert status == "Voice changed to Serena."
+    handler.change_voice.assert_awaited_once_with("Serena")
+    assert stream._voice_override == "Serena"
+    assert not stream._restart_requested.is_set()
+
+
 def test_local_stream_persist_personality_stores_voice_override(tmp_path) -> None:
     """Persisting startup settings should write both profile and voice override."""
     stream = LocalStream(MagicMock(), MagicMock(), instance_path=str(tmp_path))

--- a/tests/test_huggingface_realtime.py
+++ b/tests/test_huggingface_realtime.py
@@ -553,6 +553,34 @@ async def test_apply_personality_uses_selected_voice_for_lb_allocated_sessions(m
     assert session["audio"]["output"]["voice"] == "Serena"
 
 
+@pytest.mark.asyncio
+async def test_change_voice_updates_live_hf_session_without_restart(monkeypatch: Any) -> None:
+    """Changing Hugging Face voice should update the active session in place."""
+    monkeypatch.setattr(config, "BACKEND_PROVIDER", "huggingface")
+
+    captured_update: dict[str, Any] = {}
+
+    class FakeSession:
+        async def update(self, **kwargs: Any) -> None:
+            captured_update.update(kwargs)
+
+    class FakeConnection:
+        session = FakeSession()
+
+    handler = HuggingFaceRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+    handler.connection = FakeConnection()
+    restart = AsyncMock(return_value=None)
+    monkeypatch.setattr(handler, "_restart_session", restart)
+
+    result = await handler.change_voice("Serena")
+
+    assert result == "Voice changed to Serena."
+    assert handler.get_current_voice() == "Serena"
+    restart.assert_not_awaited()
+    session = captured_update["session"]
+    assert session["audio"]["output"]["voice"] == "Serena"
+
+
 def test_huggingface_response_cost_defaults_to_zero() -> None:
     """Hugging Face should not inherit OpenAI pricing from the shared base handler."""
     usage = _make_usage(audio_in=1000, text_in=2000, image_in=500, audio_out=800, text_out=300)


### PR DESCRIPTION
## Summary

- Change OpenAI-compatible realtime voices with `session.update` instead of restarting the active backend.
- Delegate settings UI voice changes to the active handler so the selected backend stays connected.
- Keep the selected voice override synchronized after a successful handler update.

## Validation

- `.venv/bin/pytest tests/test_console.py tests/test_huggingface_realtime.py -q` (`39 passed`)
- `.venv/bin/ruff check src/reachy_mini_conversation_app/base_realtime.py src/reachy_mini_conversation_app/console.py tests/test_console.py tests/test_huggingface_realtime.py`
- `.venv/bin/mypy`