### PR TITLE
[codex] Avoid restarting unchanged personality

### DIFF
--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -178,7 +178,6 @@ def mount_personality_routes(
                 "ok": True,
                 "status": "Personality unchanged.",
                 "startup": persisted_choice,
-                "changed": False,
             }
 
         loop = get_loop()
@@ -203,7 +202,7 @@ def mount_personality_routes(
                     persisted_choice = _startup_choice()
                 except Exception as e:
                     logger.warning("Failed to persist startup personality: %s", e)
-            return {"ok": True, "status": status, "startup": persisted_choice, "changed": True}
+            return {"ok": True, "status": status, "startup": persisted_choice}
         except Exception as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)  # type: ignore
 

--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -162,15 +162,15 @@ def mount_personality_routes(
                 {"ok": False, "error": "profile_locked", "locked_to": LOCKED_PROFILE},
                 status_code=403,
             )  # type: ignore
-        sel_name = payload.name or DEFAULT_OPTION
-        persist_flag = bool(payload.persist)
+        selected_name = payload.name or DEFAULT_OPTION
+        persist = bool(payload.persist)
         persisted_choice = _startup_choice()
 
-        if sel_name == _current_choice():
-            if persist_flag and persist_personality is not None:
+        if selected_name == _current_choice():
+            if persist and persist_personality is not None:
                 try:
                     voice_override = _voice_override()
-                    persist_personality(None if sel_name == DEFAULT_OPTION else sel_name, voice_override)
+                    persist_personality(None if selected_name == DEFAULT_OPTION else selected_name, voice_override)
                     persisted_choice = _startup_choice()
                 except Exception as e:
                     logger.warning("Failed to persist startup personality: %s", e)
@@ -185,20 +185,20 @@ def mount_personality_routes(
             return JSONResponse({"ok": False, "error": "loop_unavailable"}, status_code=503)  # type: ignore
 
         async def _do_apply() -> tuple[str, Optional[str]]:
-            sel = None if sel_name == DEFAULT_OPTION else sel_name
+            profile = None if selected_name == DEFAULT_OPTION else selected_name
             if apply_personality is not None:
-                status = await apply_personality(sel)
+                status = await apply_personality(profile)
             else:
-                status = await handler.apply_personality(sel)
+                status = await handler.apply_personality(profile)
             return status, _voice_override()
 
         try:
-            logger.info("apply: requested name=%r", sel_name)
+            logger.info("apply: requested name=%r", selected_name)
             fut = asyncio.run_coroutine_threadsafe(_do_apply(), loop)
             status, voice_override = fut.result(timeout=10)
-            if persist_flag and persist_personality is not None:
+            if persist and persist_personality is not None:
                 try:
-                    persist_personality(None if sel_name == DEFAULT_OPTION else sel_name, voice_override)
+                    persist_personality(None if selected_name == DEFAULT_OPTION else selected_name, voice_override)
                     persisted_choice = _startup_choice()
                 except Exception as e:
                     logger.warning("Failed to persist startup personality: %s", e)

--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -82,6 +82,10 @@ def mount_personality_routes(
         except Exception:
             return DEFAULT_OPTION
 
+    def _voice_override() -> Optional[str]:
+        current_voice_callback = get_current_voice or getattr(handler, "get_current_voice", None)
+        return current_voice_callback() if callable(current_voice_callback) else None
+
     @app.get("/personalities")
     def _list() -> dict:  # type: ignore
         choices = [DEFAULT_OPTION, *list_personalities()]
@@ -158,12 +162,28 @@ def mount_personality_routes(
                 {"ok": False, "error": "profile_locked", "locked_to": LOCKED_PROFILE},
                 status_code=403,
             )  # type: ignore
+        sel_name = payload.name or DEFAULT_OPTION
+        persist_flag = bool(payload.persist)
+        persisted_choice = _startup_choice()
+
+        if sel_name == _current_choice():
+            if persist_flag and persist_personality is not None:
+                try:
+                    voice_override = _voice_override()
+                    persist_personality(None if sel_name == DEFAULT_OPTION else sel_name, voice_override)
+                    persisted_choice = _startup_choice()
+                except Exception as e:
+                    logger.warning("Failed to persist startup personality: %s", e)
+            return {
+                "ok": True,
+                "status": "Personality unchanged.",
+                "startup": persisted_choice,
+                "changed": False,
+            }
+
         loop = get_loop()
         if loop is None:
             return JSONResponse({"ok": False, "error": "loop_unavailable"}, status_code=503)  # type: ignore
-
-        sel_name = payload.name or DEFAULT_OPTION
-        persist_flag = bool(payload.persist)
 
         async def _do_apply() -> tuple[str, Optional[str]]:
             sel = None if sel_name == DEFAULT_OPTION else sel_name
@@ -171,22 +191,19 @@ def mount_personality_routes(
                 status = await apply_personality(sel)
             else:
                 status = await handler.apply_personality(sel)
-            current_voice_callback = get_current_voice or getattr(handler, "get_current_voice", None)
-            voice_override = current_voice_callback() if callable(current_voice_callback) else None
-            return status, voice_override
+            return status, _voice_override()
 
         try:
             logger.info("apply: requested name=%r", sel_name)
             fut = asyncio.run_coroutine_threadsafe(_do_apply(), loop)
             status, voice_override = fut.result(timeout=10)
-            persisted_choice = _startup_choice()
             if persist_flag and persist_personality is not None:
                 try:
                     persist_personality(None if sel_name == DEFAULT_OPTION else sel_name, voice_override)
                     persisted_choice = _startup_choice()
                 except Exception as e:
                     logger.warning("Failed to persist startup personality: %s", e)
-            return {"ok": True, "status": status, "startup": persisted_choice}
+            return {"ok": True, "status": status, "startup": persisted_choice, "changed": True}
         except Exception as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)  # type: ignore
 

--- a/src/reachy_mini_conversation_app/static/js/views/home.js
+++ b/src/reachy_mini_conversation_app/static/js/views/home.js
@@ -78,6 +78,12 @@ export async function mountHomeView({ outlet, signal, navigate }) {
   }
 
   function handleSelection(name) {
+    if (name === current) {
+      setPersonality(name);
+      setPendingApply(null);
+      navigate(ROUTES.TALK);
+      return;
+    }
     // Optimistic header update so the badge already reads the chosen
     // personality while the apply request is still in flight.
     setPersonality(name);

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -730,6 +730,42 @@ def test_personality_routes_persist_startup_with_voice_override() -> None:
         loop.close()
 
 
+def test_personality_routes_apply_same_profile_does_not_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-applying the active personality should be a no-op for the realtime handler."""
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "sorry_bro")
+    app = FastAPI()
+    handler = MagicMock()
+    handler.apply_personality = AsyncMock(return_value="should not be called")
+    handler.get_current_voice = MagicMock(return_value="shimmer")
+    mount_personality_routes(app, handler, lambda: None)
+
+    response = TestClient(app).post("/personalities/apply", json={"name": "sorry_bro"})
+
+    assert response.status_code == 200
+    assert response.json()["changed"] is False
+    assert response.json()["status"] == "Personality unchanged."
+    handler.apply_personality.assert_not_awaited()
+    handler.get_current_voice.assert_not_called()
+
+
+def test_personality_routes_persist_same_profile_without_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Saving the active personality as startup should not restart the conversation."""
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "sorry_bro")
+    app = FastAPI()
+    handler = MagicMock()
+    handler.apply_personality = AsyncMock(return_value="should not be called")
+    handler.get_current_voice = MagicMock(return_value="shimmer")
+    persist_personality = MagicMock()
+    mount_personality_routes(app, handler, lambda: None, persist_personality=persist_personality)
+
+    response = TestClient(app).post("/personalities/apply", json={"name": "sorry_bro", "persist": True})
+
+    assert response.status_code == 200
+    assert response.json()["changed"] is False
+    handler.apply_personality.assert_not_awaited()
+    persist_personality.assert_called_once_with("sorry_bro", "shimmer")
+
+
 def test_headless_personality_routes_can_use_stream_callbacks() -> None:
     """Headless personality routes can delegate apply/restart ownership to LocalStream."""
     app = FastAPI()

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -742,28 +742,9 @@ def test_personality_routes_apply_same_profile_does_not_restart(monkeypatch: pyt
     response = TestClient(app).post("/personalities/apply", json={"name": "sorry_bro"})
 
     assert response.status_code == 200
-    assert response.json()["changed"] is False
     assert response.json()["status"] == "Personality unchanged."
     handler.apply_personality.assert_not_awaited()
     handler.get_current_voice.assert_not_called()
-
-
-def test_personality_routes_persist_same_profile_without_restart(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Saving the active personality as startup should not restart the conversation."""
-    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "sorry_bro")
-    app = FastAPI()
-    handler = MagicMock()
-    handler.apply_personality = AsyncMock(return_value="should not be called")
-    handler.get_current_voice = MagicMock(return_value="shimmer")
-    persist_personality = MagicMock()
-    mount_personality_routes(app, handler, lambda: None, persist_personality=persist_personality)
-
-    response = TestClient(app).post("/personalities/apply", json={"name": "sorry_bro", "persist": True})
-
-    assert response.status_code == 200
-    assert response.json()["changed"] is False
-    handler.apply_personality.assert_not_awaited()
-    persist_personality.assert_called_once_with("sorry_bro", "shimmer")
 
 
 def test_headless_personality_routes_can_use_stream_callbacks() -> None:


### PR DESCRIPTION
## Summary

- Skip the personality apply request in the UI when the selected card is already active.
- Make `/personalities/apply` idempotent for the active profile so direct API calls do not restart the realtime handler.
- Add console route regressions for same-profile apply and same-profile startup persistence.

## Root Cause

Selecting the active personality still sent a personality apply request. The backend always forwarded apply requests to the realtime handler, which rebuilt or restarted the active conversation session even though the profile had not changed.

## Impact

Users can browse personality selection and return to the current chat without ending or restarting the conversation, unless they actually choose a different personality.

## Validation

- `.venv/bin/pytest tests/test_console.py`
