### PR TITLE
Add response.output_text.delta and response.output_text.done event handling

### DIFF
--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -745,6 +745,12 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                     if event.type == "response.output_audio.done":
                         logger.debug("response completed")
 
+                    if event.type == "response.output_text.delta":
+                        logger.debug("response text delta")
+
+                    if event.type == "response.output_text.done":
+                        logger.debug("response text done: %s", event.text)
+
                     if event.type == "response.created":
                         self._mark_activity("response_created")
                         self._response_done_event.clear()


### PR DESCRIPTION
## Summary
Adds handling for `response.output_text.delta` and `response.output_text.done` realtime events in `BaseRealtimeHandler`. Both are logged at debug level (the `done` event logs the full text), giving visibility into the model's text output stream alongside the existing audio events.

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)
