### PR TITLE
Mount web API before robot init so desktop app routes load

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -764,6 +764,21 @@ class LocalStream:
                 }
             )
 
+        try:
+            mount_personality_routes(
+                self._settings_app,
+                self.handler,
+                lambda: self._asyncio_loop,
+                persist_personality=self._persist_personality,
+                get_persisted_personality=self._read_persisted_personality,
+                apply_personality=self.apply_personality,
+                get_available_voices=self.get_available_voices,
+                get_current_voice=self.get_current_voice,
+                change_voice=self.change_voice,
+            )
+        except Exception:
+            logger.exception("Failed to mount personality routes; the personality UI will be unavailable")
+
         self._settings_initialized = True
 
     async def _run_handler_startup_loop(self) -> None:
@@ -895,22 +910,6 @@ class LocalStream:
             # Capture loop for cross-thread personality actions
             loop = asyncio.get_running_loop()
             self._asyncio_loop = loop  # type: ignore[assignment]
-            # Mount personality routes now that loop and handler are available
-            try:
-                if self._settings_app is not None:
-                    mount_personality_routes(
-                        self._settings_app,
-                        self.handler,
-                        lambda: self._asyncio_loop,
-                        persist_personality=self._persist_personality,
-                        get_persisted_personality=self._read_persisted_personality,
-                        apply_personality=self.apply_personality,
-                        get_available_voices=self.get_available_voices,
-                        get_current_voice=self.get_current_voice,
-                        change_voice=self.change_voice,
-                    )
-            except Exception:
-                logger.exception("Failed to mount personality routes; the personality UI will be unavailable")
             self._tasks = [
                 asyncio.create_task(self._run_handler_startup_loop(), name="realtime-handler"),
                 asyncio.create_task(self.record_loop(), name="stream-record-loop"),

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -259,11 +259,12 @@ def run(
         startup_voice=startup_settings.voice,
     )
 
+    # Mount the API before the robot init below, which can block; launch() repeats this as a no-op.
+    if effective_settings_app is not None:
+        stream_manager._init_settings_ui_if_needed()
+
     if args.ui and settings_app is None and effective_settings_app is not None:
         import uvicorn
-
-        # Routes must exist before uvicorn starts serving, launch() repeats this as a no-op.
-        stream_manager._init_settings_ui_if_needed()
 
         own_ui_server = uvicorn.Server(
             uvicorn.Config(effective_settings_app, host="0.0.0.0", port=7860, log_level="warning")

--- a/src/reachy_mini_conversation_app/tools/play_emotion.py
+++ b/src/reachy_mini_conversation_app/tools/play_emotion.py
@@ -2,24 +2,24 @@ import re
 import random
 import logging
 import unicodedata
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
 
 
+if TYPE_CHECKING:
+    from reachy_mini.motion.recorded_move import RecordedMoves
+
+
 logger = logging.getLogger(__name__)
 
-# Initialize emotion library
 try:
     from reachy_mini.motion.recorded_move import RecordedMoves
     from reachy_mini_conversation_app.dance_emotion_moves import EmotionQueueMove
 
-    # Note: huggingface_hub automatically reads HF_TOKEN from environment variables
-    RECORDED_MOVES = RecordedMoves("pollen-robotics/reachy-mini-emotions-library")
     EMOTION_AVAILABLE = True
 except Exception as e:
     logger.warning(f"Emotion library not available: {e}")
-    RECORDED_MOVES = None
     EMOTION_AVAILABLE = False
 
 
@@ -231,25 +231,6 @@ def random_curated_emotion(available_emotions: list[str]) -> str:
     return random.choice(available_emotions)
 
 
-def get_available_emotions_and_descriptions() -> str:
-    """Get formatted list of available emotions with descriptions."""
-    if not EMOTION_AVAILABLE:
-        return "Emotions not available"
-
-    try:
-        emotion_names = RECORDED_MOVES.list_moves()
-        if not emotion_names:
-            return "No emotions currently available"
-
-        output = "Available emotions:\n"
-        for name in emotion_names:
-            description = RECORDED_MOVES.get(name).description
-            output += f" - {name}: {description}\n"
-        return output
-    except Exception as e:
-        return f"Error getting emotions: {e}"
-
-
 class PlayEmotion(Tool):
     """Play a pre-recorded emotion."""
 
@@ -271,6 +252,7 @@ class PlayEmotion(Tool):
         },
         "required": [],
     }
+    _library: "RecordedMoves | None" = None
 
     async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> Dict[str, Any]:
         """Play a pre-recorded emotion."""
@@ -282,7 +264,11 @@ class PlayEmotion(Tool):
         logger.info("Tool call: play_emotion emotion=%s", requested_emotion)
 
         try:
-            emotion_names = RECORDED_MOVES.list_moves()
+            if self._library is None:
+                # Constructing this downloads the dataset, so it must not run at import.
+                self._library = RecordedMoves("pollen-robotics/reachy-mini-emotions-library")
+            library = self._library
+            emotion_names = library.list_moves()
             if not emotion_names:
                 return {"error": "No emotions currently available"}
 
@@ -292,7 +278,7 @@ class PlayEmotion(Tool):
                 emotion_name = random_curated_emotion(emotion_names)
 
             movement_manager = deps.movement_manager
-            emotion_move = EmotionQueueMove(emotion_name, RECORDED_MOVES)
+            emotion_move = EmotionQueueMove(emotion_name, library)
             movement_manager.queue_move(emotion_move)
 
             return {"status": "queued", "emotion": emotion_name}

--- a/tests/tools/test_play_emotion.py
+++ b/tests/tools/test_play_emotion.py
@@ -176,13 +176,14 @@ async def test_play_emotion_queues_resolved_emotion(monkeypatch: pytest.MonkeyPa
             self.recorded_moves = recorded_moves
 
     monkeypatch.setattr(play_emotion_module, "EMOTION_AVAILABLE", True)
-    monkeypatch.setattr(play_emotion_module, "RECORDED_MOVES", FakeRecordedMoves())
     monkeypatch.setattr(play_emotion_module, "EmotionQueueMove", FakeEmotionQueueMove)
 
     movement_manager = MagicMock()
     deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=movement_manager)
 
-    result = await PlayEmotion()(deps, emotion="sad no")
+    tool = PlayEmotion()
+    monkeypatch.setattr(tool, "_library", FakeRecordedMoves())
+    result = await tool(deps, emotion="sad no")
 
     assert result == {"status": "queued", "emotion": "no_sad1"}
     queued_move = movement_manager.queue_move.call_args.args[0]
@@ -206,7 +207,6 @@ async def test_play_emotion_queues_random_for_unknown_emotion(
             self.recorded_moves = recorded_moves
 
     monkeypatch.setattr(play_emotion_module, "EMOTION_AVAILABLE", True)
-    monkeypatch.setattr(play_emotion_module, "RECORDED_MOVES", FakeRecordedMoves())
     monkeypatch.setattr(play_emotion_module, "EmotionQueueMove", FakeEmotionQueueMove)
 
     def fake_choice(emotion_names: list[str]) -> str:
@@ -219,8 +219,10 @@ async def test_play_emotion_queues_random_for_unknown_emotion(
     movement_manager = MagicMock()
     deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=movement_manager)
 
+    tool = PlayEmotion()
+    monkeypatch.setattr(tool, "_library", FakeRecordedMoves())
     with caplog.at_level(logging.INFO, logger=play_emotion_module.logger.name):
-        result = await PlayEmotion()(deps, emotion="contento")
+        result = await tool(deps, emotion="contento")
 
     assert result == {"status": "queued", "emotion": "confused1"}
     assert "play_emotion: 'contento' did not resolve; using random curated" in caplog.text


### PR DESCRIPTION
## Summary
On the desktop app the conversation app served its page but every API call 404'd, so the orb kept reconnecting, the mic toggle failed, and the voice selector was empty. This mounts the web API before the blocking robot init for the daemon path too (matching what `--ui` already does).

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>
