### PR TITLE
Align sleep startup and shutdown

### DIFF
--- a/src/reachy_mini_conversation_app/app_lifecycle.py
+++ b/src/reachy_mini_conversation_app/app_lifecycle.py
@@ -1,0 +1,83 @@
+"""Helpers for app startup and shutdown lifecycle behavior."""
+
+import asyncio
+import logging
+import urllib.error
+import urllib.request
+
+import numpy as np
+import numpy.typing as npt
+
+from reachy_mini import ReachyMini
+from reachy_mini.reachy_mini import SLEEP_HEAD_POSE
+from reachy_mini.utils.interpolation import distance_between_poses
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.go_to_sleep import GoToSleep
+
+
+_STOP_CURRENT_APP_PATH = "/api/apps/stop-current-app"
+_STOP_CURRENT_APP_TIMEOUT_S = 2.0
+_SLEEP_HEAD_TRANSLATION_TOLERANCE_M = 0.05
+_SLEEP_HEAD_ROTATION_TOLERANCE_RAD = 0.35
+
+
+def request_stop_current_app(robot: ReachyMini, logger: logging.Logger) -> bool:
+    """Request the Reachy Mini daemon to stop the current app."""
+    stop_current_app_url = f"http://{robot.client.host}:{robot.client.port}{_STOP_CURRENT_APP_PATH}"
+    request = urllib.request.Request(stop_current_app_url, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=_STOP_CURRENT_APP_TIMEOUT_S) as response:
+            response.read()
+    except urllib.error.URLError as e:
+        logger.error("Failed to request current app stop via %s: %s", stop_current_app_url, e)
+        return False
+
+    logger.info("Requested current app stop via %s", stop_current_app_url)
+    return True
+
+
+def _is_sleep_head_pose(head_pose: npt.ArrayLike) -> bool:
+    try:
+        current_head_pose: npt.NDArray[np.float64] = np.asarray(head_pose, dtype=np.float64)
+    except (TypeError, ValueError):
+        return False
+
+    if current_head_pose.shape != (4, 4):
+        return False
+
+    pose_distances = distance_between_poses(current_head_pose, SLEEP_HEAD_POSE)
+    translation_distance = float(pose_distances[0])
+    rotation_angle = float(pose_distances[1])
+    return (
+        translation_distance <= _SLEEP_HEAD_TRANSLATION_TOLERANCE_M
+        and rotation_angle <= _SLEEP_HEAD_ROTATION_TOLERANCE_RAD
+    )
+
+
+def wake_up_if_sleeping(robot: ReachyMini, logger: logging.Logger) -> bool:
+    """Run the SDK wake-up movement when Reachy starts from the sleep pose."""
+    try:
+        head_pose = robot.get_current_head_pose()
+    except Exception as e:
+        logger.warning("Could not read robot pose before startup wake-up check: %s", e)
+        return False
+
+    if not _is_sleep_head_pose(head_pose):
+        return False
+
+    logger.info("Robot is in sleep pose; running wake-up movement.")
+    try:
+        robot.wake_up()
+    except Exception as e:
+        logger.error("Failed to run wake-up movement: %s", e)
+        return False
+    return True
+
+
+def run_go_to_sleep_tool(deps: ToolDependencies, logger: logging.Logger) -> dict[str, object]:
+    """Run the shared go_to_sleep tool from synchronous shutdown paths."""
+    try:
+        return asyncio.run(GoToSleep()(deps))
+    except Exception as e:
+        logger.error("Failed to run go_to_sleep tool during shutdown: %s", e)
+        return {"error": f"go_to_sleep failed: {type(e).__name__}: {e}"}

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -7,8 +7,6 @@ import asyncio
 import logging
 import argparse
 import threading
-import urllib.error
-import urllib.request
 from typing import TYPE_CHECKING, Any, Optional
 from pathlib import Path
 from collections.abc import Callable, Awaitable
@@ -16,6 +14,7 @@ from collections.abc import Callable, Awaitable
 from fastapi import FastAPI, Request, Response
 
 from reachy_mini import ReachyMini, ReachyMiniApp
+from reachy_mini_conversation_app import app_lifecycle
 from reachy_mini_conversation_app.utils import (
     parse_args,
     setup_logger,
@@ -25,25 +24,6 @@ from reachy_mini_conversation_app.utils import (
 
 if TYPE_CHECKING:
     from reachy_mini_conversation_app.console import LocalStream
-
-
-_STOP_CURRENT_APP_PATH = "/api/apps/stop-current-app"
-_STOP_CURRENT_APP_TIMEOUT_S = 2.0
-
-
-def _request_stop_current_app(robot: ReachyMini, logger: logging.Logger) -> bool:
-    """Request the Reachy Mini daemon to stop the current app."""
-    stop_current_app_url = f"http://{robot.client.host}:{robot.client.port}{_STOP_CURRENT_APP_PATH}"
-    request = urllib.request.Request(stop_current_app_url, method="POST")
-    try:
-        with urllib.request.urlopen(request, timeout=_STOP_CURRENT_APP_TIMEOUT_S) as response:
-            response.read()
-    except urllib.error.URLError as e:
-        logger.error("Failed to request current app stop via %s: %s", stop_current_app_url, e)
-        return False
-
-    logger.info("Requested current app stop via %s", stop_current_app_url)
-    return True
 
 
 def _start_inactivity_timeout_thread(
@@ -187,6 +167,8 @@ def run(
             logger.error("Please check your configuration and try again.")
             sys.exit(1)
 
+    app_lifecycle.wake_up_if_sleeping(robot, logger)
+
     movement_manager = MovementManager(current_robot=robot)
 
     deps = ToolDependencies(
@@ -300,7 +282,9 @@ def run(
                 sleep_error = f"{type(e).__name__}: {e}"
                 logger.error("Failed to move Reachy Mini to sleep pose: %s", e)
 
-            stop_current_app_requested = _request_stop_current_app(robot, logger)
+            stop_current_app_requested = False
+            if app_stop_event is None or not app_stop_event.is_set():
+                stop_current_app_requested = app_lifecycle.request_stop_current_app(robot, logger)
             local_stop_requested = True
             if app_stop_event is not None:
                 app_stop_event.set()
@@ -323,6 +307,9 @@ def run(
             go_to_sleep_lock.release()
 
     deps.go_to_sleep = go_to_sleep_and_stop_app
+
+    def run_go_to_sleep_tool() -> dict[str, Any]:
+        return app_lifecycle.run_go_to_sleep_tool(deps, logger)
 
     if args.ui and settings_app is None and effective_settings_app is not None:
         import uvicorn
@@ -348,9 +335,7 @@ def run(
 
     timeout_minutes = resolve_app_timeout_minutes()
     if timeout_minutes is not None:
-        _start_inactivity_timeout_thread(
-            timeout_minutes, stream_manager, logger, app_stop_event, go_to_sleep_and_stop_app
-        )
+        _start_inactivity_timeout_thread(timeout_minutes, stream_manager, logger, app_stop_event, run_go_to_sleep_tool)
 
     def poll_stop_event() -> None:
         """Poll the stop event to allow graceful shutdown."""
@@ -358,6 +343,7 @@ def run(
             app_stop_event.wait()
 
         logger.info("App stop event detected, shutting down...")
+        run_go_to_sleep_tool()
         try:
             stream_manager.close()
         except Exception as e:
@@ -374,7 +360,9 @@ def run(
         if own_ui_server is not None:
             own_ui_server.should_exit = True
 
-        movement_manager.stop()
+        sleep_result = run_go_to_sleep_tool()
+        if "error" in sleep_result:
+            movement_manager.stop(reset_to_neutral=False)
         try:
             robot.disable_wobbling()
         except Exception as e:

--- a/tests/test_app_lifecycle.py
+++ b/tests/test_app_lifecycle.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from reachy_mini.reachy_mini import SLEEP_HEAD_POSE
+from reachy_mini_conversation_app import app_lifecycle
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+
+
+def test_request_stop_current_app_posts_to_daemon(monkeypatch) -> None:
+    """The app stop request should call the connected Reachy daemon endpoint."""
+
+    class FakeResponse:
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    def fake_urlopen(request, timeout):
+        assert request.full_url == "http://192.168.1.42:8000/api/apps/stop-current-app"
+        assert request.get_method() == "POST"
+        assert timeout == 2.0
+        return FakeResponse()
+
+    monkeypatch.setattr(app_lifecycle.urllib.request, "urlopen", fake_urlopen)
+    robot = SimpleNamespace(client=SimpleNamespace(host="192.168.1.42", port=8000))
+
+    assert app_lifecycle.request_stop_current_app(robot, MagicMock())
+
+
+def test_wake_up_if_sleeping_runs_wake_up_from_sleep_head_pose() -> None:
+    """Startup should play the wake-up movement when the robot head is sleeping."""
+    robot = MagicMock()
+    robot.get_current_head_pose.return_value = SLEEP_HEAD_POSE.copy()
+
+    assert app_lifecycle.wake_up_if_sleeping(robot, MagicMock())
+
+    robot.get_current_joint_positions.assert_not_called()
+    robot.wake_up.assert_called_once_with()
+
+
+def test_wake_up_if_sleeping_skips_non_sleep_head_pose() -> None:
+    """Startup should leave an already-awake robot alone."""
+    robot = MagicMock()
+    robot.get_current_head_pose.return_value = np.eye(4)
+
+    assert not app_lifecycle.wake_up_if_sleeping(robot, MagicMock())
+
+    robot.get_current_joint_positions.assert_not_called()
+    robot.wake_up.assert_not_called()
+
+
+def test_run_go_to_sleep_tool_uses_runtime_callback() -> None:
+    """Synchronous lifecycle paths should enter through the go_to_sleep tool."""
+    expected = {"status": "sleeping"}
+    go_to_sleep = MagicMock(return_value=expected)
+    deps = ToolDependencies(
+        reachy_mini=MagicMock(),
+        movement_manager=MagicMock(),
+        go_to_sleep=go_to_sleep,
+    )
+
+    result = app_lifecycle.run_go_to_sleep_tool(deps, MagicMock())
+
+    assert result == expected
+    go_to_sleep.assert_called_once_with()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,28 +40,3 @@ def test_inactivity_timeout_thread_closes_stream_manager_without_sleep_callback(
     thread.join(timeout=1.0)
     assert not thread.is_alive()
     stream_manager.close.assert_called_once_with()
-
-
-def test_request_stop_current_app_posts_to_daemon(monkeypatch) -> None:
-    """The app stop request should call the connected Reachy daemon endpoint."""
-
-    class FakeResponse:
-        def __enter__(self) -> "FakeResponse":
-            return self
-
-        def __exit__(self, *_args: object) -> None:
-            pass
-
-        def read(self) -> bytes:
-            return b"{}"
-
-    def fake_urlopen(request, timeout):
-        assert request.full_url == "http://192.168.1.42:8000/api/apps/stop-current-app"
-        assert request.get_method() == "POST"
-        assert timeout == 2.0
-        return FakeResponse()
-
-    monkeypatch.setattr(main_mod.urllib.request, "urlopen", fake_urlopen)
-    robot = SimpleNamespace(client=SimpleNamespace(host="192.168.1.42", port=8000))
-
-    assert main_mod._request_stop_current_app(robot, MagicMock())


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
- Route lifecycle shutdown paths through the existing `go_to_sleep` tool so app stops leave Reachy asleep instead of resetting to neutral.
- Wake Reachy at startup when the current antenna pose indicates it is still in the SDK sleep pose.
- Avoid sending a duplicate stop-current-app request when the daemon stop event is already set.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [x] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [x] Movement manager (dances, emotions, head motion)
- [x] Profiles or custom tools
</details>

## Notes
Validated locally with:
- `.venv/bin/ruff check $(git ls-files '*.py') --fix`
- `.venv/bin/ruff format $(git ls-files '*.py')`
- `.venv/bin/mypy --pretty --show-error-codes`
- `UV_INDEX_URL=https://pypi.org/simple UV_DEFAULT_INDEX=https://pypi.org/simple .venv/bin/pytest tests/ -v`

The explicit PyPI index avoids a local uv mirror timeout on this machine.
