### PR TITLE
Add tool selection to the custom personality creation modal

### DIFF
--- a/src/reachy_mini_conversation_app/static/js/components/profile-modal.js
+++ b/src/reachy_mini_conversation_app/static/js/components/profile-modal.js
@@ -1,17 +1,20 @@
-/** Modal to collect name + instructions for a new custom personality. Returns { name, instructions } or null. */
+/** Modal to collect name + instructions + tools for a new custom personality. Returns { name, instructions, tools } or null. */
 
 import { h } from "../ui.js";
 
 const NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 /**
- * @param {{ signal?: AbortSignal }} [options]
- * @returns {Promise<{ name: string, instructions: string }|null>}
+ * @param {{ availableTools?: string[], signal?: AbortSignal }} [options]
+ * @returns {Promise<{ name: string, instructions: string, tools: string[] }|null>}
  */
-export function openCustomProfileModal({ signal } = {}) {
+export function openCustomProfileModal({ availableTools = [], signal } = {}) {
+  // A new personality starts from the available tool palette, all enabled; the user unchecks what it shouldn't have.
+  const toolChoices = [...availableTools].sort();
+
   return new Promise((resolve) => {
     const overlay = buildOverlay();
-    const dialog = buildDialog();
+    const dialog = buildDialog(toolChoices);
     overlay.appendChild(dialog);
     document.body.appendChild(overlay);
 
@@ -85,7 +88,8 @@ export function openCustomProfileModal({ signal } = {}) {
       }
       if (!instructions) return showError(errorBox, "Please write some instructions.");
 
-      close({ name, instructions });
+      const tools = Array.from(dialog.querySelectorAll('input[name="tool"]:checked')).map((el) => el.value);
+      close({ name, instructions, tools });
     });
   });
 }
@@ -97,7 +101,7 @@ function buildOverlay() {
   });
 }
 
-function buildDialog() {
+function buildDialog(toolChoices) {
   return h(
     "div",
     {
@@ -113,7 +117,7 @@ function buildDialog() {
       h(
         "p",
         { class: "modal__subtitle" },
-        "Define how Reachy should behave. The full standard tool set (dance, emotions, head tracking, ...) will be enabled by default."
+        "Define how Reachy should behave and which tools it can use."
       )
     ),
     h(
@@ -147,12 +151,34 @@ function buildDialog() {
           class: "modal__textarea",
         })
       ),
+      buildToolsField(toolChoices),
       h("p", { class: "modal__error", role: "alert", "aria-live": "polite" }),
       h(
         "div",
         { class: "modal__actions" },
         h("button", { type: "button", class: "btn btn--ghost", "data-action": "cancel" }, "Cancel"),
         h("button", { type: "submit", class: "btn btn--primary" }, "Create & start")
+      )
+    )
+  );
+}
+
+/** Render the tool checklist; every available tool is pre-checked. */
+function buildToolsField(toolChoices) {
+  return h(
+    "fieldset",
+    { class: "modal__field modal__tools" },
+    h("legend", { class: "modal__label" }, "Tools"),
+    h(
+      "div",
+      { class: "modal__tools-grid" },
+      ...toolChoices.map((tool) =>
+        h(
+          "label",
+          { class: "modal__tool" },
+          h("input", { type: "checkbox", name: "tool", value: tool, checked: "checked" }),
+          h("span", null, tool)
+        )
       )
     )
   );

--- a/src/reachy_mini_conversation_app/static/js/views/home.js
+++ b/src/reachy_mini_conversation_app/static/js/views/home.js
@@ -88,18 +88,31 @@ export async function mountHomeView({ outlet, signal, navigate }) {
   }
 
   async function handleCustomClick() {
-    const created = await openCustomProfileModal({ signal });
+    // Load the available tool palette so the modal can offer a checklist.
+    let defaults;
+    try {
+      defaults = await loadPersonality(BUILT_IN_DEFAULT_OPTION);
+    } catch (error) {
+      if (signal.aborted) return;
+      status.textContent = `Could not load tools: ${describeError(error)}`;
+      status.classList.add("is-error");
+      return;
+    }
+    if (signal.aborted) return;
+
+    const created = await openCustomProfileModal({
+      availableTools: defaults?.available_tools || [],
+      signal,
+    });
     if (!created || signal.aborted) return;
     status.classList.remove("is-warning", "is-error");
     status.textContent = `Saving "${created.name}"…`;
     let newName;
     try {
-      // Custom profiles start with the built-in default profile's tool set.
-      const defaults = await loadPersonality(BUILT_IN_DEFAULT_OPTION);
       const saveResult = await savePersonality({
         name: created.name,
         instructions: created.instructions,
-        tools_text: defaults?.tools_text || "",
+        tools_text: created.tools.join("\n"),
         voice: "", // falls back to backend default; user can change in Settings
       });
       if (signal.aborted) return;

--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -775,6 +775,8 @@ button {
 
 .modal {
   width: min(560px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
   background: var(--bg-elev);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-lg);
@@ -856,6 +858,40 @@ button {
   justify-content: flex-end;
   gap: 10px;
   margin-top: 4px;
+}
+
+/* Tool checklist (personality creation/editing) */
+.modal__tools {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0; /* let the grid shrink inside the flex form */
+}
+
+.modal__tools-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 16px;
+  margin-top: 6px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.modal__tool {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.modal__tool input {
+  accent-color: var(--accent);
 }
 
 /* 8. Conversation orb


### PR DESCRIPTION
Restore per-personality tool selection that was lost when Gradio was replaced by the standalone UI (#356). 

The create-personality modal now shows a checklist of the available tools.

Changes are UI only.