### PR TITLE
Unify idle behavior

### DIFF
--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -7,11 +7,10 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Final, Tuple, ClassVar, Optional
-from datetime import datetime
 
 import numpy as np
 from openai import AsyncOpenAI
-from fastrtc import AdditionalOutputs, wait_for_item, audio_to_int16
+from fastrtc import AdditionalOutputs, audio_to_int16
 from pydantic import Field, BaseModel
 from numpy.typing import NDArray
 from scipy.signal import resample
@@ -31,8 +30,7 @@ from reachy_mini_conversation_app.config import (
     get_default_voice_for_backend,
     get_available_voices_for_backend,
 )
-from reachy_mini_conversation_app.idle_policy import start_idle_tool_call
-from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.core_tools import ToolSpec, ToolDependencies
 from reachy_mini_conversation_app.conversation_handler import ConversationHandler
 from reachy_mini_conversation_app.tools.background_tool_manager import (
     ToolCallRoutine,
@@ -54,26 +52,18 @@ class InputTranscriptChunksByItem(BaseModel):
     deltas: list[str] = Field(default_factory=list)
 
 
-def to_realtime_tools_config(tool_specs: list[dict[str, Any]]) -> RealtimeToolsConfigParam:
+def to_realtime_tools_config(tool_specs: list[ToolSpec]) -> RealtimeToolsConfigParam:
     """Convert app tool specs to the OpenAI-compatible realtime session shape."""
     realtime_tools: RealtimeToolsConfigParam = []
     for spec in tool_specs:
-        tool_type = spec.get("type")
-        name = spec.get("name")
-        description = spec.get("description")
-        parameters = spec.get("parameters", {})
-
-        if tool_type != "function" or not isinstance(name, str):
-            raise ValueError(f"Unsupported realtime tool spec: {spec!r}")
-
-        realtime_tool = RealtimeFunctionToolParam(
-            type="function",
-            name=name,
-            parameters=parameters,
+        realtime_tools.append(
+            RealtimeFunctionToolParam(
+                type="function",
+                name=spec["name"],
+                description=spec["description"],
+                parameters=spec["parameters"],
+            )
         )
-        if isinstance(description, str):
-            realtime_tool["description"] = description
-        realtime_tools.append(realtime_tool)
     return realtime_tools
 
 
@@ -130,9 +120,6 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         self.connection: AsyncRealtimeConnection | None = None
         self.output_queue: "asyncio.Queue[Tuple[int, NDArray[np.int16]] | AdditionalOutputs]" = asyncio.Queue()
 
-        self.last_activity_time = time.monotonic()
-        self.start_time = time.monotonic()
-        self.is_idle_tool_call = False
         self.instance_path = instance_path
         self._voice_override: str | None = self._normalize_startup_voice(startup_voice)
         self._realtime_connect_query: dict[str, str] = {}
@@ -236,12 +223,16 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         """Return the configured session voice for this backend."""
 
     @abstractmethod
-    def _get_active_tool_specs(self) -> list[dict[str, Any]]:
-        """Return active tool specs for the current session dependencies."""
-
-    @abstractmethod
-    def _get_session_config(self, tool_specs: list[dict[str, Any]]) -> RealtimeSessionCreateRequestParam:
+    def _get_session_config(self, tool_specs: list[ToolSpec]) -> RealtimeSessionCreateRequestParam:
         """Return the backend-specific realtime session config."""
+
+    def _is_connected(self) -> bool:
+        """Return whether the realtime connection is open."""
+        return self.connection is not None
+
+    def _idle_behavior_ready(self) -> bool:
+        """Hold idle behavior while a model response is still active."""
+        return self._response_done_event.is_set()
 
     async def _cancel_partial_transcript_task(self) -> None:
         if self.partial_transcript_task and not self.partial_transcript_task.done():
@@ -250,17 +241,6 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                 await self.partial_transcript_task
             except asyncio.CancelledError:
                 pass
-
-    def _mark_activity(self, reason: str) -> None:
-        """Record non-idle conversation activity for the idle timer."""
-        self.last_activity_time = time.monotonic()
-        logger.debug("last activity time updated to %s (%s)", self.last_activity_time, reason)
-        observer = self._activity_observer
-        if observer is not None:
-            try:
-                observer(reason)
-            except Exception:
-                logger.debug("activity observer raised (ignored)", exc_info=True)
 
     def copy(self) -> "BaseRealtimeHandler":
         """Return a fresh handler of the same type, preserving deps and voice override."""
@@ -567,7 +547,12 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
     async def _handle_tool_result(self, completed_tool: ToolNotification) -> None:
         """Process the result of a tool call."""
         if completed_tool.error is not None:
-            logger.error("Tool '%s' (id=%s) failed with error: %s", completed_tool.tool_name, completed_tool.id, completed_tool.error)
+            logger.error(
+                "Tool '%s' (id=%s) failed with error: %s",
+                completed_tool.tool_name,
+                completed_tool.id,
+                completed_tool.error,
+            )
             tool_result = {"error": completed_tool.error}
             tool_result_for_model = tool_result
         elif completed_tool.result is not None:
@@ -584,7 +569,9 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
             )
             logger.debug("Tool '%s' model-visible result: %s", completed_tool.tool_name, tool_result_for_model)
         else:
-            logger.warning("Tool '%s' (id=%s) returned no result and no error", completed_tool.tool_name, completed_tool.id)
+            logger.warning(
+                "Tool '%s' (id=%s) returned no result and no error", completed_tool.tool_name, completed_tool.id
+            )
             tool_result = {"error": "No result returned from tool execution"}
             tool_result_for_model = tool_result
 
@@ -730,7 +717,6 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                 async for event in self.connection:
                     logger.debug("Realtime event: %s", event.type)
                     if event.type == "input_audio_buffer.speech_started":
-                        self.is_idle_tool_call = False
                         self._mark_activity("user_speech_started")
                         self._turn_user_done_at = None
                         self._turn_response_created_at = None
@@ -801,7 +787,6 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
 
                     # Handle completed transcription (user finished speaking)
                     if event.type == "conversation.item.input_audio_transcription.completed":
-                        self.is_idle_tool_call = False
                         self._mark_activity("user_transcription_completed")
                         raw_transcript = event.transcript or ""
                         transcript = raw_transcript.strip()
@@ -887,7 +872,10 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                             ),
                         )
                         logger.info(
-                            "Started background tool: %s (id=%s, call_id=%s)", tool_name, background_tool.tool_id, call_id
+                            "Started background tool: %s (id=%s, call_id=%s)",
+                            tool_name,
+                            background_tool.tool_id,
+                            call_id,
                         )
 
                     # server error
@@ -971,24 +959,6 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
             logger.debug("Dropping audio frame: connection not ready (%s)", e)
             return
 
-    async def emit(self) -> Tuple[int, NDArray[np.int16]] | AdditionalOutputs | None:
-        """Emit audio frame to be played by the speaker."""
-        # Sends output queued by the realtime event handler to the stream.
-        # This is called periodically by the fastrtc Stream
-
-        # Handle idle
-        idle_duration = time.monotonic() - self.last_activity_time
-        if idle_duration > 180.0 and self._response_done_event.is_set() and self.deps.movement_manager.is_idle():
-            try:
-                await self.send_idle_signal(idle_duration)
-            except Exception as e:
-                logger.warning("Idle tool skipped (connection closed?): %s", e)
-                return None
-
-            self.last_activity_time = time.monotonic()  # avoid repeated resets
-
-        return await wait_for_item(self.output_queue)  # type: ignore[no-any-return]
-
     async def shutdown(self) -> None:
         """Shutdown the handler."""
         # Unblock the response sender worker so it can exit
@@ -1016,13 +986,6 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
             except asyncio.QueueEmpty:
                 break
 
-    def format_timestamp(self) -> str:
-        """Format current timestamp with date, time, and elapsed seconds."""
-        loop_time = time.monotonic()
-        elapsed_seconds = loop_time - self.start_time
-        dt = datetime.now()  # wall-clock
-        return f"[{dt.strftime('%Y-%m-%d %H:%M:%S')} | +{elapsed_seconds:.1f}s]"
-
     async def get_available_voices(self) -> list[str]:
         """Return available voices for this backend."""
         return get_available_voices_for_backend(self.BACKEND_PROVIDER)
@@ -1030,21 +993,3 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
     @abstractmethod
     async def _build_realtime_client(self) -> AsyncOpenAI:
         """Build the realtime SDK client for this backend."""
-
-    async def send_idle_signal(self, idle_duration: float) -> None:
-        """Run a locally selected idle tool without sending an idle turn to the model."""
-        logger.debug("Selecting local idle tool")
-        if not self.connection:
-            logger.debug("No connection, cannot run idle tool")
-            return
-
-        available_tool_names = {
-            spec["name"] for spec in self._get_active_tool_specs() if isinstance(spec.get("name"), str)
-        }
-        await start_idle_tool_call(
-            deps=self.deps,
-            tool_manager=self.tool_manager,
-            output_queue=self.output_queue,
-            available_tool_names=available_tool_names,
-            idle_duration=idle_duration,
-        )

--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -564,27 +564,27 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
 
                 sent = True
 
-    async def _handle_tool_result(self, bg_tool: ToolNotification) -> None:
+    async def _handle_tool_result(self, completed_tool: ToolNotification) -> None:
         """Process the result of a tool call."""
-        if bg_tool.error is not None:
-            logger.error("Tool '%s' (id=%s) failed with error: %s", bg_tool.tool_name, bg_tool.id, bg_tool.error)
-            tool_result = {"error": bg_tool.error}
+        if completed_tool.error is not None:
+            logger.error("Tool '%s' (id=%s) failed with error: %s", completed_tool.tool_name, completed_tool.id, completed_tool.error)
+            tool_result = {"error": completed_tool.error}
             tool_result_for_model = tool_result
-        elif bg_tool.result is not None:
-            tool_result = bg_tool.result
+        elif completed_tool.result is not None:
+            tool_result = completed_tool.result
             tool_result_for_model = (
-                self._sanitize_tool_result_for_model(bg_tool.tool_name, tool_result)
+                self._sanitize_tool_result_for_model(completed_tool.tool_name, tool_result)
                 if isinstance(tool_result, dict)
                 else tool_result
             )
             logger.info(
                 "Tool '%s' (id=%s) executed successfully.",
-                bg_tool.tool_name,
-                bg_tool.id,
+                completed_tool.tool_name,
+                completed_tool.id,
             )
-            logger.debug("Tool '%s' model-visible result: %s", bg_tool.tool_name, tool_result_for_model)
+            logger.debug("Tool '%s' model-visible result: %s", completed_tool.tool_name, tool_result_for_model)
         else:
-            logger.warning("Tool '%s' (id=%s) returned no result and no error", bg_tool.tool_name, bg_tool.id)
+            logger.warning("Tool '%s' (id=%s) returned no result and no error", completed_tool.tool_name, completed_tool.id)
             tool_result = {"error": "No result returned from tool execution"}
             tool_result_for_model = tool_result
 
@@ -592,36 +592,36 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         if not self.connection:
             logger.warning(
                 "Connection closed during tool '%s' (id=%s) execution; cannot send result back",
-                bg_tool.tool_name,
-                bg_tool.id,
+                completed_tool.tool_name,
+                completed_tool.id,
             )
             return
 
         try:
             self._mark_activity("tool_result_ready")
-            send_result_to_model = not bg_tool.is_idle_tool_call
+            send_result_to_model = not completed_tool.is_idle_tool_call
             model_result_submitted = False
-            if send_result_to_model and isinstance(bg_tool.id, str):
+            if send_result_to_model and isinstance(completed_tool.id, str):
                 if not await self._wait_for_response_done_before_tool_result():
                     send_result_to_model = False
                 if not send_result_to_model:
                     logger.warning(
                         "Dropping realtime model result for tool '%s' (id=%s) because response.done was not observed",
-                        bg_tool.tool_name,
-                        bg_tool.id,
+                        completed_tool.tool_name,
+                        completed_tool.id,
                     )
                 elif not self.connection:
                     logger.warning(
                         "Connection closed before sending tool '%s' (id=%s) result back",
-                        bg_tool.tool_name,
-                        bg_tool.id,
+                        completed_tool.tool_name,
+                        completed_tool.id,
                     )
                     return
                 else:
                     await self.connection.conversation.item.create(
                         item={
                             "type": "function_call_output",
-                            "call_id": bg_tool.id,
+                            "call_id": completed_tool.id,
                             "output": json.dumps(tool_result_for_model),
                         },
                     )
@@ -636,7 +636,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                 ),
             )
 
-            if model_result_submitted and bg_tool.tool_name == "camera" and "b64_im" in tool_result:
+            if model_result_submitted and completed_tool.tool_name == "camera" and "b64_im" in tool_result:
                 # use raw base64, don't json.dumps (which adds quotes)
                 b64_im = tool_result["b64_im"]
                 if not isinstance(b64_im, str):
@@ -671,9 +671,9 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                         jpeg_bytes,
                     )
 
-            tool = core_tools.ALL_TOOLS.get(bg_tool.tool_name)
+            tool = core_tools.ALL_TOOLS.get(completed_tool.tool_name)
             # Always surface errors, skip the spoken follow-up for tools that opt out.
-            if model_result_submitted and (bg_tool.error is not None or tool is None or tool.needs_response):
+            if model_result_submitted and (completed_tool.error is not None or tool is None or tool.needs_response):
                 await self._safe_response_create()
 
         except self._connection_closed_errors():
@@ -868,7 +868,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                             )
                             continue
 
-                        bg_tool = await self.tool_manager.start_tool(
+                        background_tool = await self.tool_manager.start_tool(
                             call_id=call_id,
                             tool_call_routine=ToolCallRoutine(
                                 tool_name=tool_name,
@@ -882,12 +882,12 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
                             AdditionalOutputs(
                                 {
                                     "role": "assistant",
-                                    "content": f"🛠️ Used tool {tool_name} with args {args_json_str}. The tool is now running. Tool ID: {bg_tool.tool_id}",
+                                    "content": f"🛠️ Used tool {tool_name} with args {args_json_str}. The tool is now running. Tool ID: {background_tool.tool_id}",
                                 },
                             ),
                         )
                         logger.info(
-                            "Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id
+                            "Started background tool: %s (id=%s, call_id=%s)", tool_name, background_tool.tool_id, call_id
                         )
 
                     # server error

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -940,13 +940,15 @@ class LocalStream:
         except Exception as e:
             logger.debug(f"Error stopping playback (may already be stopped): {e}")
 
-        # Now signal async loops to stop
-        self._stop_event.set()
-
-        # Cancel all running tasks
+        # close() runs on watcher threads, loop-owned state must change on the loop.
+        loop = self._asyncio_loop
+        if loop is None or not loop.is_running():
+            self._stop_event.set()
+            return
+        loop.call_soon_threadsafe(self._stop_event.set)
         for task in self._tasks:
             if not task.done():
-                task.cancel()
+                loop.call_soon_threadsafe(task.cancel)
 
     def clear_audio_queue(self) -> None:
         """Flush queued playback audio immediately on user barge-in.

--- a/src/reachy_mini_conversation_app/conversation_handler.py
+++ b/src/reachy_mini_conversation_app/conversation_handler.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
+import time
 import asyncio
+import logging
 from abc import ABC, abstractmethod
-from typing import TypeAlias
+from typing import Literal, ClassVar, TypeAlias
 from collections.abc import Callable
 
 import numpy as np
-from fastrtc import AdditionalOutputs, AsyncStreamHandler
+from fastrtc import AdditionalOutputs, AsyncStreamHandler, wait_for_item
 from numpy.typing import NDArray
 
-from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.idle_policy import start_idle_tool_call
+from reachy_mini_conversation_app.tools.core_tools import ToolSpec, ToolDependencies, get_active_tool_specs
+from reachy_mini_conversation_app.tools.background_tool_manager import BackgroundToolManager
+
+
+logger = logging.getLogger(__name__)
 
 
 AudioFrame: TypeAlias = tuple[int, NDArray[np.int16]]
@@ -17,16 +24,91 @@ QueueItem: TypeAlias = AudioFrame | AdditionalOutputs
 
 
 class ConversationHandler(AsyncStreamHandler, ABC):
-    """Shared app handler contract for realtime conversation backends."""
+    """Shared app handler contract and idle behavior for realtime conversation backends."""
+
+    IDLE_BEHAVIOR_THRESHOLD_S: ClassVar[float] = 180.0
 
     deps: ToolDependencies
+    tool_manager: BackgroundToolManager
     output_queue: asyncio.Queue[QueueItem]
     _clear_queue: Callable[[], None] | None = None
     _activity_observer: Callable[[str], None] | None = None
 
+    def __init__(
+        self,
+        expected_layout: Literal["mono", "stereo"] = "mono",
+        output_sample_rate: int = 24000,
+        output_frame_size: int | None = None,
+        input_sample_rate: int = 48000,
+        fps: int = 30,
+    ) -> None:
+        """Initialize the stream handler and shared idle/activity tracking."""
+        super().__init__(
+            expected_layout=expected_layout,
+            output_sample_rate=output_sample_rate,
+            output_frame_size=output_frame_size,
+            input_sample_rate=input_sample_rate,
+            fps=fps,
+        )
+        self.last_activity_time = time.monotonic()
+
     def set_activity_observer(self, observer: Callable[[str], None] | None) -> None:
         """Attach or detach an activity observer. Pass None to clear."""
         self._activity_observer = observer
+
+    def _mark_activity(self, reason: str) -> None:
+        """Record non-idle conversation activity for the idle timer."""
+        self.last_activity_time = time.monotonic()
+        logger.debug("last activity time updated to %s (%s)", self.last_activity_time, reason)
+        if self._activity_observer is not None:
+            try:
+                self._activity_observer(reason)
+            except Exception:
+                logger.debug("activity observer raised (ignored)", exc_info=True)
+
+    def _idle_behavior_ready(self) -> bool:
+        """Return whether idle behavior may run now. Backends can add guards."""
+        return True
+
+    async def emit(self) -> HandlerOutput:
+        """Emit the next queued output, triggering local idle behavior when due."""
+        idle_duration = time.monotonic() - self.last_activity_time
+        if (
+            idle_duration > self.IDLE_BEHAVIOR_THRESHOLD_S
+            and self._idle_behavior_ready()
+            and self.deps.movement_manager.is_idle()
+        ):
+            try:
+                await self.send_idle_signal(idle_duration)
+            except Exception as e:
+                logger.warning("Idle tool skipped (connection closed?): %s", e)
+                return None
+            self.last_activity_time = time.monotonic()  # avoid repeated resets
+        return await wait_for_item(self.output_queue)  # type: ignore[no-any-return]
+
+    async def send_idle_signal(self, idle_duration: float) -> None:
+        """Run a locally selected idle tool without sending an idle turn to the model."""
+        if not self._is_connected():
+            logger.debug("No active session; cannot run idle tool")
+            return
+
+        available_tool_names = {spec["name"] for spec in self._get_active_tool_specs()}
+        await start_idle_tool_call(
+            deps=self.deps,
+            tool_manager=self.tool_manager,
+            output_queue=self.output_queue,
+            available_tool_names=available_tool_names,
+            idle_duration=idle_duration,
+        )
+
+    def _get_active_tool_specs(self) -> list[ToolSpec]:
+        """Return active tool specs for the current session dependencies."""
+        return get_active_tool_specs(self.deps)
+
+    @abstractmethod
+    def _is_connected(self) -> bool:
+        """Return whether the backend session/connection is currently open."""
+        ...
 
     @abstractmethod
     def copy(self) -> ConversationHandler:
@@ -46,11 +128,6 @@ class ConversationHandler(AsyncStreamHandler, ABC):
     @abstractmethod
     async def receive(self, frame: AudioFrame) -> None:
         """Receive an input audio frame."""
-        ...
-
-    @abstractmethod
-    async def emit(self) -> HandlerOutput:
-        """Emit the next output item."""
         ...
 
     @abstractmethod

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -9,18 +9,16 @@ Audio formats (per Gemini Live API spec):
 """
 
 import json
-import time
 import uuid
 import base64
 import random
 import asyncio
 import logging
 from typing import Any, Dict, List, Final, Tuple, Literal, Optional
-from datetime import datetime
 
 import numpy as np
 from google import genai
-from fastrtc import AdditionalOutputs, wait_for_item, audio_to_int16
+from fastrtc import AdditionalOutputs, audio_to_int16
 from google.genai import types
 from numpy.typing import NDArray
 from scipy.signal import resample
@@ -32,10 +30,9 @@ from reachy_mini_conversation_app.config import (
     config,
 )
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
-from reachy_mini_conversation_app.idle_policy import start_idle_tool_call
 from reachy_mini_conversation_app.tools.core_tools import (
+    ToolSpec,
     ToolDependencies,
-    get_active_tool_specs,
 )
 from reachy_mini_conversation_app.conversation_handler import ConversationHandler
 from reachy_mini_conversation_app.camera_frame_encoding import encode_bgr_frame_as_jpeg
@@ -52,7 +49,7 @@ GEMINI_INPUT_SAMPLE_RATE: Final[int] = 16000
 GEMINI_OUTPUT_SAMPLE_RATE: Final[int] = 24000
 
 
-def _openai_tool_specs_to_gemini(specs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _openai_tool_specs_to_gemini(specs: list[ToolSpec]) -> List[Dict[str, Any]]:
     """Convert OpenAI-style tool specs to Gemini function_declarations format.
 
     OpenAI format:
@@ -68,10 +65,9 @@ def _openai_tool_specs_to_gemini(specs: List[Dict[str, Any]]) -> List[Dict[str, 
     for spec in specs:
         decl: Dict[str, Any] = {
             "name": spec["name"],
+            "description": spec["description"],
         }
-        if "description" in spec:
-            decl["description"] = spec["description"]
-        if "parameters" in spec and spec["parameters"]:
+        if spec["parameters"]:
             decl["parameters"] = _convert_schema_types(spec["parameters"])
         declarations.append(decl)
     return declarations
@@ -162,10 +158,6 @@ class GeminiLiveHandler(ConversationHandler):
         self.session: Any = None  # google.genai live session
         self.output_queue: "asyncio.Queue[Tuple[int, NDArray[np.int16]] | AdditionalOutputs]" = asyncio.Queue()
 
-        self.last_activity_time = time.monotonic()
-        self.start_time = time.monotonic()
-        self.is_idle_tool_call = False
-
         # Track API key source (env vs textbox)
         self._key_source: Literal["env", "textbox"] = "env"
         self._provided_api_key: str | None = None
@@ -209,16 +201,9 @@ class GeminiLiveHandler(ConversationHandler):
 
         await self.output_queue.put(AdditionalOutputs({"role": role, "content": transcript}))
 
-    def _mark_activity(self, reason: str) -> None:
-        """Refresh the idle timestamp and notify the activity observer."""
-        self.last_activity_time = asyncio.get_event_loop().time()
-        logger.debug("last activity time updated to %s (%s)", self.last_activity_time, reason)
-        observer = self._activity_observer
-        if observer is not None:
-            try:
-                observer(reason)
-            except Exception:
-                logger.debug("activity observer raised (ignored)", exc_info=True)
+    def _is_connected(self) -> bool:
+        """Return whether the Gemini Live session is open."""
+        return self.session is not None
 
     async def _mark_model_response_started(self) -> None:
         """Switch out of user-listening mode when the model begins responding."""
@@ -363,7 +348,7 @@ class GeminiLiveHandler(ConversationHandler):
         voice = _resolve_gemini_voice(self._voice_override or get_session_voice())
 
         # Convert OpenAI-style tool specs to Gemini function declarations
-        tool_specs = get_active_tool_specs(self.deps)
+        tool_specs = self._get_active_tool_specs()
         logger.info(
             "Tools to be used in conversation: %s",
             [tool["name"] for tool in tool_specs],
@@ -439,13 +424,17 @@ class GeminiLiveHandler(ConversationHandler):
     async def _handle_tool_result(self, completed_tool: ToolNotification) -> None:
         """Process the result of a completed tool and send it back to Gemini."""
         if completed_tool.error is not None:
-            logger.error("Tool '%s' (id=%s) failed: %s", completed_tool.tool_name, completed_tool.id, completed_tool.error)
+            logger.error(
+                "Tool '%s' (id=%s) failed: %s", completed_tool.tool_name, completed_tool.id, completed_tool.error
+            )
             tool_result = {"error": completed_tool.error}
         elif completed_tool.result is not None:
             tool_result = completed_tool.result
             logger.info("Tool '%s' (id=%s) succeeded.", completed_tool.tool_name, completed_tool.id)
         else:
-            logger.warning("Tool '%s' (id=%s) returned no result and no error", completed_tool.tool_name, completed_tool.id)
+            logger.warning(
+                "Tool '%s' (id=%s) returned no result and no error", completed_tool.tool_name, completed_tool.id
+            )
             tool_result = {"error": "No result returned from tool execution"}
 
         if not self.session:
@@ -665,20 +654,6 @@ class GeminiLiveHandler(ConversationHandler):
             logger.debug("Dropping audio frame: session not ready (%s)", e)
             return
 
-    async def emit(self) -> Tuple[int, NDArray[np.int16]] | AdditionalOutputs | None:
-        """Emit audio frame to be played by the speaker."""
-        # Handle idle
-        idle_duration = time.monotonic() - self.last_activity_time
-        if idle_duration > 15.0 and self.deps.movement_manager.is_idle():
-            try:
-                await self.send_idle_signal(idle_duration)
-            except Exception as e:
-                logger.warning("Idle tool skipped: %s", e)
-                return None
-            self.last_activity_time = time.monotonic()
-
-        return await wait_for_item(self.output_queue)  # type: ignore[no-any-return]
-
     async def shutdown(self) -> None:
         """Shutdown the handler."""
         self._stop_event.set()
@@ -699,31 +674,6 @@ class GeminiLiveHandler(ConversationHandler):
                 self.output_queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
-
-    def format_timestamp(self) -> str:
-        """Format current timestamp with date, time, and elapsed seconds."""
-        loop_time = time.monotonic()
-        elapsed_seconds = loop_time - self.start_time
-        dt = datetime.now()
-        return f"[{dt.strftime('%Y-%m-%d %H:%M:%S')} | +{elapsed_seconds:.1f}s]"
-
-    async def send_idle_signal(self, idle_duration: float) -> None:
-        """Run a locally selected idle tool without sending an idle turn to Gemini."""
-        logger.debug("Selecting local Gemini idle tool")
-        if not self.session:
-            logger.debug("No session, cannot run idle tool")
-            return
-
-        available_tool_names = {
-            spec["name"] for spec in get_active_tool_specs(self.deps) if isinstance(spec.get("name"), str)
-        }
-        await start_idle_tool_call(
-            deps=self.deps,
-            tool_manager=self.tool_manager,
-            output_queue=self.output_queue,
-            available_tool_names=available_tool_names,
-            idle_duration=idle_duration,
-        )
 
     async def get_available_voices(self) -> list[str]:
         """Return the list of available Gemini voices."""

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -415,7 +415,7 @@ class GeminiLiveHandler(ConversationHandler):
                 args_json_str,
             )
 
-            bg_tool = await self.tool_manager.start_tool(
+            background_tool = await self.tool_manager.start_tool(
                 call_id=call_id,
                 tool_call_routine=ToolCallRoutine(
                     tool_name=tool_name,
@@ -429,35 +429,35 @@ class GeminiLiveHandler(ConversationHandler):
                 AdditionalOutputs(
                     {
                         "role": "assistant",
-                        "content": f"🛠️ Used tool {tool_name} with args {args_json_str}. Tool ID: {bg_tool.tool_id}",
+                        "content": f"🛠️ Used tool {tool_name} with args {args_json_str}. Tool ID: {background_tool.tool_id}",
                     },
                 ),
             )
 
-            logger.info("Started background tool: %s (id=%s, call_id=%s)", tool_name, bg_tool.tool_id, call_id)
+            logger.info("Started background tool: %s (id=%s, call_id=%s)", tool_name, background_tool.tool_id, call_id)
 
-    async def _handle_tool_result(self, bg_tool: ToolNotification) -> None:
+    async def _handle_tool_result(self, completed_tool: ToolNotification) -> None:
         """Process the result of a completed tool and send it back to Gemini."""
-        if bg_tool.error is not None:
-            logger.error("Tool '%s' (id=%s) failed: %s", bg_tool.tool_name, bg_tool.id, bg_tool.error)
-            tool_result = {"error": bg_tool.error}
-        elif bg_tool.result is not None:
-            tool_result = bg_tool.result
-            logger.info("Tool '%s' (id=%s) succeeded.", bg_tool.tool_name, bg_tool.id)
+        if completed_tool.error is not None:
+            logger.error("Tool '%s' (id=%s) failed: %s", completed_tool.tool_name, completed_tool.id, completed_tool.error)
+            tool_result = {"error": completed_tool.error}
+        elif completed_tool.result is not None:
+            tool_result = completed_tool.result
+            logger.info("Tool '%s' (id=%s) succeeded.", completed_tool.tool_name, completed_tool.id)
         else:
-            logger.warning("Tool '%s' (id=%s) returned no result and no error", bg_tool.tool_name, bg_tool.id)
+            logger.warning("Tool '%s' (id=%s) returned no result and no error", completed_tool.tool_name, completed_tool.id)
             tool_result = {"error": "No result returned from tool execution"}
 
         if not self.session:
-            logger.warning("Connection closed during tool '%s' execution", bg_tool.tool_name)
+            logger.warning("Connection closed during tool '%s' execution", completed_tool.tool_name)
             return
 
         try:
-            send_result_to_model = not bg_tool.is_idle_tool_call
+            send_result_to_model = not completed_tool.is_idle_tool_call
 
             if (
                 send_result_to_model
-                and bg_tool.tool_name == "camera"
+                and completed_tool.tool_name == "camera"
                 and isinstance(tool_result, dict)
                 and "b64_im" in tool_result
             ):
@@ -480,8 +480,8 @@ class GeminiLiveHandler(ConversationHandler):
             self._mark_activity("tool_result_ready")
             if send_result_to_model:
                 function_response = types.FunctionResponse(
-                    id=bg_tool.id if isinstance(bg_tool.id, str) else str(bg_tool.id),
-                    name=bg_tool.tool_name,
+                    id=completed_tool.id if isinstance(completed_tool.id, str) else str(completed_tool.id),
+                    name=completed_tool.tool_name,
                     response=tool_result,
                 )
                 await self.session.send_tool_response(function_responses=[function_response])

--- a/src/reachy_mini_conversation_app/huggingface_realtime.py
+++ b/src/reachy_mini_conversation_app/huggingface_realtime.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any
 
 import httpx
 from openai import AsyncOpenAI
@@ -27,7 +26,7 @@ from reachy_mini_conversation_app.base_realtime import (
     InputTranscriptChunksByItem,
     to_realtime_tools_config,
 )
-from reachy_mini_conversation_app.tools.core_tools import get_active_tool_specs
+from reachy_mini_conversation_app.tools.core_tools import ToolSpec
 
 
 logger = logging.getLogger(__name__)
@@ -79,11 +78,7 @@ class HuggingFaceRealtimeHandler(BaseRealtimeHandler):
         """Return the configured Hugging Face session voice."""
         return get_session_voice(default)
 
-    def _get_active_tool_specs(self) -> list[dict[str, Any]]:
-        """Return active tool specs for the current session dependencies."""
-        return get_active_tool_specs(self.deps)
-
-    def _get_session_config(self, tool_specs: list[dict[str, Any]]) -> RealtimeSessionCreateRequestParam:
+    def _get_session_config(self, tool_specs: list[ToolSpec]) -> RealtimeSessionCreateRequestParam:
         """Return the Hugging Face OpenAI-compatible session config."""
         return RealtimeSessionCreateRequestParam(
             type="realtime",

--- a/src/reachy_mini_conversation_app/idle_policy.py
+++ b/src/reachy_mini_conversation_app/idle_policy.py
@@ -108,7 +108,7 @@ async def start_idle_tool_call(
     tool_name, arguments = selected_tool
     args_json_str = json.dumps(arguments)
     call_id = f"idle-{uuid.uuid4()}"
-    bg_tool = await tool_manager.start_tool(
+    background_tool = await tool_manager.start_tool(
         call_id=call_id,
         tool_call_routine=ToolCallRoutine(
             tool_name=tool_name,
@@ -123,7 +123,7 @@ async def start_idle_tool_call(
                 "role": "assistant",
                 "content": (
                     f"🛠️ Idle tool {tool_name} with args {args_json_str}. "
-                    f"The tool is now running. Tool ID: {bg_tool.tool_id}"
+                    f"The tool is now running. Tool ID: {background_tool.tool_id}"
                 ),
             },
         ),
@@ -132,8 +132,8 @@ async def start_idle_tool_call(
         "Started local idle tool after %.1fs idle: %s (id=%s, call_id=%s, args=%s)",
         idle_duration,
         tool_name,
-        bg_tool.tool_id,
+        background_tool.tool_id,
         call_id,
         args_json_str,
     )
-    return bg_tool
+    return background_tool

--- a/src/reachy_mini_conversation_app/openai_realtime.py
+++ b/src/reachy_mini_conversation_app/openai_realtime.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any
 
 from openai import AsyncOpenAI
 from openai.types.realtime import (
@@ -15,7 +14,7 @@ from openai.types.realtime.realtime_audio_input_turn_detection_param import Serv
 from reachy_mini_conversation_app.config import OPENAI_BACKEND, config, get_default_voice_for_backend
 from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
 from reachy_mini_conversation_app.base_realtime import BaseRealtimeHandler, to_realtime_tools_config
-from reachy_mini_conversation_app.tools.core_tools import get_active_tool_specs
+from reachy_mini_conversation_app.tools.core_tools import ToolSpec
 
 
 logger = logging.getLogger(__name__)
@@ -43,11 +42,7 @@ class OpenaiRealtimeHandler(BaseRealtimeHandler):
         """Return the configured OpenAI session voice."""
         return get_session_voice(default)
 
-    def _get_active_tool_specs(self) -> list[dict[str, Any]]:
-        """Return active tool specs for the current session dependencies."""
-        return get_active_tool_specs(self.deps)
-
-    def _get_session_config(self, tool_specs: list[dict[str, Any]]) -> RealtimeSessionCreateRequestParam:
+    def _get_session_config(self, tool_specs: list[ToolSpec]) -> RealtimeSessionCreateRequestParam:
         """Return the OpenAI Realtime session config."""
         return RealtimeSessionCreateRequestParam(
             type="realtime",

--- a/src/reachy_mini_conversation_app/tools/background_tool_manager.py
+++ b/src/reachy_mini_conversation_app/tools/background_tool_manager.py
@@ -145,51 +145,53 @@ class BackgroundToolManager(BaseModel):
         """
         tool_name = tool_call_routine.tool_name
         id = call_id
-        bg_tool = BackgroundTool(
+        background_tool = BackgroundTool(
             id=id,
             tool_name=tool_name,
             is_idle_tool_call=is_idle_tool_call,
             progress=ToolProgress(progress=0.0) if with_progress else None,
             status=ToolState.RUNNING,
         )
-        self._tools[bg_tool.tool_id] = bg_tool
+        self._tools[background_tool.tool_id] = background_tool
 
         async_task = asyncio.create_task(
-            self._run_tool(bg_tool, tool_call_routine),
+            self._run_tool(background_tool, tool_call_routine),
             name=f"bg-{tool_name}-{id}",
         )
-        bg_tool._task = async_task
+        background_tool._task = async_task
 
-        logger.info(f"Started background tool: {bg_tool.tool_name} (id={id})")
+        logger.info(f"Started background tool: {background_tool.tool_name} (id={id})")
 
-        return bg_tool
+        return background_tool
 
     async def _run_tool(
         self,
-        bg_tool: BackgroundTool,
+        background_tool: BackgroundTool,
         tool_call_routine: ToolCallRoutine,
     ) -> None:
         """Execute the tool and handle completion."""
         result: dict[str, Any] = await tool_call_routine(self)
-        bg_tool.completed_at = time.monotonic()
+        background_tool.completed_at = time.monotonic()
         error = result.get("error")
 
         if error is not None:
             if error == "Tool cancelled":
-                bg_tool.status = ToolState.CANCELLED
-                logger.debug(f"Background tool cancelled: {bg_tool.tool_name} (id={bg_tool.id})")
+                background_tool.status = ToolState.CANCELLED
+                logger.debug(f"Background tool cancelled: {background_tool.tool_name} (id={background_tool.id})")
             else:
-                bg_tool.status = ToolState.FAILED
-                logger.debug(f"Background tool failed: {bg_tool.tool_name} (id={bg_tool.id}): {bg_tool.error}")
-            bg_tool.error = result["error"]
+                background_tool.status = ToolState.FAILED
+                logger.debug(
+                    f"Background tool failed: {background_tool.tool_name} (id={background_tool.id}): {background_tool.error}"
+                )
+            background_tool.error = result["error"]
 
         else:
-            bg_tool.result = result
-            bg_tool.status = ToolState.COMPLETED
-            logger.debug(f"Background tool completed: {bg_tool.tool_name} (id={bg_tool.id})")
+            background_tool.result = result
+            background_tool.status = ToolState.COMPLETED
+            logger.debug(f"Background tool completed: {background_tool.tool_name} (id={background_tool.id})")
 
-        await self._notification_queue.put(bg_tool.get_notification())
-        logger.debug(f"Queued notification for tool: {bg_tool.tool_name} (id={bg_tool.id})")
+        await self._notification_queue.put(background_tool.get_notification())
+        logger.debug(f"Queued notification for tool: {background_tool.tool_name} (id={background_tool.id})")
 
     async def update_progress(
         self,
@@ -265,9 +267,9 @@ class BackgroundToolManager(BaseModel):
 
         async def _listener() -> None:
             while True:
-                bg_tool = await self._notification_queue.get()
+                background_tool = await self._notification_queue.get()
                 for callback in tool_callbacks:
-                    await callback(bg_tool)
+                    await callback(background_tool)
 
         async def _cleanup(interval_seconds: float = 5 * 60) -> None:
             while True:

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -9,7 +9,7 @@ import logging
 import importlib
 import importlib.util
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Dict, List, Callable, ClassVar, Sequence
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Callable, ClassVar, Sequence, TypedDict
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -46,6 +46,15 @@ class ToolDependencies:
     motion_duration_s: float = 1.0
 
 
+class ToolSpec(TypedDict):
+    """Function-calling spec for a tool, in the OpenAI-compatible shape."""
+
+    type: Literal["function"]
+    name: str
+    description: str
+    parameters: dict[str, Any]  # arbitrary JSON Schema
+
+
 class Tool(abc.ABC):
     """Base abstraction for tools used in function-calling.
 
@@ -65,7 +74,7 @@ class Tool(abc.ABC):
     description: str
     parameters_schema: Dict[str, Any]
 
-    def spec(self) -> Dict[str, Any]:
+    def spec(self) -> ToolSpec:
         """Return the function spec for LLM consumption."""
         return {
             "type": "function",
@@ -81,7 +90,7 @@ class Tool(abc.ABC):
 
 
 ALL_TOOLS: Dict[str, Tool] = {}
-ALL_TOOL_SPECS: List[Dict[str, Any]] = []
+ALL_TOOL_SPECS: list[ToolSpec] = []
 _TOOLS_INITIALIZED = False
 _TOOLS_SIGNATURE: tuple[str, str, str | None, bool, str | None] | None = None
 _TOOLS_INSTANCE_PATH: str | Path | None = None
@@ -515,14 +524,14 @@ def initialize_tools(instance_path: str | Path | None = None, *, force: bool = F
     _TOOLS_SIGNATURE = signature
 
 
-def get_tool_specs(exclusion_list: list[str] | None = None) -> list[Dict[str, Any]]:
+def get_tool_specs(exclusion_list: list[str] | None = None) -> list[ToolSpec]:
     """Get tool specs, optionally excluding some tools."""
     initialize_tools()
     exclusion_list = exclusion_list or []
-    return [spec for spec in ALL_TOOL_SPECS if spec.get("name") not in exclusion_list]
+    return [spec for spec in ALL_TOOL_SPECS if spec["name"] not in exclusion_list]
 
 
-def get_active_tool_specs(deps: ToolDependencies) -> list[Dict[str, Any]]:
+def get_active_tool_specs(deps: ToolDependencies) -> list[ToolSpec]:
     """Get tool specs filtered by what the current session deps support."""
     exclusion_list: list[str] = []
     if not (deps.camera_worker and deps.camera_worker.head_tracker):

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -1,5 +1,6 @@
 """Behavior tests for the Gemini Live handler."""
 
+import time
 import base64
 import asyncio
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ from fastrtc import AdditionalOutputs
 import reachy_mini_conversation_app.gemini_live as gemini_mod
 import reachy_mini_conversation_app.idle_policy as idle_policy_mod
 import reachy_mini_conversation_app.tools.core_tools as ct_mod
+import reachy_mini_conversation_app.conversation_handler as conv_mod
 from reachy_mini_conversation_app.gemini_live import GeminiLiveHandler
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.tools.tool_constants import ToolState
@@ -101,7 +103,7 @@ async def test_gemini_turn_buffers_transcripts_and_schedules_motion_reset(
     """Gemini turns should emit one transcript per role and let the wobbler reset after speech."""
     monkeypatch.setattr(gemini_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(gemini_mod, "get_session_voice", lambda: "Kore")
-    monkeypatch.setattr(gemini_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
 
     movement_manager = MagicMock()
     movement_manager.is_idle.return_value = False
@@ -232,6 +234,29 @@ async def test_gemini_camera_tool_sends_snapshot_and_returns_json_result() -> No
             "content": '{"status": "image_captured"}',
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_emit_triggers_idle_through_shared_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gemini drives idle behavior through the shared base emit and threshold, not the old 15s cadence."""
+    movement_manager = MagicMock()
+    movement_manager.is_idle.return_value = True
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=movement_manager)
+    handler = GeminiLiveHandler(deps)
+
+    send_idle_signal = AsyncMock()
+    monkeypatch.setattr(handler, "send_idle_signal", send_idle_signal)
+    monkeypatch.setattr(conv_mod, "wait_for_item", AsyncMock(return_value=None))
+
+    # Idle well past the old Gemini-only 15s cadence but under the shared threshold: must not fire.
+    handler.last_activity_time = time.monotonic() - (handler.IDLE_BEHAVIOR_THRESHOLD_S - 30.0)
+    await handler.emit()
+    send_idle_signal.assert_not_awaited()
+
+    # Past the shared threshold: fires once.
+    handler.last_activity_time = time.monotonic() - (handler.IDLE_BEHAVIOR_THRESHOLD_S + 10.0)
+    await handler.emit()
+    send_idle_signal.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_huggingface_realtime.py
+++ b/tests/test_huggingface_realtime.py
@@ -1,10 +1,10 @@
-import asyncio
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import reachy_mini_conversation_app.base_realtime as base_rt_mod
+import reachy_mini_conversation_app.conversation_handler as conv_mod
 import reachy_mini_conversation_app.huggingface_realtime as hf_mod
 from reachy_mini_conversation_app.config import HF_BACKEND, config, get_default_voice_for_backend
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
@@ -48,7 +48,7 @@ async def test_partial_transcription_uses_latest_snapshot(monkeypatch: Any) -> N
     """Partial transcription snapshots should replace older snapshots for the same item."""
     monkeypatch.setattr(hf_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(hf_mod, "get_session_voice", lambda default=HF_DEFAULT_VOICE: "Aiden")
-    monkeypatch.setattr(hf_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
 
     class FakeEvent:
         def __init__(self, etype: str, **kwargs: Any) -> None:
@@ -145,12 +145,12 @@ async def test_emit_skips_idle_signal_while_response_active(monkeypatch: Any) ->
     movement_manager.is_idle.return_value = True
     deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=movement_manager)
     handler = HuggingFaceRealtimeHandler(deps)
-    handler.last_activity_time = asyncio.get_running_loop().time() - 60.0
+    handler.last_activity_time = time.monotonic() - (handler.IDLE_BEHAVIOR_THRESHOLD_S + 10.0)
     handler._response_done_event.clear()
 
     send_idle_signal = AsyncMock()
     monkeypatch.setattr(handler, "send_idle_signal", send_idle_signal)
-    monkeypatch.setattr(base_rt_mod, "wait_for_item", AsyncMock(return_value=None))
+    monkeypatch.setattr(conv_mod, "wait_for_item", AsyncMock(return_value=None))
 
     result = await handler.emit()
 
@@ -197,7 +197,7 @@ async def test_run_realtime_session_uses_default_voice_for_lb_allocated_sessions
     """Use the backend default speaker when no profile voice is selected for the hf LB."""
     monkeypatch.setattr(hf_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(hf_mod, "get_session_voice", lambda default=HF_DEFAULT_VOICE: default)
-    monkeypatch.setattr(hf_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
     monkeypatch.setattr(config, "BACKEND_PROVIDER", "huggingface")
     monkeypatch.setattr(config, "HF_REALTIME_SESSION_URL", "https://lb.example.test/session")
 
@@ -285,7 +285,7 @@ async def test_run_realtime_session_passes_allocated_session_query(monkeypatch: 
     """Hugging Face sessions must forward the allocated session token to the websocket connect call."""
     monkeypatch.setattr(hf_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(hf_mod, "get_session_voice", lambda default=HF_DEFAULT_VOICE: default)
-    monkeypatch.setattr(hf_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
 
     captured_connect: dict[str, Any] = {}
 

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 from types import SimpleNamespace
 from typing import Any, Callable
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -13,6 +12,7 @@ import reachy_mini_conversation_app.idle_policy as idle_policy_mod
 import reachy_mini_conversation_app.base_realtime as base_rt_mod
 import reachy_mini_conversation_app.openai_realtime as rt_mod
 import reachy_mini_conversation_app.tools.core_tools as ct_mod
+import reachy_mini_conversation_app.conversation_handler as conv_mod
 import reachy_mini_conversation_app.tools.background_tool_manager as btm_mod
 from reachy_mini_conversation_app.config import OPENAI_BACKEND, config, get_default_voice_for_backend
 from reachy_mini_conversation_app.openai_realtime import OpenaiRealtimeHandler
@@ -22,12 +22,6 @@ from reachy_mini_conversation_app.tools.background_tool_manager import ToolCallR
 
 
 OPENAI_DEFAULT_VOICE = get_default_voice_for_backend(OPENAI_BACKEND)
-
-
-def _build_handler(loop: asyncio.AbstractEventLoop) -> OpenaiRealtimeHandler:
-    asyncio.set_event_loop(loop)
-    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
-    return OpenaiRealtimeHandler(deps)
 
 
 async def _run_openai_handler_with_events(
@@ -40,7 +34,7 @@ async def _run_openai_handler_with_events(
     """Run an OpenAI realtime handler against a fixed event sequence."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=OPENAI_DEFAULT_VOICE: "alloy")
-    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
 
     class FakeSession:
         async def update(self, **_kw: Any) -> None:
@@ -122,7 +116,7 @@ async def test_non_idle_tool_call_does_not_queue_progress_response(monkeypatch: 
     """Tool-call startup should not enqueue a second speech response."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=OPENAI_DEFAULT_VOICE: "alloy")
-    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
 
     class FakeEvent:
         def __init__(self, etype: str, **kwargs: Any) -> None:
@@ -213,29 +207,6 @@ async def test_non_idle_tool_call_does_not_queue_progress_response(monkeypatch: 
 
     start_tool.assert_awaited_once()
     safe_response_create.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_completed_user_transcript_resets_idle_state(monkeypatch: Any) -> None:
-    """A completed user turn should refresh activity and cancel stale idle intent."""
-
-    def setup_idle_state(handler: OpenaiRealtimeHandler) -> None:
-        handler.is_idle_tool_call = True
-        handler.last_activity_time = 1.0
-
-    handler = await _run_openai_handler_with_events(
-        monkeypatch,
-        [
-            SimpleNamespace(
-                type="conversation.item.input_audio_transcription.completed",
-                transcript="Can you check the weather?",
-            )
-        ],
-        handler_setup=setup_idle_state,
-    )
-
-    assert handler.is_idle_tool_call is False
-    assert handler.last_activity_time > 1.0
 
 
 @pytest.mark.asyncio
@@ -520,27 +491,6 @@ def test_copy_preserves_current_voice_override(monkeypatch: Any) -> None:
     assert copied_handler.get_current_voice() == "marin"
 
 
-def test_format_timestamp_uses_wall_clock() -> None:
-    """Test that format_timestamp uses wall clock time."""
-    try:
-        previous_loop = asyncio.get_event_loop()
-    except RuntimeError:
-        previous_loop = asyncio.new_event_loop()
-    loop = asyncio.new_event_loop()
-    try:
-        print("Testing format_timestamp...")
-        handler = _build_handler(loop)
-        formatted = handler.format_timestamp()
-        print(f"Formatted timestamp: {formatted}")
-    finally:
-        loop.close()
-        asyncio.set_event_loop(previous_loop)
-
-    # Extract year from "[YYYY-MM-DD ...]"
-    year = int(formatted[1:5])
-    assert year == datetime.now(timezone.utc).year
-
-
 @pytest.mark.asyncio
 async def test_start_up_retries_on_abrupt_close(monkeypatch: Any, caplog: Any) -> None:
     """First connection dies with ConnectionClosedError during iteration -> retried.
@@ -653,7 +603,7 @@ async def test_run_realtime_session_propagates_session_update_failure(monkeypatc
     """A failed session.update must abort startup instead of looking like a clean session exit."""
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=OPENAI_DEFAULT_VOICE: "alloy")
-    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
 
     class FakeSession:
         async def update(self, **_kw: Any) -> None:
@@ -768,7 +718,7 @@ async def test_response_sender_retries_when_active_response_error_uses_type_only
     monkeypatch.setattr(base_rt_mod, "_RESPONSE_REJECTION_RETRY_DELAY", 0.01)
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=OPENAI_DEFAULT_VOICE: "alloy")
-    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
 
     class FakeError:
         def __init__(self, message: str) -> None:
@@ -913,7 +863,7 @@ async def test_response_sender_retries_on_active_response_rejection(monkeypatch:
     monkeypatch.setattr(base_rt_mod, "ConnectionClosedError", FakeCCE)
     monkeypatch.setattr(rt_mod, "get_session_instructions", lambda _instance_path=None: "test")
     monkeypatch.setattr(rt_mod, "get_session_voice", lambda default=OPENAI_DEFAULT_VOICE: "alloy")
-    monkeypatch.setattr(rt_mod, "get_active_tool_specs", lambda _: [])
+    monkeypatch.setattr(conv_mod, "get_active_tool_specs", lambda _: [])
 
     # 400 near-simultaneous tool results coalesce into far fewer response.create sends.
     N_TOOL_RESULTS = 400


### PR DESCRIPTION
## Summary
Fixes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/412
The idle-behavior loop and the activity/idle timestamps were implemented twice: once in `BaseRealtimeHandler` (OpenAI / Hugging Face) and again in `GeminiLiveHandler`, and the copies had drifted, so any change to idle or activity logic had to be made in both places and kept in sync. This came up while adding the app inactivity timeout, which had to add the same state to both handlers.
- Moved the idle loop, the activity/idle timestamps, `_mark_activity`, `emit` and the idle dispatch into the shared `ConversationHandler` – one source of truth that can't drift, so the inactivity timeout (and any future idle change) is made once. Each backend only provides two hooks for its real differences: `_is_connected` (connection vs session) and `_idle_behavior_ready` (the response-in-progress guard the realtime base needs and Gemini doesn't). The idle threshold is standardised to 180s for all backends (Gemini was 15s) so behavior is consistent and tuned in one place, and the activity clock to a single `time.monotonic()` source (Gemini compared `monotonic()` against an asyncio-loop timestamp, which matched only by coincidence)
- Typed tool specs with a `ToolSpec` TypedDict instead of `dict[str, Any]`: the shape is now checked at type-check time, which made the runtime "is this a valid spec" checks dead, so they're removed
- Renamed the obscure `bg_tool`, which named two different objects, to `background_tool` (the running handle) and `completed_tool` (the finished-tool notification) so the name tells you which one it is

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
