### PR TITLE
sync README, PR template, and architecture diagram

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,9 +20,8 @@
 <details>
 <summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>
 
-- [ ] Headless mode (default)
-- [ ] Gradio UI (`--gradio`)
-- [ ] Simulation (`--gradio` required)
+- [ ] Console mode (default)
+- [ ] Web UI (`--ui`)
 </details>
 
 <details>
@@ -32,7 +31,6 @@
 - [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
 - [ ] Camera pipeline (with/without `--no-camera`)
 - [ ] Movement manager (dances, emotions, head motion)
-- [ ] Head wobble
 - [ ] Profiles or custom tools
 </details>
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Copy `.env.example` to `.env` when you want to switch backends, provide API keys
 | `HF_HOME` | Cache directory for local Hugging Face downloads (only used with `--local-vision` flag, defaults to `./cache`). |
 | `HF_TOKEN` | Optional token for Hugging Face access (for gated/private assets). |
 | `LOCAL_VISION_MODEL` | Hugging Face model path for local vision processing (only used with `--local-vision` flag, defaults to `HuggingFaceTB/SmolVLM2-2.2B-Instruct`). |
+| `REACHY_MINI_APP_TIMEOUT_MINUTES` | Minutes of inactivity before the app closes. Defaults to `1440` (one day); set to `0` to disable. |
 
 ### Hugging Face Connection Modes
 
@@ -180,7 +181,7 @@ HF_REALTIME_CONNECTION_MODE=local
 HF_REALTIME_WS_URL=ws://127.0.0.1:8765/v1/realtime
 ```
 
-When using the headless settings UI, selecting `Hugging Face` lets you choose either the built-in server or a local `host:port` target. The UI writes `HF_REALTIME_CONNECTION_MODE` for you, and the local path writes `HF_REALTIME_WS_URL` with a default of `localhost:8765`.
+When using the web UI's Settings view, selecting `Hugging Face` lets you choose either the built-in server or a local `host:port` target. The UI writes `HF_REALTIME_CONNECTION_MODE` for you, and the local path writes `HF_REALTIME_WS_URL` with a default of `localhost:8765`.
 
 ## Running the app
 

--- a/docs/assets/conversation_app_arch.svg
+++ b/docs/assets/conversation_app_arch.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2820dbe4f3564bb25f5f8810efcc5bac94d4167b6acddf5472e04d4ee99b236d
-size 123954
+oid sha256:749ae28a8684944e1cf02d4df587eab87ed25767e1d1311d95b731fd51f3e619
+size 125254

--- a/docs/scheme.mmd
+++ b/docs/scheme.mmd
@@ -7,7 +7,7 @@ config:
 flowchart TB
     User(["<span style='font-size:16px;font-weight:bold;'>User</span><br><span style='font-size:13px;color:#01579b;'>Person interacting with system</span>"]) 
       -- audio stream --> 
-    UI@{ label: "<span style='font-size:16px;font-weight:bold;'>UI Layer</span><br><span style='font-size:13px;color:#0277bd;'>Gradio/Console</span>" }
+    UI@{ label: "<span style='font-size:16px;font-weight:bold;'>UI Layer</span><br><span style='font-size:13px;color:#0277bd;'>Web UI / Console</span>" }
 
     UI -- audio stream --> 
     Backend@{ label: "<span style='font-size:16px;font-weight:bold;'>Realtime Backend</span><br><span style='font-size:12px; color:#7b1fa2;'>Audio + Tool Calls + Vision</span>" }

--- a/src/reachy_mini_conversation_app/utils.py
+++ b/src/reachy_mini_conversation_app/utils.py
@@ -39,7 +39,10 @@ def parse_args() -> tuple[argparse.Namespace, list]:  # type: ignore
         help="Use local vision model instead of the selected realtime backend vision",
     )
     parser.add_argument(
-        "--ui", default=False, action="store_true", help="Serve the modern web UI at http://localhost:7860"
+        "--ui",
+        default=False,
+        action="store_true",
+        help="Serve the web UI at http://127.0.0.1:7860/, in addition to console mode",
     )
     parser.add_argument("--debug", default=False, action="store_true", help="Enable debug logging")
     parser.add_argument(


### PR DESCRIPTION
## Summary
Cleans up documentation that the Gradio -> web UI migration left stale, plus a couple of gaps from later PRs.
- replace leftover `--gradio` / Gradio UI references with the current `--ui` web UI across the README, PR template, and architecture diagram.
- drop the obsolete "simulation" and "head wobble" PR-template checklist items
- document `REACHY_MINI_APP_TIMEOUT_MINUTES` in the config table.
- fix the "headless settings UI" wording to the web UI's Settings view, and align the `--ui` help text with the README.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Headless mode (default)
- [ ] Gradio UI (`--gradio`)
- [ ] Simulation (`--gradio` required)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Head wobble
- [ ] Profiles or custom tools
</details>
