### PR TITLE
Add go to sleep tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,5 @@ HF_TOKEN=
 # This is convenient for downloaded tools used with built-in/default profiles.
 # AUTOLOAD_EXTERNAL_TOOLS=1
 
-# Minutes of inactivity before the app closes. Default 1440 (one day), 0 disables.
+# Minutes of inactivity before Reachy goes to sleep and the app stops. Default 1440 (one day), 0 disables.
 # REACHY_MINI_APP_TIMEOUT_MINUTES=1440

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Copy `.env.example` to `.env` when you want to switch backends, provide API keys
 | `HF_REALTIME_CONNECTION_MODE` | Hugging Face connection selector: `deployed` uses the built-in Hugging Face server; `local` uses `HF_REALTIME_WS_URL`. Defaults to `deployed`. |
 | `HF_REALTIME_WS_URL` | Direct websocket endpoint for your own Hugging Face backend. Accepts either a base URL like `ws://127.0.0.1:8765/v1` or the full websocket URL `ws://127.0.0.1:8765/v1/realtime`. Used when `HF_REALTIME_CONNECTION_MODE=local`. |
 | `HF_TOKEN` | Optional token for Hugging Face access (for gated/private assets). |
-| `REACHY_MINI_APP_TIMEOUT_MINUTES` | Minutes of inactivity before the app closes. Defaults to `1440` (one day); set to `0` to disable. |
+| `REACHY_MINI_APP_TIMEOUT_MINUTES` | Minutes of inactivity before Reachy goes to sleep and the app stops. Defaults to `1440` (one day); set to `0` to disable. |
 
 ### Hugging Face Connection Modes
 
@@ -204,6 +204,7 @@ reachy-mini-conversation-app --ui
 | `stop_emotion` | Clear queued emotions. | Core install only. |
 | `remember` | Save one short, stable fact about the user for future sessions. | Core install only. Stored in the app instance data directory. |
 | `forget` | Remove a saved memory fact by matching a short query. | Core install only. |
+| `go_to_sleep` | Run Reachy's sleep movement and stop the current app after an explicit user request. | Core install only. |
 | `idle_do_nothing` | Explicitly remain idle during an idle turn. Not intended for normal conversation turns. | Core install only. |
 
 > [!NOTE]

--- a/profiles/bored_teenager/tools.txt
+++ b/profiles/bored_teenager/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/captain_circuit/tools.txt
+++ b/profiles/captain_circuit/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/chess_coach/tools.txt
+++ b/profiles/chess_coach/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/cosmic_kitchen/tools.txt
+++ b/profiles/cosmic_kitchen/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/default/tools.txt
+++ b/profiles/default/tools.txt
@@ -5,6 +5,7 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 sweep_look
 remember
 forget

--- a/profiles/hype_bot/tools.txt
+++ b/profiles/hype_bot/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/mad_scientist_assistant/tools.txt
+++ b/profiles/mad_scientist_assistant/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/mars_rover/tools.txt
+++ b/profiles/mars_rover/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/nature_documentarian/tools.txt
+++ b/profiles/nature_documentarian/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/noir_detective/tools.txt
+++ b/profiles/noir_detective/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/sorry_bro/tools.txt
+++ b/profiles/sorry_bro/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/tedai/tools.txt
+++ b/profiles/tedai/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/time_traveler/tools.txt
+++ b/profiles/time_traveler/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/profiles/victorian_butler/tools.txt
+++ b/profiles/victorian_butler/tools.txt
@@ -5,5 +5,6 @@ stop_emotion
 camera
 idle_do_nothing
 move_head
+go_to_sleep
 remember
 forget

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -7,7 +7,9 @@ import asyncio
 import logging
 import argparse
 import threading
-from typing import TYPE_CHECKING, Optional
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING, Any, Optional
 from pathlib import Path
 from collections.abc import Callable, Awaitable
 
@@ -25,13 +27,32 @@ if TYPE_CHECKING:
     from reachy_mini_conversation_app.console import LocalStream
 
 
+_STOP_CURRENT_APP_URL = "http://127.0.0.1:8000/api/apps/stop-current-app"
+_STOP_CURRENT_APP_TIMEOUT_S = 2.0
+
+
+def _request_stop_current_app(logger: logging.Logger) -> bool:
+    """Request the Reachy Mini daemon to stop the current app."""
+    request = urllib.request.Request(_STOP_CURRENT_APP_URL, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=_STOP_CURRENT_APP_TIMEOUT_S) as response:
+            response.read()
+    except urllib.error.URLError as e:
+        logger.error("Failed to request current app stop via %s: %s", _STOP_CURRENT_APP_URL, e)
+        return False
+
+    logger.info("Requested current app stop via %s", _STOP_CURRENT_APP_URL)
+    return True
+
+
 def _start_inactivity_timeout_thread(
     timeout_minutes: float,
     stream_manager: LocalStream,
     logger: logging.Logger,
     app_stop_event: threading.Event | None,
+    go_to_sleep: Callable[[], dict[str, Any]] | None = None,
 ) -> threading.Thread:
-    """Start a daemon that closes the app after `timeout_minutes` without activity."""
+    """Start a daemon that puts the app to sleep after inactivity."""
     timeout_seconds = timeout_minutes * 60.0
 
     def poll_inactivity_timeout() -> None:
@@ -39,11 +60,18 @@ def _start_inactivity_timeout_thread(
         while app_stop_event is None or not app_stop_event.is_set():
             elapsed = stream_manager.seconds_since_activity()
             if elapsed >= timeout_seconds:
-                logger.info("No activity for %.1f minutes; closing conversation app.", elapsed / 60.0)
+                logger.info("No activity for %.1f minutes; going to sleep.", elapsed / 60.0)
                 try:
-                    stream_manager.close()
+                    if go_to_sleep is not None:
+                        go_to_sleep()
+                    else:
+                        stream_manager.close()
                 except Exception as e:
-                    logger.error("Error while closing stream manager after inactivity timeout: %s", e)
+                    logger.error("Error while going to sleep after inactivity timeout: %s", e)
+                    try:
+                        stream_manager.close()
+                    except Exception as close_error:
+                        logger.error("Error while closing stream manager after inactivity timeout: %s", close_error)
                 return
             time.sleep(1.0)
 
@@ -242,6 +270,59 @@ def run(
     if effective_settings_app is not None:
         stream_manager._init_settings_ui_if_needed()
 
+    go_to_sleep_lock = threading.Lock()
+    go_to_sleep_requested = threading.Event()
+
+    def go_to_sleep_and_stop_app() -> dict[str, Any]:
+        """Put Reachy to sleep, then stop the current app."""
+        if not go_to_sleep_lock.acquire(blocking=False):
+            return {"status": "already_requested"}
+
+        try:
+            if go_to_sleep_requested.is_set():
+                return {"status": "already_requested"}
+            go_to_sleep_requested.set()
+
+            logger.info("Going to sleep before stopping conversation app.")
+            sleep_error: str | None = None
+
+            try:
+                robot.disable_wobbling()
+            except Exception as e:
+                logger.debug("Error disabling wobbling before sleep: %s", e)
+
+            movement_manager.stop(reset_to_neutral=False)
+
+            try:
+                robot.goto_sleep()
+            except Exception as e:
+                sleep_error = f"{type(e).__name__}: {e}"
+                logger.error("Failed to move Reachy Mini to sleep pose: %s", e)
+
+            stop_current_app_requested = _request_stop_current_app(logger)
+            local_stop_requested = True
+            if app_stop_event is not None:
+                app_stop_event.set()
+            else:
+                try:
+                    stream_manager.close()
+                except Exception as e:
+                    local_stop_requested = False
+                    logger.error("Error while closing stream manager after go_to_sleep: %s", e)
+
+            result: dict[str, Any] = {
+                "status": "sleeping" if sleep_error is None else "stop_requested",
+                "stop_current_app_requested": stop_current_app_requested,
+                "local_stop_requested": local_stop_requested,
+            }
+            if sleep_error is not None:
+                result["error"] = f"go_to_sleep movement failed: {sleep_error}"
+            return result
+        finally:
+            go_to_sleep_lock.release()
+
+    deps.go_to_sleep = go_to_sleep_and_stop_app
+
     if args.ui and settings_app is None and effective_settings_app is not None:
         import uvicorn
 
@@ -266,7 +347,9 @@ def run(
 
     timeout_minutes = resolve_app_timeout_minutes()
     if timeout_minutes is not None:
-        _start_inactivity_timeout_thread(timeout_minutes, stream_manager, logger, app_stop_event)
+        _start_inactivity_timeout_thread(
+            timeout_minutes, stream_manager, logger, app_stop_event, go_to_sleep_and_stop_app
+        )
 
     def poll_stop_event() -> None:
         """Poll the stop event to allow graceful shutdown."""

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -27,21 +27,22 @@ if TYPE_CHECKING:
     from reachy_mini_conversation_app.console import LocalStream
 
 
-_STOP_CURRENT_APP_URL = "http://127.0.0.1:8000/api/apps/stop-current-app"
+_STOP_CURRENT_APP_PATH = "/api/apps/stop-current-app"
 _STOP_CURRENT_APP_TIMEOUT_S = 2.0
 
 
-def _request_stop_current_app(logger: logging.Logger) -> bool:
+def _request_stop_current_app(robot: ReachyMini, logger: logging.Logger) -> bool:
     """Request the Reachy Mini daemon to stop the current app."""
-    request = urllib.request.Request(_STOP_CURRENT_APP_URL, method="POST")
+    stop_current_app_url = f"http://{robot.client.host}:{robot.client.port}{_STOP_CURRENT_APP_PATH}"
+    request = urllib.request.Request(stop_current_app_url, method="POST")
     try:
         with urllib.request.urlopen(request, timeout=_STOP_CURRENT_APP_TIMEOUT_S) as response:
             response.read()
     except urllib.error.URLError as e:
-        logger.error("Failed to request current app stop via %s: %s", _STOP_CURRENT_APP_URL, e)
+        logger.error("Failed to request current app stop via %s: %s", stop_current_app_url, e)
         return False
 
-    logger.info("Requested current app stop via %s", _STOP_CURRENT_APP_URL)
+    logger.info("Requested current app stop via %s", stop_current_app_url)
     return True
 
 
@@ -299,7 +300,7 @@ def run(
                 sleep_error = f"{type(e).__name__}: {e}"
                 logger.error("Failed to move Reachy Mini to sleep pose: %s", e)
 
-            stop_current_app_requested = _request_stop_current_app(logger)
+            stop_current_app_requested = _request_stop_current_app(robot, logger)
             local_stop_requested = True
             if app_stop_event is not None:
                 app_stop_event.set()

--- a/src/reachy_mini_conversation_app/moves.py
+++ b/src/reachy_mini_conversation_app/moves.py
@@ -572,16 +572,19 @@ class MovementManager:
         self._thread.start()
         logger.debug("Move worker started")
 
-    def stop(self) -> None:
+    def stop(self, reset_to_neutral: bool = True) -> None:
         """Request the worker thread to stop and wait for it to exit.
 
-        Before stopping, resets the robot to a neutral position.
+        Optionally resets the robot to a neutral position after stopping.
         """
         if self._thread is None or not self._thread.is_alive():
             logger.debug("Move worker not running; stop() ignored")
             return
 
-        logger.info("Stopping movement manager and resetting to neutral position...")
+        if reset_to_neutral:
+            logger.info("Stopping movement manager and resetting to neutral position...")
+        else:
+            logger.info("Stopping movement manager...")
 
         # Clear any queued moves and stop current move
         self.clear_move_queue()
@@ -592,6 +595,9 @@ class MovementManager:
             self._thread.join()
             self._thread = None
         logger.debug("Move worker stopped")
+
+        if not reset_to_neutral:
+            return
 
         # Reset to neutral position using goto_target (same approach as wake_up)
         try:

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -43,6 +43,7 @@ class ToolDependencies:
     instance_path: str | Path | None = None
     camera_enabled: bool = False
     motion_duration_s: float = 1.0
+    go_to_sleep: Callable[[], dict[str, Any]] | None = None
 
 
 class ToolSpec(TypedDict):

--- a/src/reachy_mini_conversation_app/tools/go_to_sleep.py
+++ b/src/reachy_mini_conversation_app/tools/go_to_sleep.py
@@ -1,0 +1,44 @@
+import asyncio
+import logging
+from typing import Any
+
+from reachy_mini_conversation_app.tools.core_tools import Tool, ToolDependencies
+
+
+logger = logging.getLogger(__name__)
+
+
+class GoToSleep(Tool):
+    """Put Reachy to sleep and stop the current app."""
+
+    name = "go_to_sleep"
+    description = (
+        "Use only when the user explicitly asks Reachy to go to sleep, stop the current app, shut down this app, "
+        "or end the conversation. Do not use for idle turns, sleepy emotions, silence, or ambiguous requests."
+    )
+    needs_response = False
+    parameters_schema = {
+        "type": "object",
+        "properties": {
+            "confirmation": {
+                "type": "string",
+                "enum": ["go_to_sleep"],
+                "description": "Required exact confirmation for an explicit user request to stop this app.",
+            },
+        },
+        "required": ["confirmation"],
+    }
+
+    async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> dict[str, Any]:
+        """Put Reachy to sleep and request app shutdown."""
+        if kwargs.get("confirmation") != "go_to_sleep":
+            return {"error": "go_to_sleep requires explicit confirmation"}
+        if deps.go_to_sleep is None:
+            return {"error": "go_to_sleep is unavailable in this runtime"}
+
+        logger.info("Tool call: go_to_sleep")
+        try:
+            return await asyncio.to_thread(deps.go_to_sleep)
+        except Exception as e:
+            logger.error("go_to_sleep failed: %s", e)
+            return {"error": f"go_to_sleep failed: {type(e).__name__}: {e}"}

--- a/src/reachy_mini_conversation_app/tools/go_to_sleep.py
+++ b/src/reachy_mini_conversation_app/tools/go_to_sleep.py
@@ -13,26 +13,18 @@ class GoToSleep(Tool):
 
     name = "go_to_sleep"
     description = (
-        "Use only when the user explicitly asks Reachy to go to sleep, stop the current app, shut down this app, "
+        "Use when you are sure the user wants Reachy to go to sleep, stop the current app, shut down this app, "
         "or end the conversation. Do not use for idle turns, sleepy emotions, silence, or ambiguous requests."
     )
     needs_response = False
     parameters_schema = {
         "type": "object",
-        "properties": {
-            "confirmation": {
-                "type": "string",
-                "enum": ["go_to_sleep"],
-                "description": "Required exact confirmation for an explicit user request to stop this app.",
-            },
-        },
-        "required": ["confirmation"],
+        "properties": {},
+        "required": [],
     }
 
     async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> dict[str, Any]:
         """Put Reachy to sleep and request app shutdown."""
-        if kwargs.get("confirmation") != "go_to_sleep":
-            return {"error": "go_to_sleep requires explicit confirmation"}
         if deps.go_to_sleep is None:
             return {"error": "go_to_sleep is unavailable in this runtime"}
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,7 +43,7 @@ def test_inactivity_timeout_thread_closes_stream_manager_without_sleep_callback(
 
 
 def test_request_stop_current_app_posts_to_daemon(monkeypatch) -> None:
-    """The app stop request should call the Reachy daemon stop-current-app endpoint."""
+    """The app stop request should call the connected Reachy daemon endpoint."""
 
     class FakeResponse:
         def __enter__(self) -> "FakeResponse":
@@ -56,11 +56,12 @@ def test_request_stop_current_app_posts_to_daemon(monkeypatch) -> None:
             return b"{}"
 
     def fake_urlopen(request, timeout):
-        assert request.full_url == "http://127.0.0.1:8000/api/apps/stop-current-app"
+        assert request.full_url == "http://192.168.1.42:8000/api/apps/stop-current-app"
         assert request.get_method() == "POST"
         assert timeout == 2.0
         return FakeResponse()
 
     monkeypatch.setattr(main_mod.urllib.request, "urlopen", fake_urlopen)
+    robot = SimpleNamespace(client=SimpleNamespace(host="192.168.1.42", port=8000))
 
-    assert main_mod._request_stop_current_app(MagicMock())
+    assert main_mod._request_stop_current_app(robot, MagicMock())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,8 +7,27 @@ from unittest.mock import MagicMock
 import reachy_mini_conversation_app.main as main_mod
 
 
-def test_inactivity_timeout_thread_closes_stream_manager() -> None:
-    """The watchdog should close the stream once activity is too old."""
+def test_inactivity_timeout_thread_goes_to_sleep() -> None:
+    """The watchdog should use the shared sleep shutdown path once activity is too old."""
+    stream_manager = SimpleNamespace(seconds_since_activity=lambda: 10.0, close=MagicMock())
+    go_to_sleep = MagicMock(return_value={"status": "sleeping"})
+
+    thread = main_mod._start_inactivity_timeout_thread(
+        timeout_minutes=0.0001,
+        stream_manager=stream_manager,
+        logger=MagicMock(),
+        app_stop_event=threading.Event(),
+        go_to_sleep=go_to_sleep,
+    )
+
+    thread.join(timeout=1.0)
+    assert not thread.is_alive()
+    go_to_sleep.assert_called_once_with()
+    stream_manager.close.assert_not_called()
+
+
+def test_inactivity_timeout_thread_closes_stream_manager_without_sleep_callback() -> None:
+    """The watchdog should still close the stream when no sleep callback is available."""
     stream_manager = SimpleNamespace(seconds_since_activity=lambda: 10.0, close=MagicMock())
 
     thread = main_mod._start_inactivity_timeout_thread(
@@ -21,3 +40,27 @@ def test_inactivity_timeout_thread_closes_stream_manager() -> None:
     thread.join(timeout=1.0)
     assert not thread.is_alive()
     stream_manager.close.assert_called_once_with()
+
+
+def test_request_stop_current_app_posts_to_daemon(monkeypatch) -> None:
+    """The app stop request should call the Reachy daemon stop-current-app endpoint."""
+
+    class FakeResponse:
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    def fake_urlopen(request, timeout):
+        assert request.full_url == "http://127.0.0.1:8000/api/apps/stop-current-app"
+        assert request.get_method() == "POST"
+        assert timeout == 2.0
+        return FakeResponse()
+
+    monkeypatch.setattr(main_mod.urllib.request, "urlopen", fake_urlopen)
+
+    assert main_mod._request_stop_current_app(MagicMock())

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -1,0 +1,29 @@
+import time
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.moves import MovementManager
+
+
+def test_stop_can_skip_neutral_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sleep shutdown should stop the movement loop without undoing the sleep pose."""
+    robot = MagicMock()
+    manager = MovementManager(robot)
+    started = threading.Event()
+
+    def fake_working_loop() -> None:
+        started.set()
+        while not manager._stop_event.is_set():
+            time.sleep(0.001)
+
+    monkeypatch.setattr(manager, "working_loop", fake_working_loop)
+
+    manager.start()
+    assert started.wait(timeout=1.0)
+
+    manager.stop(reset_to_neutral=False)
+
+    assert manager._thread is None
+    robot.goto_target.assert_not_called()

--- a/tests/tools/test_go_to_sleep.py
+++ b/tests/tools/test_go_to_sleep.py
@@ -6,20 +6,13 @@ from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.tools.go_to_sleep import GoToSleep
 
 
-@pytest.mark.asyncio
-async def test_go_to_sleep_requires_confirmation() -> None:
-    """The tool should not run without the explicit confirmation token."""
-    go_to_sleep = MagicMock(return_value={"status": "sleeping"})
-    deps = ToolDependencies(
-        reachy_mini=MagicMock(),
-        movement_manager=MagicMock(),
-        go_to_sleep=go_to_sleep,
-    )
-
-    result = await GoToSleep()(deps)
-
-    assert result == {"error": "go_to_sleep requires explicit confirmation"}
-    go_to_sleep.assert_not_called()
+def test_go_to_sleep_has_no_required_arguments() -> None:
+    """The tool should be callable without a confirmation argument."""
+    assert GoToSleep.parameters_schema == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
 
 
 @pytest.mark.asyncio
@@ -27,7 +20,7 @@ async def test_go_to_sleep_returns_unavailable_without_runtime_callback() -> Non
     """The tool should fail gracefully if the runtime did not inject a sleep callback."""
     deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
 
-    result = await GoToSleep()(deps, confirmation="go_to_sleep")
+    result = await GoToSleep()(deps)
 
     assert result == {"error": "go_to_sleep is unavailable in this runtime"}
 
@@ -47,7 +40,7 @@ async def test_go_to_sleep_calls_runtime_callback() -> None:
         go_to_sleep=go_to_sleep,
     )
 
-    result = await GoToSleep()(deps, confirmation="go_to_sleep")
+    result = await GoToSleep()(deps)
 
     assert result == expected
     go_to_sleep.assert_called_once_with()

--- a/tests/tools/test_go_to_sleep.py
+++ b/tests/tools/test_go_to_sleep.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.go_to_sleep import GoToSleep
+
+
+@pytest.mark.asyncio
+async def test_go_to_sleep_requires_confirmation() -> None:
+    """The tool should not run without the explicit confirmation token."""
+    go_to_sleep = MagicMock(return_value={"status": "sleeping"})
+    deps = ToolDependencies(
+        reachy_mini=MagicMock(),
+        movement_manager=MagicMock(),
+        go_to_sleep=go_to_sleep,
+    )
+
+    result = await GoToSleep()(deps)
+
+    assert result == {"error": "go_to_sleep requires explicit confirmation"}
+    go_to_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_go_to_sleep_returns_unavailable_without_runtime_callback() -> None:
+    """The tool should fail gracefully if the runtime did not inject a sleep callback."""
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+
+    result = await GoToSleep()(deps, confirmation="go_to_sleep")
+
+    assert result == {"error": "go_to_sleep is unavailable in this runtime"}
+
+
+@pytest.mark.asyncio
+async def test_go_to_sleep_calls_runtime_callback() -> None:
+    """The tool should delegate the actual movement and app stop to the host runtime."""
+    expected = {
+        "status": "sleeping",
+        "stop_current_app_requested": True,
+        "local_stop_requested": True,
+    }
+    go_to_sleep = MagicMock(return_value=expected)
+    deps = ToolDependencies(
+        reachy_mini=MagicMock(),
+        movement_manager=MagicMock(),
+        go_to_sleep=go_to_sleep,
+    )
+
+    result = await GoToSleep()(deps, confirmation="go_to_sleep")
+
+    assert result == expected
+    go_to_sleep.assert_called_once_with()


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
Adds a `go_to_sleep` tool that the model can call with no arguments when it is sure the user wants Reachy to sleep or stop the app. The tool calls the SDK sleep movement and then requests `/api/apps/stop-current-app`. The inactivity timeout now uses the same sleep shutdown path so idle shutdown looks intentional instead of abruptly closing the app.

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [x] Console mode (default)
- [x] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [x] Movement manager (dances, emotions, head motion)
- [x] Profiles or custom tools
</details>

## Notes
Local validation:

- `.venv/bin/ruff check $(git ls-files '*.py')`
- `.venv/bin/ruff format --check $(git ls-files '*.py')`
- `.venv/bin/mypy --pretty --show-error-codes`
- `.venv/bin/pytest tests/ -v`
- After removing the confirmation argument: `.venv/bin/ruff check src/reachy_mini_conversation_app/tools/go_to_sleep.py tests/tools/test_go_to_sleep.py`, `.venv/bin/ruff format --check src/reachy_mini_conversation_app/tools/go_to_sleep.py tests/tools/test_go_to_sleep.py`, `.venv/bin/pytest tests/tools/test_go_to_sleep.py -v`, `.venv/bin/mypy --pretty --show-error-codes`

`ruff check .` includes pre-existing untracked local files in this checkout, so the tracked-file lint command above was used for the PR scope.