### PR TITLE
Hide always-injected and support tool modules from personality UI

### DIFF
--- a/src/reachy_mini_conversation_app/gradio_personality.py
+++ b/src/reachy_mini_conversation_app/gradio_personality.py
@@ -17,6 +17,7 @@ from reachy_mini_conversation_app.config import (
     get_default_voice_for_backend,
     get_available_voices_for_backend,
 )
+from reachy_mini_conversation_app.tools.tool_constants import SystemTool
 
 
 class PersonalityUI:
@@ -93,7 +94,9 @@ class PersonalityUI:
         shared: list[str] = []
         try:
             for py in self._tools_dir.glob("*.py"):
-                if py.stem in {"__init__", "core_tools"}:
+                if py.stem in {"__init__", "core_tools", "background_tool_manager", "tool_constants"} or py.stem in {
+                    t.value for t in SystemTool
+                }:
                     continue
                 shared.append(py.stem)
         except Exception:

--- a/src/reachy_mini_conversation_app/headless_personality.py
+++ b/src/reachy_mini_conversation_app/headless_personality.py
@@ -12,6 +12,7 @@ from typing import List
 from pathlib import Path
 
 from .config import DEFAULT_PROFILES_DIRECTORY, get_default_voice_for_backend
+from .tools.tool_constants import SystemTool
 
 
 DEFAULT_OPTION = "(built-in default)"
@@ -87,7 +88,9 @@ def available_tools_for(selected: str) -> List[str]:
     shared: List[str] = []
     try:
         for py in _tools_dir().glob("*.py"):
-            if py.stem in {"__init__", "core_tools"}:
+            if py.stem in {"__init__", "core_tools", "background_tool_manager", "tool_constants"} or py.stem in {
+                t.value for t in SystemTool
+            }:
                 continue
             shared.append(py.stem)
     except Exception:


### PR DESCRIPTION
Some tools are exposed in personality UI but shouldn't:

- System tools are always present (so shouldn't be exposed with a checkbox)
- same for support tool modules "background_tool_manager", "tool_constants"

This PR simply removes them from the list exposed tools in Gradio and headless personality UI