### PR TITLE
Add mobile settings API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ reachy-mini-conversation-app
 
 The app runs in console mode by default. Add `--ui` to also serve a web UI at http://127.0.0.1:7860/ for picking a personality, controlling the mic, and changing settings. All options are described in the CLI table below.
 
+### Mobile/settings API
+
+When `--ui` is enabled, the web UI and settings-only clients use the versioned API under `/api/v1`. This API controls configuration and UI state only; live conversation audio still runs through the robot/Python media pipeline.
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/v1/status` | Current backend, readiness, and connection state. |
+| `POST /api/v1/backend_config` | Save backend selection and credentials/connection target. |
+| `GET /api/v1/personalities` | List available personalities and current/startup selection. |
+| `GET /api/v1/personalities/load?name=...` | Load editable personality text, tools, and voice. |
+| `POST /api/v1/personalities/save` | Save a user personality. |
+| `POST /api/v1/personalities/apply` | Apply a personality, optionally persisting it for startup. |
+| `GET /api/v1/mic`, `POST /api/v1/mic` | Read or set whether the robot microphone is muted. |
+| `GET /api/v1/voices`, `GET /api/v1/voices/current`, `POST /api/v1/voices/apply` | List, read, or change the selected backend voice. |
+| `GET /api/v1/conversation_events` | Server-sent events for conversation activity state. |
+
 ### CLI options
 
 | Option | Default | Description |

--- a/README.md
+++ b/README.md
@@ -173,22 +173,6 @@ reachy-mini-conversation-app
 
 The app runs in console mode by default. Add `--ui` to also serve a web UI at http://127.0.0.1:7860/ for picking a personality, controlling the mic, and changing settings. All options are described in the CLI table below.
 
-### Mobile/settings API
-
-When `--ui` is enabled, the web UI and settings-only clients use the versioned API under `/api/v1`. This API controls configuration and UI state only; live conversation audio still runs through the robot/Python media pipeline.
-
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /api/v1/status` | Current backend, readiness, and connection state. |
-| `POST /api/v1/backend_config` | Save backend selection and credentials/connection target. |
-| `GET /api/v1/personalities` | List available personalities and current/startup selection. |
-| `GET /api/v1/personalities/load?name=...` | Load editable personality text, tools, and voice. |
-| `POST /api/v1/personalities/save` | Save a user personality. |
-| `POST /api/v1/personalities/apply` | Apply a personality, optionally persisting it for startup. |
-| `GET /api/v1/mic`, `POST /api/v1/mic` | Read or set whether the robot microphone is muted. |
-| `GET /api/v1/voices`, `GET /api/v1/voices/current`, `POST /api/v1/voices/apply` | List, read, or change the selected backend voice. |
-| `GET /api/v1/conversation_events` | Server-sent events for conversation activity state. |
-
 ### CLI options
 
 | Option | Default | Description |

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -5,7 +5,6 @@ served via the Reachy Mini Apps settings server so users can configure it.
 """
 
 import os
-import sys
 import time
 import asyncio
 import logging
@@ -66,10 +65,11 @@ except Exception:  # pragma: no cover - only loaded when settings_app is used
 logger = logging.getLogger(__name__)
 
 _SSE_KEEPALIVE_INTERVAL_SECONDS = 15.0  # below typical 60s proxy idle timeout
+SETTINGS_API_PREFIX = "/api/v1"
 
 
 def _detach_framework_root_routes(app: "FastAPI") -> None:
-    """Strip framework-registered GET / and /static routes so ours aren't silently shadowed."""
+    """Strip framework routes that would shadow the settings UI."""
     routes = getattr(app, "router", None)
     routes = getattr(routes, "routes", None) if routes else getattr(app, "routes", None)
     if routes is None:
@@ -77,7 +77,8 @@ def _detach_framework_root_routes(app: "FastAPI") -> None:
     survivors = []
     for route in routes:
         path = getattr(route, "path", None)
-        if path in ("/", "/static"):
+        is_catch_all = isinstance(path, str) and path.startswith("/{") and path.endswith(":path}")
+        if path in ("/", "/static") or is_catch_all:
             logger.debug("detaching framework-provided route %r (%s)", path, type(route).__name__)
             continue
         survivors.append(route)
@@ -197,12 +198,12 @@ class LocalStream:
         self._instance_path: Optional[str] = instance_path
         self._settings_initialized = False
         self._asyncio_loop = None
-        self._mic_muted = False  # mic starts live; the UI toggles it via /mic
+        self._mic_muted = False  # mic starts live; the UI toggles it via the settings API
         self._active_backend_name = get_backend_choice()
         self._backend_connection_state = "not_started"
         self._backend_error: str | None = None
         self._backend_retry_delay = BACKEND_RETRY_DELAY_SECONDS
-        # One bus for the stream's lifetime: the /conversation_events route
+        # One bus for the stream's lifetime: the conversation events route
         # closes over it, so handler rebuilds must keep publishing into it.
         self._event_bus = ConversationEventBus()
         self._install_handler(handler)
@@ -335,7 +336,7 @@ class LocalStream:
             self._backend_error = None
 
     def _backend_connection_status(self) -> dict[str, object]:
-        """Return the backend connection state exposed in /status."""
+        """Return the backend connection state exposed in the settings API."""
         connected = self._backend_connected()
         state = "connected" if connected else self._backend_connection_state
         return {
@@ -595,17 +596,18 @@ class LocalStream:
             return
         if self._settings_app is None:
             return
+        settings_app = self._settings_app
 
         static_dir = Path(__file__).parent / "static"
         index_file = static_dir / "index.html"
         logger.info("Serving settings UI from %s", static_dir)
 
         # Framework pre-registers GET / and /static; strip them so our routes aren't shadowed.
-        _detach_framework_root_routes(self._settings_app)
+        _detach_framework_root_routes(settings_app)
 
-        if hasattr(self._settings_app, "mount"):
+        if hasattr(settings_app, "mount"):
             try:
-                self._settings_app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+                settings_app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
             except Exception:
                 pass
 
@@ -657,33 +659,22 @@ class LocalStream:
             }
 
         # GET / -> index.html
-        @self._settings_app.get("/")
+        @settings_app.get("/")
         def _root() -> FileResponse:
             return FileResponse(str(index_file))
 
         # GET /favicon.ico -> optional, avoid noisy 404s on some browsers
-        @self._settings_app.get("/favicon.ico")
+        @settings_app.get("/favicon.ico")
         def _favicon() -> Response:
             return Response(status_code=204)
 
-        # GET /status -> whether key is set
-        @self._settings_app.get("/status")
+        @settings_app.get(f"{SETTINGS_API_PREFIX}/status")
         def _status() -> JSONResponse:
             return JSONResponse(_status_payload())
 
-        # GET /ready -> whether backend finished loading tools
-        @self._settings_app.get("/ready")
-        def _ready() -> JSONResponse:
-            try:
-                mod = sys.modules.get("reachy_mini_conversation_app.tools.core_tools")
-                ready = bool(getattr(mod, "_TOOLS_INITIALIZED", False)) if mod else False
-            except Exception:
-                ready = False
-            return JSONResponse({"ready": ready})
-
         event_bus = self._event_bus
 
-        @self._settings_app.get("/conversation_events")
+        @settings_app.get(f"{SETTINGS_API_PREFIX}/conversation_events")
         async def _conversation_events(request: Request) -> StreamingResponse:
             return StreamingResponse(
                 _conversation_events_stream(event_bus, request),
@@ -698,19 +689,17 @@ class LocalStream:
         class MicPayload(BaseModel):
             muted: bool
 
-        # GET /mic -> current mic mute state
-        @self._settings_app.get("/mic")
+        @settings_app.get(f"{SETTINGS_API_PREFIX}/mic")
         def _mic_state() -> JSONResponse:
             return JSONResponse({"muted": self._mic_muted})
 
-        # POST /mic -> mute/unmute the user's microphone (Reachy Mini keeps speaking)
-        @self._settings_app.post("/mic")
+        @settings_app.post(f"{SETTINGS_API_PREFIX}/mic")
         def _set_mic(payload: MicPayload) -> JSONResponse:
             self._mic_muted = bool(payload.muted)
             logger.info("Microphone %s via web UI", "muted" if self._mic_muted else "unmuted")
             return JSONResponse({"muted": self._mic_muted})
 
-        @self._settings_app.post("/backend_config")
+        @settings_app.post(f"{SETTINGS_API_PREFIX}/backend_config")
         def _set_backend(payload: BackendPayload) -> JSONResponse:
             backend = payload.backend.strip().lower()
             if backend not in {OPENAI_BACKEND, GEMINI_BACKEND, HF_BACKEND}:
@@ -775,6 +764,7 @@ class LocalStream:
                 get_available_voices=self.get_available_voices,
                 get_current_voice=self.get_current_voice,
                 change_voice=self.change_voice,
+                api_prefix=SETTINGS_API_PREFIX,
             )
         except Exception:
             logger.exception("Failed to mount personality routes; the personality UI will be unavailable")

--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class ApplyPayload(BaseModel):
-    """Body of POST /personalities/apply.
+    """Body of the apply-personality endpoint.
 
     Module-level: under postponed annotations, FastAPI can't resolve a
     function-local model and silently treats it as a query param.
@@ -58,9 +58,12 @@ def mount_personality_routes(
     get_available_voices: Callable[[], Awaitable[list[str]]] | None = None,
     get_current_voice: Callable[[], str] | None = None,
     change_voice: Callable[[str], Awaitable[str]] | None = None,
+    api_prefix: str | None = None,
 ) -> None:
     """Register personality management endpoints on a FastAPI app."""
     from fastapi.responses import JSONResponse
+
+    api_prefix = (api_prefix or "").rstrip("/")
 
     def _startup_choice() -> Any:
         """Return the persisted startup personality or default."""
@@ -87,7 +90,7 @@ def mount_personality_routes(
         current_voice_callback = get_current_voice or getattr(handler, "get_current_voice", None)
         return current_voice_callback() if callable(current_voice_callback) else None
 
-    @app.get("/personalities")
+    @app.get(f"{api_prefix}/personalities")
     def _list() -> dict:  # type: ignore
         choices = [DEFAULT_OPTION, *list_personalities()]
         return {
@@ -98,7 +101,7 @@ def mount_personality_routes(
             "locked_to": LOCKED_PROFILE,
         }
 
-    @app.get("/personalities/load")
+    @app.get(f"{api_prefix}/personalities/load")
     def _load(name: str) -> dict:  # type: ignore
         instr = read_instructions_for(name)
         tools_txt = read_tools_for(name)
@@ -124,7 +127,7 @@ def mount_personality_routes(
             "enabled_tools": enabled,
         }
 
-    @app.post("/personalities/save")
+    @app.post(f"{api_prefix}/personalities/save")
     async def _save(request: Request) -> dict:  # type: ignore
         # Accept raw JSON only to avoid validation-related 422s
         try:
@@ -166,7 +169,7 @@ def mount_personality_routes(
         except Exception as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)  # type: ignore
 
-    @app.post("/personalities/apply")
+    @app.post(f"{api_prefix}/personalities/apply")
     async def _apply(payload: ApplyPayload) -> dict:  # type: ignore
         if LOCKED_PROFILE is not None:
             return JSONResponse(
@@ -217,7 +220,7 @@ def mount_personality_routes(
         except Exception as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)  # type: ignore
 
-    @app.get("/voices")
+    @app.get(f"{api_prefix}/voices")
     async def _voices() -> list[str]:
         loop = get_loop()
         if loop is None:
@@ -237,7 +240,7 @@ def mount_personality_routes(
         except Exception:
             return get_available_voices_for_backend()
 
-    @app.get("/voices/current")
+    @app.get(f"{api_prefix}/voices/current")
     def _current_voice() -> dict[str, str]:
         try:
             if get_current_voice is not None:
@@ -246,7 +249,7 @@ def mount_personality_routes(
         except Exception:
             return {"voice": get_default_voice_for_backend()}
 
-    @app.post("/voices/apply")
+    @app.post(f"{api_prefix}/voices/apply")
     async def _apply_voice(request: Request, voice: str | None = Query(None)) -> dict:  # type: ignore
         voice = str(voice or "")
         if not voice:

--- a/src/reachy_mini_conversation_app/static/js/api.js
+++ b/src/reachy_mini_conversation_app/static/js/api.js
@@ -1,6 +1,7 @@
 /** HTTP client for all calls to the settings backend. */
 
 const DEFAULT_TIMEOUT_MS = 8000;
+export const API_PREFIX = "/api/v1";
 
 class HttpError extends Error {
   constructor(status, body, message) {
@@ -60,26 +61,26 @@ export async function untilReady(requestFn, signal, onRetry) {
   }
 }
 
-export const getStatus = () => request("GET", "/status");
+export const getStatus = () => request("GET", `${API_PREFIX}/status`);
 
 export const saveBackendConfig = (payload) =>
-  request("POST", "/backend_config", { body: payload });
+  request("POST", `${API_PREFIX}/backend_config`, { body: payload });
 
-export const listPersonalities = () => request("GET", "/personalities");
+export const listPersonalities = () => request("GET", `${API_PREFIX}/personalities`);
 export const loadPersonality = (name) =>
-  request("GET", `/personalities/load?name=${encodeURIComponent(name)}`);
+  request("GET", `${API_PREFIX}/personalities/load?name=${encodeURIComponent(name)}`);
 export const savePersonality = (payload) =>
-  request("POST", "/personalities/save", { body: payload });
+  request("POST", `${API_PREFIX}/personalities/save`, { body: payload });
 export const applyPersonality = (name, { persist = false } = {}) =>
-  request("POST", "/personalities/apply", { body: { name, persist } });
+  request("POST", `${API_PREFIX}/personalities/apply`, { body: { name, persist } });
 
-export const getMicState = () => request("GET", "/mic");
-export const setMicMuted = (muted) => request("POST", "/mic", { body: { muted } });
+export const getMicState = () => request("GET", `${API_PREFIX}/mic`);
+export const setMicMuted = (muted) => request("POST", `${API_PREFIX}/mic`, { body: { muted } });
 
-export const listVoices = () => request("GET", "/voices");
-export const getCurrentVoice = () => request("GET", "/voices/current");
+export const listVoices = () => request("GET", `${API_PREFIX}/voices`);
+export const getCurrentVoice = () => request("GET", `${API_PREFIX}/voices/current`);
 export const applyVoice = (voice) =>
-  request("POST", "/voices/apply", { body: { voice } });
+  request("POST", `${API_PREFIX}/voices/apply`, { body: { voice } });
 
 /** Backend error codes that need friendlier copy than the raw code. */
 const ERROR_MESSAGES = Object.freeze({

--- a/src/reachy_mini_conversation_app/static/js/views/talk.js
+++ b/src/reachy_mini_conversation_app/static/js/views/talk.js
@@ -4,14 +4,14 @@
  * Robot stays live, tapping the orb only mutes or unmutes the user's mic.
  */
 
-import { getMicState, listPersonalities, setMicMuted } from "../api.js";
+import { API_PREFIX, getMicState, listPersonalities, setMicMuted } from "../api.js";
 import { BUILT_IN_DEFAULT_OPTION, ORB_STATES } from "../constants.js";
 import { createOrb, mapActivityToState } from "../orb.js";
 import { consumePendingApply } from "../pending-apply.js";
 import { setPersonality } from "../personality-badge.js";
 import { h, prettifyProfileName } from "../ui.js";
 
-const SSE_ENDPOINT = "/conversation_events";
+const SSE_ENDPOINT = `${API_PREFIX}/conversation_events`;
 
 const CAPTION_BY_STATE = Object.freeze({
   [ORB_STATES.MUTED]: "Muted",

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from reachy_mini_conversation_app.config import GEMINI_AVAILABLE_VOICES, config
@@ -82,23 +82,67 @@ def test_clear_audio_queue_drains_queue_in_place() -> None:
 
 
 def test_mic_endpoints_report_and_toggle_mute_state() -> None:
-    """The mic starts live; /mic exposes and flips the pause state."""
+    """The mic starts live; the settings API exposes and flips the pause state."""
     app = FastAPI()
     robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
     stream = LocalStream(MagicMock(), robot, settings_app=app)
     stream._init_settings_ui_if_needed()
     client = TestClient(app)
 
-    assert client.get("/mic").json() == {"muted": False}
+    assert client.get("/api/v1/mic").json() == {"muted": False}
 
-    assert client.post("/mic", json={"muted": True}).json() == {"muted": True}
+    assert client.post("/api/v1/mic", json={"muted": True}).json() == {"muted": True}
     assert stream._mic_muted is True
 
-    assert client.post("/mic", json={"muted": False}).json() == {"muted": False}
+    assert client.post("/api/v1/mic", json={"muted": False}).json() == {"muted": False}
     assert stream._mic_muted is False
 
     # headless streams keep the mic live
     assert LocalStream(MagicMock(), robot)._mic_muted is False
+
+
+def test_settings_api_uses_versioned_routes_only() -> None:
+    """Settings clients should use the versioned API paths."""
+    app = FastAPI()
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    stream = LocalStream(MagicMock(), robot, settings_app=app)
+    stream._init_settings_ui_if_needed()
+    client = TestClient(app)
+
+    assert client.get("/api/v1/mic").json() == {"muted": False}
+
+    response = client.post("/api/v1/mic", json={"muted": True})
+
+    assert response.status_code == 200
+    assert response.json() == {"muted": True}
+    assert stream._mic_muted is True
+    assert client.get("/api/v1/status").json()["backend_provider"]
+    assert client.get("/api/v1/ready").status_code == 404
+    assert client.get("/status").status_code == 404
+    assert client.get("/ready").status_code == 404
+    assert client.post("/backend_config", json={"backend": "openai"}).status_code == 404
+    assert client.get("/mic").status_code == 404
+    assert client.post("/mic", json={"muted": False}).status_code == 404
+    assert client.get("/conversation_events").status_code == 404
+
+
+def test_settings_ui_detaches_framework_catch_all_before_api_routes() -> None:
+    """Framework fallback routes should not shadow the settings API."""
+    app = FastAPI()
+
+    @app.get("/{path:path}")
+    def _framework_fallback(path: str) -> None:
+        raise HTTPException(status_code=404)
+
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    stream = LocalStream(MagicMock(), robot, settings_app=app)
+    stream._init_settings_ui_if_needed()
+    client = TestClient(app)
+
+    assert client.get("/").status_code == 200
+    assert client.get("/static/js/api.js").status_code == 200
+    assert client.get("/api/v1/mic").status_code == 200
+    assert client.get("/api/v1/personalities").status_code == 200
 
 
 @pytest.mark.asyncio
@@ -146,7 +190,7 @@ def test_backend_config_persists_gemini_selection_and_status(
     client = TestClient(app)
 
     response = client.post(
-        "/backend_config",
+        "/api/v1/backend_config",
         json={"backend": "gemini", "api_key": "gem-test-token"},
     )
 
@@ -162,7 +206,7 @@ def test_backend_config_persists_gemini_selection_and_status(
     assert data["can_proceed_with_gemini"] is True
     assert data["requires_restart"] is True
 
-    status = client.get("/status")
+    status = client.get("/api/v1/status")
     assert status.status_code == 200
     status_data = status.json()
     assert status_data["backend_provider"] == "gemini"
@@ -206,7 +250,7 @@ def test_backend_config_requests_in_process_restart_with_handler_factory(
     stream._init_settings_ui_if_needed()
 
     response = TestClient(app).post(
-        "/backend_config",
+        "/api/v1/backend_config",
         json={"backend": "gemini", "api_key": "gem-test-token"},
     )
 
@@ -243,7 +287,7 @@ def test_backend_config_preserves_explicit_model_override_when_saving_key(
 
     client = TestClient(app)
     response = client.post(
-        "/backend_config",
+        "/api/v1/backend_config",
         json={"backend": "openai", "api_key": "openai-test-key"},
     )
 
@@ -285,7 +329,7 @@ def test_backend_config_persists_local_hf_selection_and_status(
 
     client = TestClient(app)
     response = client.post(
-        "/backend_config",
+        "/api/v1/backend_config",
         json={
             "backend": "huggingface",
             "hf_mode": "local",
@@ -345,7 +389,7 @@ def test_backend_config_persists_deployed_mode_without_clearing_local_hf_ws_url(
 
     client = TestClient(app)
     response = client.post(
-        "/backend_config",
+        "/api/v1/backend_config",
         json={
             "backend": "huggingface",
             "hf_mode": "deployed",
@@ -396,7 +440,7 @@ def test_backend_config_switches_to_saved_local_hf_connection_without_payload_ta
 
     client = TestClient(app)
     response = client.post(
-        "/backend_config",
+        "/api/v1/backend_config",
         json={"backend": "huggingface"},
     )
 
@@ -431,7 +475,7 @@ def test_backend_config_rejects_invalid_hf_port_zero(
 
     client = TestClient(app)
     response = client.post(
-        "/backend_config",
+        "/api/v1/backend_config",
         json={
             "backend": "huggingface",
             "hf_mode": "local",
@@ -460,7 +504,7 @@ def test_status_reports_direct_hf_ws_url_as_ready(
     stream._init_settings_ui_if_needed()
 
     client = TestClient(app)
-    response = client.get("/status")
+    response = client.get("/api/v1/status")
 
     assert response.status_code == 200
     data = response.json()
@@ -491,7 +535,7 @@ def test_status_reports_backend_connection_failure(
     stream._init_settings_ui_if_needed()
 
     client = TestClient(app)
-    response = client.get("/status")
+    response = client.get("/api/v1/status")
 
     assert response.status_code == 200
     data = response.json()
@@ -543,7 +587,7 @@ def test_backend_startup_failure_is_recorded_without_raising(
 
     handler.start_up.assert_awaited_once()
     client = TestClient(app)
-    response = client.get("/status")
+    response = client.get("/api/v1/status")
 
     assert response.status_code == 200
     data = response.json()
@@ -645,6 +689,27 @@ def test_personality_routes_return_gemini_voices_when_backend_selected(
     assert response.json() == GEMINI_AVAILABLE_VOICES
 
 
+def test_personality_routes_mount_versioned_paths() -> None:
+    """Personality and voice endpoints should use the configured API prefix."""
+    app = FastAPI()
+    handler = MagicMock()
+
+    mount_personality_routes(
+        app,
+        handler,
+        lambda: None,
+        api_prefix="/api/v1",
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/voices")
+
+    assert response.status_code == 200
+    assert client.get("/personalities").status_code == 404
+    assert client.get("/voices").status_code == 404
+    assert client.post("/voices/apply?voice=cedar").status_code == 404
+
+
 def test_personality_routes_load_builtin_default_tools() -> None:
     """Headless personality UI should expose built-in default tools on initial load."""
     app = FastAPI()
@@ -680,10 +745,10 @@ def test_personality_routes_apply_voice_accepts_query_param() -> None:
     started.wait(timeout=1.0)
 
     try:
-        mount_personality_routes(app, handler, lambda: loop)
+        mount_personality_routes(app, handler, lambda: loop, api_prefix="/api/v1")
 
         client = TestClient(app)
-        response = client.post("/voices/apply?voice=cedar")
+        response = client.post("/api/v1/voices/apply?voice=cedar")
 
         assert response.status_code == 200
         assert response.json() == {"ok": True, "status": "Voice changed to cedar."}


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
Adds versioned `/api/v1` settings routes for backend status/config, mic state, conversation events, personality management, and voice controls. The bundled web UI now calls the versioned routes, so the old settings API paths are no longer registered by the settings app.

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Local vision (`--local-vision`)
- [ ] Head tracker (`--head-tracker {yolo,mediapipe}`)
- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>

## Notes
Validated locally with:

- `.venv/bin/pytest tests/test_console.py -q` (30 passed)
- `node --check src/reachy_mini_conversation_app/static/js/api.js && node --check src/reachy_mini_conversation_app/static/js/views/talk.js`
- `.venv/bin/ruff check src/reachy_mini_conversation_app/console.py tests/test_console.py`
- `git ls-files -z '*.py' | xargs -0 .venv/bin/ruff check --fix`
- `git ls-files -z '*.py' | xargs -0 .venv/bin/ruff format`
- `.venv/bin/mypy --pretty --show-error-codes`

Full `.venv/bin/pytest tests/ -v` reached 249 passed / 1 failed; the failing `tests/test_profile_paths.py::test_wheel_file_paths_stay_within_windows_budget` retried and failed again because `uv build` timed out fetching `setuptools` from `https://pypi.registries.huggingface.tech/setuptools/`.