### PR TITLE
Remove prompt include compatibility

### DIFF
--- a/src/reachy_mini_conversation_app/prompts.py
+++ b/src/reachy_mini_conversation_app/prompts.py
@@ -1,4 +1,3 @@
-import re
 import sys
 import logging
 from pathlib import Path
@@ -14,7 +13,6 @@ INSTRUCTIONS_FILENAME = "instructions.txt"
 VOICE_FILENAME = "voice.txt"
 GREETING_FILENAME = "greeting.txt"
 DEFAULT_PROFILE_NAME = "default"
-DEFAULT_PROMPT_INCLUDE = "default_prompt"
 
 DEFAULT_GREETING_PROMPT = (
     "Start the conversation now with a brief, spontaneous greeting in character. "
@@ -24,40 +22,6 @@ DEFAULT_GREETING_PROMPT = (
 
 def _default_instructions_file() -> Path:
     return DEFAULT_PROFILES_DIRECTORY / DEFAULT_PROFILE_NAME / INSTRUCTIONS_FILENAME
-
-
-def _expand_prompt_includes(content: str) -> str:
-    """Expand supported prompt placeholders."""
-    pattern = re.compile(r"^\[([a-zA-Z0-9_-]+)\]$")
-
-    lines = content.split("\n")
-    expanded_lines = []
-
-    for line in lines:
-        stripped = line.strip()
-        match = pattern.match(stripped)
-
-        if not match:
-            expanded_lines.append(line)
-            continue
-
-        template_name = match.group(1)
-        if template_name != DEFAULT_PROMPT_INCLUDE:
-            logger.warning("Prompt include not found: [%s], keeping placeholder", template_name)
-            expanded_lines.append(line)
-            continue
-
-        try:
-            template_content = _default_instructions_file().read_text(encoding="utf-8").rstrip()
-        except OSError as e:
-            logger.warning("Failed to read prompt include '%s': %s, keeping placeholder", template_name, e)
-            expanded_lines.append(line)
-            continue
-
-        expanded_lines.append(template_content)
-        logger.debug("Expanded template: [%s]", template_name)
-
-    return "\n".join(expanded_lines)
 
 
 def get_session_instructions(instance_path: str | Path | None = None) -> str:
@@ -82,11 +46,10 @@ def get_session_instructions(instance_path: str | Path | None = None) -> str:
         if instructions_file.exists():
             instructions = instructions_file.read_text(encoding="utf-8").strip()
             if instructions:
-                expanded_instructions = _expand_prompt_includes(instructions)
                 memory_prompt = format_memory_for_prompt(instance_path)
                 if memory_prompt:
-                    return f"{memory_prompt}\n\n{expanded_instructions}"
-                return expanded_instructions
+                    return f"{memory_prompt}\n\n{instructions}"
+                return instructions
             logger.error("Profile '%s' has empty %s", profile_name, INSTRUCTIONS_FILENAME)
             sys.exit(1)
         logger.error("Profile '%s' has no %s", profile_name, INSTRUCTIONS_FILENAME)
@@ -128,7 +91,7 @@ def get_session_greeting_prompt() -> str:
         if greeting_file.exists():
             greeting = greeting_file.read_text(encoding="utf-8").strip()
             if greeting:
-                return _expand_prompt_includes(greeting)
+                return greeting
     except Exception as e:
         logger.warning("Failed to load greeting prompt from profile %r: %s", profile, e)
     return DEFAULT_GREETING_PROMPT

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -99,27 +99,19 @@ def test_default_session_instructions_load_from_default_profile(
     assert read_instructions_for(DEFAULT_OPTION) == expected
 
 
-def test_default_prompt_include_keeps_compatibility(
+def test_bracketed_prompt_line_stays_plain_text(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Existing profiles using [default_prompt] should still expand."""
-    profile_dir = tmp_path / "legacy"
+    """Bracketed prompt text should not be treated as an include."""
+    profile_dir = tmp_path / "literal_prompt"
     profile_dir.mkdir()
-    (profile_dir / "instructions.txt").write_text("[default_prompt]\n\nStay extra brief.\n", encoding="utf-8")
+    (profile_dir / "instructions.txt").write_text("[custom_prompt]\n\nStay extra brief.\n", encoding="utf-8")
 
     monkeypatch.setattr(config, "PROFILES_DIRECTORY", tmp_path)
-    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "legacy")
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "literal_prompt")
 
-    expected_default = (
-        (DEFAULT_PROFILES_DIRECTORY / "default" / "instructions.txt")
-        .read_text(
-            encoding="utf-8",
-        )
-        .strip()
-    )
-
-    assert prompts_mod.get_session_instructions(instance_path=tmp_path) == f"{expected_default}\n\nStay extra brief."
+    assert prompts_mod.get_session_instructions(instance_path=tmp_path) == "[custom_prompt]\n\nStay extra brief."
 
 
 def test_builtin_default_profile_tools_load_for_ui() -> None:


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
Removes the legacy prompt include expansion path. Profile `instructions.txt` and `greeting.txt` files now load as plain text, including bracketed lines, because bundled profiles no longer use prompt includes.

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>

## Notes
Validated locally with:

```bash
ruff check . --fix && ruff format . && mypy --pretty --show-error-codes && pytest tests/ -v
```
