### PR TITLE
Marshal LocalStream.close() shutdown onto the loop thread

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -940,13 +940,15 @@ class LocalStream:
         except Exception as e:
             logger.debug(f"Error stopping playback (may already be stopped): {e}")
 
-        # Now signal async loops to stop
-        self._stop_event.set()
-
-        # Cancel all running tasks
+        # close() runs on watcher threads, loop-owned state must change on the loop.
+        loop = self._asyncio_loop
+        if loop is None or not loop.is_running():
+            self._stop_event.set()
+            return
+        loop.call_soon_threadsafe(self._stop_event.set)
         for task in self._tasks:
             if not task.done():
-                task.cancel()
+                loop.call_soon_threadsafe(task.cancel)
 
     def clear_audio_queue(self) -> None:
         """Flush queued playback audio immediately on user barge-in.


### PR DESCRIPTION
## Summary
Route `LocalStream.close()`'s `_stop_event.set()` and `task.cancel()` through `loop.call_soon_threadsafe()` so loop-owned asyncio state is only touched on the loop thread, not the watcher thread that calls `close()`. When no loop is running yet (pre-launch config wait), it falls back to setting the event directly since there are no tasks to cancel.

Closes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/413.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
