### PR TITLE
Show a calm connecting state at startup instead of red reconnecting

### DIFF
--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -136,12 +136,6 @@ def run(
     from reachy_mini_conversation_app.tools.core_tools import ToolDependencies, initialize_tools
     from reachy_mini_conversation_app.conversation_handler import ConversationHandler
 
-    try:
-        initialize_tools(instance_path=instance_path)
-    except Exception as e:
-        logger.error("Failed to initialize tools: %s", e)
-        sys.exit(1)
-
     if args.no_camera and args.head_tracker is not None:
         logger.warning("Head tracking disabled: --no-camera flag is set. Remove --no-camera to enable head tracking.")
 
@@ -259,7 +253,7 @@ def run(
         startup_voice=startup_settings.voice,
     )
 
-    # Mount the API before the robot init below, which can block; launch() repeats this as a no-op.
+    # The page is served immediately, so the API must be live before the slow startup work below.
     if effective_settings_app is not None:
         stream_manager._init_settings_ui_if_needed()
 
@@ -271,6 +265,12 @@ def run(
         )
         threading.Thread(target=own_ui_server.run, daemon=True, name="ui-server").start()
         logger.info("Web UI available at http://localhost:7860")
+
+    try:
+        initialize_tools(instance_path=instance_path)
+    except Exception as e:
+        logger.error("Failed to initialize tools: %s", e)
+        sys.exit(1)
 
     # Each async service → its own thread/loop
     movement_manager.start()

--- a/src/reachy_mini_conversation_app/static/js/views/talk.js
+++ b/src/reachy_mini_conversation_app/static/js/views/talk.js
@@ -16,11 +16,11 @@ const SSE_ENDPOINT = "/conversation_events";
 const CAPTION_BY_STATE = Object.freeze({
   [ORB_STATES.MUTED]: "Muted",
   [ORB_STATES.IDLE]: "Ready",
-  [ORB_STATES.CONNECTING]: "Connecting",
+  [ORB_STATES.CONNECTING]: "Connecting to the backend...",
   [ORB_STATES.LISTENING]: "Listening",
   [ORB_STATES.THINKING]: "Thinking",
   [ORB_STATES.SPEAKING]: "Speaking",
-  [ORB_STATES.ERROR]: "Reconnecting",
+  [ORB_STATES.ERROR]: "Connection error",
 });
 
 export async function mountTalkView({ outlet, signal }) {
@@ -76,9 +76,11 @@ export async function mountTalkView({ outlet, signal }) {
   if (signal.aborted) return;
   syncMicAria();
 
+  let everConnected = false;
   const subscription = subscribeConversationEvents({
     // Re-sync mic state on (re)connect: another tab may have toggled it.
     onReady: async () => {
+      everConnected = true;
       if (!togglePending) {
         try {
           muted = Boolean((await getMicState())?.muted);
@@ -98,9 +100,9 @@ export async function mountTalkView({ outlet, signal }) {
       orb.setState(next);
     },
     onError: () => {
-      // The subscription keeps reconnecting, show the error meanwhile.
-      orb.setState(ORB_STATES.ERROR);
-      caption.textContent = CAPTION_BY_STATE[ORB_STATES.ERROR];
+      // SSE auto-retries (e.g. 404 before routes exist), so a failure here is transient.
+      orb.setState(ORB_STATES.CONNECTING);
+      caption.textContent = everConnected ? "Reconnecting..." : CAPTION_BY_STATE[ORB_STATES.CONNECTING];
     },
   });
 


### PR DESCRIPTION
## Summary
On the desktop app the page loads instantly, but the conversation API only came up late in startup, so the orb sat in its red "Reconnecting" error state the whole time. That reads as a failure to users when the app is in fact just connecting. Bringing the API up first, plus an honest in-progress state, makes startup look like what it is.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>
