### PR TITLE
Fix/Edit personality (prompt and tools) on the new UI 

### DIFF
--- a/src/reachy_mini_conversation_app/static/js/components/profile-modal.js
+++ b/src/reachy_mini_conversation_app/static/js/components/profile-modal.js
@@ -1,25 +1,41 @@
-/** Modal to collect name + instructions + tools for a new custom personality. Returns { name, instructions, tools } or null. */
+/** Modal to create or edit a personality (name + instructions + tools). Returns { name, instructions, tools } or null. */
 
 import { h } from "../ui.js";
 
 const NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 /**
- * @param {{ availableTools?: string[], signal?: AbortSignal }} [options]
+ * @param {{
+ *   mode?: "create" | "edit",
+ *   initial?: { name?: string, instructions?: string, enabledTools?: string[] },
+ *   availableTools?: string[],
+ *   signal?: AbortSignal,
+ * }} [options]
  * @returns {Promise<{ name: string, instructions: string, tools: string[] }|null>}
  */
-export function openCustomProfileModal({ availableTools = [], signal } = {}) {
-  // A new personality starts from the available tool palette, all enabled; the user unchecks what it shouldn't have.
-  const toolChoices = [...availableTools].sort();
+export function openProfileModal({ mode = "create", initial = {}, availableTools = [], signal } = {}) {
+  const isEdit = mode === "edit";
+  const enabledTools = initial.enabledTools || [];
+  // Create starts from the available palette with everything enabled. Edit shows the union of
+  // available and currently-enabled tools (so tools that aren't importable modules, e.g. a profile's
+  // own files, still appear pre-checked) and never silently drops an enabled tool on save.
+  const enabledSet = new Set(enabledTools);
+  const toolChoices = isEdit
+    ? [...new Set([...availableTools, ...enabledTools])].sort()
+    : [...availableTools].sort();
+  const isToolChecked = isEdit ? (tool) => enabledSet.has(tool) : () => true;
 
   return new Promise((resolve) => {
     const overlay = buildOverlay();
-    const dialog = buildDialog(toolChoices);
+    const dialog = buildDialog({ isEdit, initial, toolChoices, isToolChecked });
     overlay.appendChild(dialog);
     document.body.appendChild(overlay);
 
-    // Focus the first text input on next paint so the user can type immediately.
-    requestAnimationFrame(() => dialog.querySelector("input")?.focus());
+    // Focus the first editable field on next paint (the name in create mode, the textarea in edit).
+    requestAnimationFrame(() => {
+      const target = isEdit ? dialog.querySelector("textarea") : dialog.querySelector("input");
+      target?.focus();
+    });
 
     function close(value) {
       cleanup();
@@ -79,12 +95,15 @@ export function openCustomProfileModal({ availableTools = [], signal } = {}) {
     dialog.querySelector("form").addEventListener("submit", (event) => {
       event.preventDefault();
       const formData = new FormData(event.target);
-      const name = String(formData.get("name") || "").trim();
+      // The name is locked in edit mode (renaming would mean a new profile dir), so keep the original.
+      const name = isEdit ? String(initial.name || "") : String(formData.get("name") || "").trim();
       const instructions = String(formData.get("instructions") || "").trim();
 
-      if (!name) return showError(errorBox, "Please pick a name.");
-      if (!NAME_PATTERN.test(name)) {
-        return showError(errorBox, "Use only letters, numbers, dashes or underscores.");
+      if (!isEdit) {
+        if (!name) return showError(errorBox, "Please pick a name.");
+        if (!NAME_PATTERN.test(name)) {
+          return showError(errorBox, "Use only letters, numbers, dashes or underscores.");
+        }
       }
       if (!instructions) return showError(errorBox, "Please write some instructions.");
 
@@ -101,7 +120,7 @@ function buildOverlay() {
   });
 }
 
-function buildDialog(toolChoices) {
+function buildDialog({ isEdit, initial, toolChoices, isToolChecked }) {
   return h(
     "div",
     {
@@ -113,7 +132,11 @@ function buildDialog(toolChoices) {
     h(
       "header",
       { class: "modal__header" },
-      h("h2", { id: "custom-profile-title", class: "modal__title" }, "Create a custom personality"),
+      h(
+        "h2",
+        { id: "custom-profile-title", class: "modal__title" },
+        isEdit ? `Edit ${initial.name || "personality"}` : "Create a custom personality"
+      ),
       h(
         "p",
         { class: "modal__subtitle" },
@@ -130,41 +153,47 @@ function buildDialog(toolChoices) {
         h("input", {
           type: "text",
           name: "name",
-          required: "required",
+          required: isEdit ? null : "required",
+          readonly: isEdit ? "readonly" : null,
           autocomplete: "off",
           spellcheck: "false",
           placeholder: "e.g. zen_master",
           pattern: "[a-zA-Z0-9_-]+",
-          class: "modal__input",
+          value: isEdit ? initial.name || "" : null,
+          class: ["modal__input", isEdit && "is-readonly"],
         })
       ),
       h(
         "label",
         { class: "modal__field" },
         h("span", { class: "modal__label" }, "Instructions"),
-        h("textarea", {
-          name: "instructions",
-          required: "required",
-          rows: "8",
-          placeholder:
-            "You are a calm, slow-speaking zen guide. Pause between sentences. Encourage the user to breathe.",
-          class: "modal__textarea",
-        })
+        h(
+          "textarea",
+          {
+            name: "instructions",
+            required: "required",
+            rows: "8",
+            placeholder:
+              "You are a calm, slow-speaking zen guide. Pause between sentences. Encourage the user to breathe.",
+            class: "modal__textarea",
+          },
+          initial.instructions || ""
+        )
       ),
-      buildToolsField(toolChoices),
+      buildToolsField(toolChoices, isToolChecked),
       h("p", { class: "modal__error", role: "alert", "aria-live": "polite" }),
       h(
         "div",
         { class: "modal__actions" },
         h("button", { type: "button", class: "btn btn--ghost", "data-action": "cancel" }, "Cancel"),
-        h("button", { type: "submit", class: "btn btn--primary" }, "Create & start")
+        h("button", { type: "submit", class: "btn btn--primary" }, isEdit ? "Save changes" : "Create & start")
       )
     )
   );
 }
 
-/** Render the tool checklist; every available tool is pre-checked. */
-function buildToolsField(toolChoices) {
+/** Render the tool checklist; isToolChecked decides each box's initial state. */
+function buildToolsField(toolChoices, isToolChecked) {
   return h(
     "fieldset",
     { class: "modal__field modal__tools" },
@@ -176,7 +205,7 @@ function buildToolsField(toolChoices) {
         h(
           "label",
           { class: "modal__tool" },
-          h("input", { type: "checkbox", name: "tool", value: tool, checked: "checked" }),
+          h("input", { type: "checkbox", name: "tool", value: tool, checked: isToolChecked(tool) ? "checked" : null }),
           h("span", null, tool)
         )
       )

--- a/src/reachy_mini_conversation_app/static/js/views/home.js
+++ b/src/reachy_mini_conversation_app/static/js/views/home.js
@@ -15,7 +15,7 @@ import {
   avatarFor,
 } from "../constants.js";
 import { $, h, prettifyProfileName } from "../ui.js";
-import { openCustomProfileModal } from "../components/profile-modal.js";
+import { openProfileModal } from "../components/profile-modal.js";
 import { setPendingApply } from "../pending-apply.js";
 import { setPersonality } from "../personality-badge.js";
 
@@ -61,12 +61,15 @@ export async function mountHomeView({ outlet, signal, navigate }) {
 
   grid.replaceChildren();
   for (const name of choices) {
+    const disabled = Boolean(lockedTo) && name !== lockedTo;
+    const editable = name.startsWith("user_personalities/") && !disabled;
     grid.appendChild(
       buildPersonalityCard({
         name,
         isActive: name === current,
-        disabled: Boolean(lockedTo) && name !== lockedTo,
+        disabled,
         onSelect: () => handleSelection(name),
+        onEdit: editable ? () => handleEditClick(name) : null,
       })
     );
   }
@@ -100,7 +103,8 @@ export async function mountHomeView({ outlet, signal, navigate }) {
     }
     if (signal.aborted) return;
 
-    const created = await openCustomProfileModal({
+    const created = await openProfileModal({
+      mode: "create",
       availableTools: defaults?.available_tools || [],
       signal,
     });
@@ -127,16 +131,68 @@ export async function mountHomeView({ outlet, signal, navigate }) {
     setPendingApply({ name: newName, promise: applyPersonality(newName, { persist: false }) });
     navigate(ROUTES.TALK);
   }
+
+  async function handleEditClick(name) {
+    status.classList.remove("is-warning", "is-error");
+    let data;
+    try {
+      data = await loadPersonality(name);
+    } catch (error) {
+      if (signal.aborted) return;
+      status.textContent = `Could not load "${prettifyProfileName(name)}": ${describeError(error)}`;
+      status.classList.add("is-error");
+      return;
+    }
+    if (signal.aborted) return;
+
+    const edited = await openProfileModal({
+      mode: "edit",
+      availableTools: data?.available_tools || [],
+      initial: {
+        name,
+        instructions: data?.instructions || "",
+        enabledTools: data?.enabled_tools || [],
+      },
+      signal,
+    });
+    if (!edited || signal.aborted) return;
+
+    status.textContent = `Saving "${prettifyProfileName(name)}"…`;
+    try {
+      await savePersonality({
+        // Strip the prefix: the save endpoint always writes under user_personalities/<name>.
+        name: stripUserPrefix(name),
+        instructions: edited.instructions,
+        tools_text: edited.tools.join("\n"),
+        voice: data?.voice || "", // keep the profile's existing voice
+      });
+    } catch (error) {
+      if (signal.aborted) return;
+      status.textContent = `Failed to save: ${describeError(error)}`;
+      status.classList.add("is-error");
+      return;
+    }
+    if (signal.aborted) return;
+
+    // Editing the live personality restarts the conversation and reloads the tool registry;
+    // otherwise the changes take effect the next time it is selected.
+    if (name === current) {
+      setPersonality(name);
+      setPendingApply({ name, promise: applyPersonality(name, { persist: false }) });
+      navigate(ROUTES.TALK);
+    } else {
+      status.textContent = `Saved "${prettifyProfileName(name)}". It will apply next time you select it.`;
+    }
+  }
 }
 
-function buildPersonalityCard({ name, isActive, disabled, onSelect }) {
+function buildPersonalityCard({ name, isActive, disabled, onSelect, onEdit }) {
   const hasAvatar = Object.prototype.hasOwnProperty.call(AVATAR_BY_PROFILE, stripUserPrefix(name));
-  return h(
+  const card = h(
     "button",
     {
       type: "button",
       class: ["personality-card", isActive && "is-active", disabled && "is-disabled"],
-      role: "listitem",
       disabled: disabled ? "disabled" : null,
       "aria-pressed": isActive ? "true" : "false",
       "aria-label": `Use personality ${prettifyProfileName(name)}`,
@@ -157,6 +213,28 @@ function buildPersonalityCard({ name, isActive, disabled, onSelect }) {
     h("span", { class: "personality-card__name" }, prettifyProfileName(name)),
     isActive && checkBadge()
   );
+  // Wrap so the edit button is a sibling, not a nested <button> inside the card button.
+  return h(
+    "div",
+    { class: "personality-card-slot", role: "listitem" },
+    card,
+    onEdit ? buildEditButton({ name, onEdit }) : null
+  );
+}
+
+/** Small overlay button to edit a user personality, anchored to the card corner. */
+function buildEditButton({ name, onEdit }) {
+  return h("button", {
+    type: "button",
+    class: "personality-card__edit",
+    "aria-label": `Edit personality ${prettifyProfileName(name)}`,
+    onClick: onEdit,
+    html: `
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 20h9"/>
+        <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/>
+      </svg>`,
+  });
 }
 
 function checkBadge() {

--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -438,6 +438,53 @@ button {
   gap: 18px;
 }
 
+/* Slot wraps a card button + its (optional) edit button so the edit control
+   is a sibling, never a <button> nested inside the card button. */
+.personality-card-slot {
+  position: relative;
+  display: flex;
+}
+
+.personality-card-slot .personality-card {
+  flex: 1;
+  width: 100%;
+}
+
+.personality-card__edit {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: var(--bg-soft);
+  color: var(--text-muted);
+  box-shadow: inset 0 0 0 1px var(--border);
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity var(--transition-fast), background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.personality-card-slot:hover .personality-card__edit,
+.personality-card__edit:focus-visible {
+  opacity: 1;
+}
+
+.personality-card__edit:hover {
+  background: var(--bg-elev-hover);
+  color: var(--text);
+}
+
+.personality-card__edit svg {
+  width: 15px;
+  height: 15px;
+}
+
 .personality-card {
   position: relative;
   display: flex;
@@ -839,6 +886,11 @@ button {
   outline: none;
   border-color: var(--accent);
   background: var(--bg-elev);
+}
+
+.modal__input.is-readonly {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 .modal__error {


### PR DESCRIPTION
Following the new UI replacing Gradio, we lost the possibility of editing profiles (both tools and prompts)

We re-introduce this :

- custom personality avatars now have a small edit icons in the top right corner (see image below)
- the edit allows to tweak personality and tool choices
- validating restarts the conversation

This is a UI change only.

<img width="224" height="233" alt="Capture d’écran 2026-06-22 à 17 27 55" src="https://github.com/user-attachments/assets/d04272cd-2c67-44f3-a963-c4efe735125f" />

<img width="592" height="707" alt="Capture d’écran 2026-06-22 à 17 28 07" src="https://github.com/user-attachments/assets/2f8ead96-a2d2-4426-97c7-e452a2370882" />
