### PR TITLE
Followup streaming fastrtc refactoring

### DIFF
--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -975,6 +975,8 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
             return
 
         input_sample_rate, audio_frame = frame
+        if audio_frame.size == 0:
+            return
 
         # Reshape if needed
         if audio_frame.ndim == 2:

--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -111,15 +111,11 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
         """Initialize the handler."""
         sample_rate = self.SAMPLE_RATE
         super().__init__(
-            expected_layout="mono",
             output_sample_rate=sample_rate,
             input_sample_rate=sample_rate,
         )
 
         self.deps = deps
-
-        self.output_sample_rate = sample_rate
-        self.input_sample_rate = sample_rate
 
         self.client: AsyncOpenAI
         self.connection: AsyncRealtimeConnection | None = None

--- a/src/reachy_mini_conversation_app/conversation_handler.py
+++ b/src/reachy_mini_conversation_app/conversation_handler.py
@@ -3,7 +3,7 @@ import time
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from typing import Literal, ClassVar, TypeAlias
+from typing import ClassVar, TypeAlias
 from collections.abc import Callable
 
 import numpy as np
@@ -33,24 +33,17 @@ class ConversationHandler(AsyncStreamHandler, ABC):
     output_queue: asyncio.Queue[QueueItem]
     last_activity_time: float
     last_idle_behavior_time: float
-    _clear_queue: Callable[[], None] | None = None
     _activity_observer: Callable[[str], None] | None = None
 
     def __init__(
         self,
-        expected_layout: Literal["mono", "stereo"] = "mono",
         output_sample_rate: int = 24000,
-        output_frame_size: int | None = None,
         input_sample_rate: int = 48000,
-        fps: int = 30,
     ) -> None:
         """Initialize the stream handler and shared idle/activity tracking."""
         super().__init__(
-            expected_layout=expected_layout,
             output_sample_rate=output_sample_rate,
-            output_frame_size=output_frame_size,
             input_sample_rate=input_sample_rate,
-            fps=fps,
         )
         self.last_activity_time = time.monotonic()
         self.last_idle_behavior_time = self.last_activity_time

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -670,6 +670,8 @@ class GeminiLiveHandler(ConversationHandler):
             return
 
         input_sample_rate, audio_frame = frame
+        if audio_frame.size == 0:
+            return
 
         # Reshape if needed
         if audio_frame.ndim == 2:

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -152,7 +152,6 @@ class GeminiLiveHandler(ConversationHandler):
     ):
         """Initialize the handler."""
         super().__init__(
-            expected_layout="mono",
             output_sample_rate=GEMINI_OUTPUT_SAMPLE_RATE,
             input_sample_rate=GEMINI_INPUT_SAMPLE_RATE,
         )

--- a/src/reachy_mini_conversation_app/streaming.py
+++ b/src/reachy_mini_conversation_app/streaming.py
@@ -1,6 +1,5 @@
 import asyncio
-import warnings
-from typing import Literal, TypeVar, TypeAlias
+from typing import TypeVar, TypeAlias
 from collections.abc import Mapping, Callable
 
 import numpy as np
@@ -9,7 +8,6 @@ from numpy.typing import NDArray
 
 StreamMessage: TypeAlias = Mapping[str, object]
 AudioArray: TypeAlias = NDArray[np.int16] | NDArray[np.float32]
-AudioInput: TypeAlias = AudioArray | tuple[int, AudioArray]
 
 QueueItem = TypeVar("QueueItem")
 
@@ -27,40 +25,15 @@ class AsyncStreamHandler:
 
     def __init__(
         self,
-        expected_layout: Literal["mono", "stereo"] = "mono",
         output_sample_rate: int = 24000,
-        output_frame_size: int | None = None,
         input_sample_rate: int = 48000,
-        fps: int = 30,
     ) -> None:
         """Initialize the audio stream metadata used by conversation handlers."""
-        self.expected_layout = expected_layout
+        if output_sample_rate % 50 != 0:
+            raise ValueError(f"output_sample_rate must be a multiple of 50, got {output_sample_rate}")
         self.output_sample_rate = output_sample_rate
         self.input_sample_rate = input_sample_rate
-        self.fps = fps
-        self.latest_args: list[object] = []
-        self.args_set = asyncio.Event()
-        self.channel_set = asyncio.Event()
         self._clear_queue: Callable[[], None] | None = None
-
-        sample_rate_to_frame_size_coef = 50
-        if output_sample_rate % sample_rate_to_frame_size_coef != 0:
-            raise ValueError(
-                f"output_sample_rate must be a multiple of {sample_rate_to_frame_size_coef}, got {output_sample_rate}"
-            )
-
-        actual_output_frame_size = output_sample_rate // sample_rate_to_frame_size_coef
-        if output_frame_size is not None and output_frame_size != actual_output_frame_size:
-            warnings.warn(
-                "The output_frame_size parameter is deprecated and will be removed "
-                "in a future release. The value passed in will be ignored. "
-                f"The actual output frame size is {actual_output_frame_size}, "
-                f"corresponding to {1 / sample_rate_to_frame_size_coef:.2f}s "
-                f"at output_sample_rate={output_sample_rate}Hz.",
-                UserWarning,
-                stacklevel=2,
-            )
-        self.output_frame_size = actual_output_frame_size
 
 
 async def wait_for_item(queue: asyncio.Queue[QueueItem], timeout: float = 0.1) -> QueueItem | None:
@@ -71,32 +44,19 @@ async def wait_for_item(queue: asyncio.Queue[QueueItem], timeout: float = 0.1) -
         return None
 
 
-def _unpack_audio(audio: AudioInput) -> AudioArray:
-    if isinstance(audio, tuple):
-        warnings.warn(
-            "Passing a (sample_rate, audio) tuple is deprecated; pass only the audio array.",
-            UserWarning,
-            stacklevel=2,
-        )
-        return audio[1]
-    return audio
-
-
-def audio_to_int16(audio: AudioInput) -> NDArray[np.int16]:
+def audio_to_int16(audio: AudioArray) -> NDArray[np.int16]:
     """Convert int16 or float32 audio data to int16 samples."""
-    audio_array = _unpack_audio(audio)
-    if audio_array.dtype == np.int16:
-        return audio_array.astype(np.int16, copy=False)
-    if audio_array.dtype == np.float32:
-        return (audio_array * 32767.0).astype(np.int16)
-    raise TypeError(f"Unsupported audio data type: {audio_array.dtype}")
+    if audio.dtype == np.int16:
+        return audio.astype(np.int16, copy=False)
+    if audio.dtype == np.float32:
+        return (audio * 32767.0).astype(np.int16)
+    raise TypeError(f"Unsupported audio data type: {audio.dtype}")
 
 
-def audio_to_float32(audio: AudioInput) -> NDArray[np.float32]:
+def audio_to_float32(audio: AudioArray) -> NDArray[np.float32]:
     """Convert int16 or float32 audio data to float32 samples."""
-    audio_array = _unpack_audio(audio)
-    if audio_array.dtype == np.int16:
-        return audio_array.astype(np.float32) / 32768.0
-    if audio_array.dtype == np.float32:
-        return audio_array.astype(np.float32, copy=False)
-    raise TypeError(f"Unsupported audio data type: {audio_array.dtype}")
+    if audio.dtype == np.int16:
+        return audio.astype(np.float32) / 32768.0
+    if audio.dtype == np.float32:
+        return audio.astype(np.float32, copy=False)
+    raise TypeError(f"Unsupported audio data type: {audio.dtype}")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,7 +5,6 @@ import pytest
 
 from reachy_mini_conversation_app.streaming import (
     AdditionalOutputs,
-    AsyncStreamHandler,
     wait_for_item,
     audio_to_int16,
     audio_to_float32,
@@ -19,13 +18,6 @@ def test_additional_outputs_stores_messages() -> None:
     outputs = AdditionalOutputs(message)
 
     assert outputs.args == (message,)
-
-
-def test_async_stream_handler_derives_output_frame_size() -> None:
-    """Stream handlers should derive 20 ms output frames from sample rate."""
-    handler = AsyncStreamHandler(output_sample_rate=24000)
-
-    assert handler.output_frame_size == 480
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
I removed the following things in `AsyncStreamHandler`:
- `expected_layout` – write-only, it was never read. The real mono downmix is done explicitly in each backend with `audio_frame[:, 0]` (the mic returns stereo float32 (N, 2)), so the stored hint did nothing
- `fps`, `latest_args`, `args_set`, `channel_set` – pure leftover fastrtc handler state, set in `__init__` and never read anywhere
- `output_frame_size` + its deprecation warning – the attribute had a single reader, a test that only re-asserted the arithmetic, and no caller ever passes the deprecated param

Also removed `_unpack_audio` because:
- its (rate, array) tuple branch was unreachable, all three callers (`base_realtime`, `gemini_live`, `console`) pass a bare array
- removing it let the converters take `AudioArray` directly and cleared the now-unused `AudioInput` alias and warnings import

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>
