### PR TITLE
Add a "delete" button to custom profiles

### DIFF
--- a/src/reachy_mini_conversation_app/personality.py
+++ b/src/reachy_mini_conversation_app/personality.py
@@ -115,6 +115,24 @@ def available_tools_for(selected: str) -> List[str]:
     return sorted(set(shared + local))
 
 
+def delete_personality(name: str) -> bool:
+    """Delete a user-created personality directory; return whether it existed.
+
+    Refuses anything outside the user personalities root, so built-in profiles
+    can never be removed through the UI.
+    """
+    import shutil
+
+    target = resolve_profile_dir(name).resolve()
+    user_root = config.user_personalities_root().resolve()
+    if user_root not in target.parents:
+        return False
+    if target.is_dir():
+        shutil.rmtree(target)
+        return True
+    return False
+
+
 def _write_profile(
     sanitized_name: str,
     instructions: str,

--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -170,8 +170,20 @@ def mount_personality_routes(
     @app.delete("/personalities")
     def _delete(name: str) -> dict:  # type: ignore
         """Delete a user-created personality (name is the full selection string)."""
+        if name in (_current_choice(), _startup_choice()):
+            # Deleting the active/startup profile would break get_session_instructions() at next startup.
+            return JSONResponse(
+                {"ok": False, "error": "profile_in_use", "choices": [DEFAULT_OPTION, *list_personalities()]},
+                status_code=409,
+            )  # type: ignore
         deleted = delete_personality(name)
-        return {"ok": deleted, "choices": [DEFAULT_OPTION, *list_personalities()]}
+        if not deleted:
+            # Built-in profile, outside the user root, or already gone — nothing was removed.
+            return JSONResponse(
+                {"ok": False, "error": "not_deletable", "choices": [DEFAULT_OPTION, *list_personalities()]},
+                status_code=404,
+            )  # type: ignore
+        return {"ok": True, "choices": [DEFAULT_OPTION, *list_personalities()]}
 
     @app.post("/personalities/apply")
     async def _apply(payload: ApplyPayload) -> dict:  # type: ignore

--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -25,6 +25,7 @@ from .personality import (
     _write_profile,
     read_tools_for,
     read_greeting_for,
+    delete_personality,
     list_personalities,
     available_tools_for,
     resolve_profile_dir,
@@ -165,6 +166,12 @@ def mount_personality_routes(
             return {"ok": True, "value": value, "choices": choices}
         except Exception as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)  # type: ignore
+
+    @app.delete("/personalities")
+    def _delete(name: str) -> dict:  # type: ignore
+        """Delete a user-created personality (name is the full selection string)."""
+        deleted = delete_personality(name)
+        return {"ok": deleted, "choices": [DEFAULT_OPTION, *list_personalities()]}
 
     @app.post("/personalities/apply")
     async def _apply(payload: ApplyPayload) -> dict:  # type: ignore

--- a/src/reachy_mini_conversation_app/static/js/api.js
+++ b/src/reachy_mini_conversation_app/static/js/api.js
@@ -72,6 +72,8 @@ export const savePersonality = (payload) =>
   request("POST", "/personalities/save", { body: payload });
 export const applyPersonality = (name, { persist = false } = {}) =>
   request("POST", "/personalities/apply", { body: { name, persist } });
+export const deletePersonality = (name) =>
+  request("DELETE", `/personalities?name=${encodeURIComponent(name)}`);
 
 export const getMicState = () => request("GET", "/mic");
 export const setMicMuted = (muted) => request("POST", "/mic", { body: { muted } });

--- a/src/reachy_mini_conversation_app/static/js/api.js
+++ b/src/reachy_mini_conversation_app/static/js/api.js
@@ -95,6 +95,8 @@ const ERROR_MESSAGES = Object.freeze({
   invalid_name: "Enter a valid profile name.",
   missing_voice: "Choose a voice first.",
   profile_locked: "Profile switching is locked by the administrator.",
+  profile_in_use: "This personality is active or set to load at startup. Switch to another one first.",
+  not_deletable: "This personality can't be deleted.",
   loop_unavailable: "Reachy is still starting up. Try again in a moment.",
 });
 

--- a/src/reachy_mini_conversation_app/static/js/components/confirm-dialog.js
+++ b/src/reachy_mini_conversation_app/static/js/components/confirm-dialog.js
@@ -35,8 +35,9 @@ export function confirmDialog({
       resolve(value);
     }
     function onKeydown(event) {
+      // Only handle Escape globally; let the focused button handle Enter/click
+      // natively, so pressing Enter on Cancel cancels rather than confirms.
       if (event.key === "Escape") close(false);
-      else if (event.key === "Enter") close(true);
     }
     overlay.addEventListener("click", (event) => {
       if (event.target === overlay) close(false);

--- a/src/reachy_mini_conversation_app/static/js/components/confirm-dialog.js
+++ b/src/reachy_mini_conversation_app/static/js/components/confirm-dialog.js
@@ -1,0 +1,49 @@
+/** In-app confirmation dialog. Replaces window.confirm, which embedded app hosts
+ * (the Reachy Mini control's webview / sandboxed iframes) silently suppress.
+ * Resolves true if confirmed, false otherwise. */
+
+import { h } from "../ui.js";
+
+export function confirmDialog({
+  title = "Are you sure?",
+  message = "",
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  danger = false,
+} = {}) {
+  return new Promise((resolve) => {
+    const overlay = h("div", { class: "modal-overlay", role: "presentation" });
+    const cancelBtn = h("button", { type: "button", class: "btn btn--ghost" }, cancelLabel);
+    const confirmBtn = h(
+      "button",
+      { type: "button", class: ["btn", danger ? "btn--danger" : "btn--primary"] },
+      confirmLabel
+    );
+    const dialog = h(
+      "div",
+      { class: "modal modal--confirm", role: "dialog", "aria-modal": "true", "aria-labelledby": "confirm-title" },
+      h("h2", { id: "confirm-title", class: "modal__title" }, title),
+      message ? h("p", { class: "modal__subtitle" }, message) : null,
+      h("div", { class: "modal__actions" }, cancelBtn, confirmBtn)
+    );
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    function close(value) {
+      window.removeEventListener("keydown", onKeydown);
+      overlay.remove();
+      resolve(value);
+    }
+    function onKeydown(event) {
+      if (event.key === "Escape") close(false);
+      else if (event.key === "Enter") close(true);
+    }
+    overlay.addEventListener("click", (event) => {
+      if (event.target === overlay) close(false);
+    });
+    cancelBtn.addEventListener("click", () => close(false));
+    confirmBtn.addEventListener("click", () => close(true));
+    window.addEventListener("keydown", onKeydown);
+    requestAnimationFrame(() => confirmBtn.focus());
+  });
+}

--- a/src/reachy_mini_conversation_app/static/js/views/home.js
+++ b/src/reachy_mini_conversation_app/static/js/views/home.js
@@ -2,6 +2,7 @@
 
 import {
   applyPersonality,
+  deletePersonality,
   describeError,
   listPersonalities,
   loadPersonality,
@@ -16,6 +17,7 @@ import {
 } from "../constants.js";
 import { $, h, prettifyProfileName } from "../ui.js";
 import { openProfileModal } from "../components/profile-modal.js";
+import { confirmDialog } from "../components/confirm-dialog.js";
 import { setPendingApply } from "../pending-apply.js";
 import { setPersonality } from "../personality-badge.js";
 
@@ -70,6 +72,9 @@ export async function mountHomeView({ outlet, signal, navigate }) {
         disabled,
         onSelect: () => handleSelection(name),
         onEdit: editable ? () => handleEditClick(name) : null,
+        // No delete affordance for the active personality: it would keep
+        // running with no card to manage it.
+        onDelete: editable && name !== current ? (slot) => handleDeleteClick(name, slot) : null,
       })
     );
   }
@@ -193,9 +198,31 @@ export async function mountHomeView({ outlet, signal, navigate }) {
       status.textContent = `Saved "${prettifyProfileName(name)}". It will apply next time you select it.`;
     }
   }
+
+  async function handleDeleteClick(name, slot) {
+    const ok = await confirmDialog({
+      title: "Delete personality?",
+      message: `"${prettifyProfileName(name)}" will be permanently removed.`,
+      confirmLabel: "Delete",
+      danger: true,
+    });
+    if (!ok || signal.aborted) return;
+    status.classList.remove("is-warning", "is-error");
+    try {
+      await deletePersonality(name);
+    } catch (error) {
+      if (signal.aborted) return;
+      status.textContent = `Failed to delete: ${describeError(error)}`;
+      status.classList.add("is-error");
+      return;
+    }
+    if (signal.aborted) return;
+    slot.remove();
+    status.textContent = `Deleted "${prettifyProfileName(name)}".`;
+  }
 }
 
-function buildPersonalityCard({ name, isActive, disabled, onSelect, onEdit }) {
+function buildPersonalityCard({ name, isActive, disabled, onSelect, onEdit, onDelete }) {
   const hasAvatar = Object.prototype.hasOwnProperty.call(AVATAR_BY_PROFILE, stripUserPrefix(name));
   const card = h(
     "button",
@@ -222,13 +249,29 @@ function buildPersonalityCard({ name, isActive, disabled, onSelect, onEdit }) {
     h("span", { class: "personality-card__name" }, prettifyProfileName(name)),
     isActive && checkBadge()
   );
-  // Wrap so the edit button is a sibling, not a nested <button> inside the card button.
-  return h(
-    "div",
-    { class: "personality-card-slot", role: "listitem" },
-    card,
-    onEdit ? buildEditButton({ name, onEdit }) : null
-  );
+  // Wrap so the edit/delete buttons are siblings, not nested <button>s inside the card button.
+  const slot = h("div", { class: "personality-card-slot", role: "listitem" }, card);
+  if (onDelete) slot.appendChild(buildDeleteButton({ name, onDelete: () => onDelete(slot) }));
+  if (onEdit) slot.appendChild(buildEditButton({ name, onEdit }));
+  return slot;
+}
+
+/** Small overlay button to delete a user personality, anchored left of the edit button. */
+function buildDeleteButton({ name, onDelete }) {
+  return h("button", {
+    type: "button",
+    class: "personality-card__delete",
+    "aria-label": `Delete personality ${prettifyProfileName(name)}`,
+    onClick: onDelete,
+    html: `
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M3 6h18"/>
+        <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"/>
+        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+        <path d="M10 11v6"/>
+        <path d="M14 11v6"/>
+      </svg>`,
+  });
 }
 
 /** Small overlay button to edit a user personality, anchored to the card corner. */

--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -421,6 +421,16 @@ button {
   color: var(--text);
 }
 
+.btn--danger {
+  background: #e5484d;
+  color: #fff;
+  font-weight: 600;
+}
+
+.btn--danger:hover:not(:disabled) {
+  background: color-mix(in srgb, #e5484d 88%, black);
+}
+
 .route-error {
   margin: 32px;
   padding: 16px;
@@ -450,7 +460,8 @@ button {
   width: 100%;
 }
 
-.personality-card__edit {
+.personality-card__edit,
+.personality-card__delete {
   position: absolute;
   top: 8px;
   right: 8px;
@@ -470,8 +481,15 @@ button {
     color var(--transition-fast);
 }
 
+/* Delete sits just left of the edit button. */
+.personality-card__delete {
+  right: 44px;
+}
+
 .personality-card-slot:hover .personality-card__edit,
-.personality-card__edit:focus-visible {
+.personality-card-slot:hover .personality-card__delete,
+.personality-card__edit:focus-visible,
+.personality-card__delete:focus-visible {
   opacity: 1;
 }
 
@@ -480,7 +498,13 @@ button {
   color: var(--text);
 }
 
-.personality-card__edit svg {
+.personality-card__delete:hover {
+  background: color-mix(in srgb, #e5484d 16%, var(--bg-elev));
+  color: #e5484d;
+}
+
+.personality-card__edit svg,
+.personality-card__delete svg {
   width: 15px;
   height: 15px;
 }
@@ -835,6 +859,11 @@ button {
 @keyframes modal-pop-in {
   from { transform: translateY(8px) scale(0.98); opacity: 0; }
   to   { transform: translateY(0)   scale(1);    opacity: 1; }
+}
+
+/* Confirmation dialog: a compact modal that replaces window.confirm. */
+.modal--confirm {
+  width: min(420px, 100%);
 }
 
 .modal__title {

--- a/tests/test_personality_delete.py
+++ b/tests/test_personality_delete.py
@@ -1,0 +1,116 @@
+"""Regression coverage for deleting custom personalities.
+
+Delete touches persisted user data, so we pin down both the storage-level
+contract (`delete_personality`) and the route-level guard that protects the
+active/startup profile from being removed underneath a running app.
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import reachy_mini_conversation_app.personality as personality_mod
+from reachy_mini_conversation_app.config import config
+from reachy_mini_conversation_app.personality import delete_personality
+from reachy_mini_conversation_app.personality_routes import mount_personality_routes
+
+
+def _make_user_profile(name: str) -> None:
+    """Create a minimal UI-style profile under the writable user root."""
+    personality_mod._write_profile(name, "Be brief.", "")
+
+
+def test_delete_removes_user_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A UI-created profile under the user root can be deleted."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+    _make_user_profile("doomed")
+    profile_dir = tmp_path / "user_personalities" / "doomed"
+    assert profile_dir.is_dir()
+
+    assert delete_personality("user_personalities/doomed") is True
+    assert not profile_dir.exists()
+
+
+def test_delete_refuses_builtin_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Built-in profiles live outside the user root and must never be deletable."""
+    builtin_dir = personality_mod.resolve_profile_dir("mad_scientist_assistant")
+    assert builtin_dir.is_dir()
+
+    assert delete_personality("mad_scientist_assistant") is False
+    assert builtin_dir.is_dir()
+
+
+def test_delete_refuses_path_outside_user_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A traversal selection escaping the user root is refused, not followed."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+    victim = tmp_path / "user_personalities" / "outside_target"
+    victim.mkdir(parents=True)
+
+    assert delete_personality("user_personalities/../outside_target") is False
+    assert victim.is_dir()
+
+
+def _client(monkeypatch: pytest.MonkeyPatch, persisted: str | None = None) -> TestClient:
+    """Mount the personality routes with stub callbacks for delete-guard tests."""
+    app = FastAPI()
+    mount_personality_routes(
+        app,
+        handler=object(),  # type: ignore[arg-type]  # delete route does not touch the handler
+        get_loop=lambda: None,
+        get_persisted_personality=(lambda: persisted),
+    )
+    return TestClient(app)
+
+
+def test_route_refuses_deleting_current_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deleting the live profile would break get_session_instructions() next startup."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "user_personalities/live")
+    _make_user_profile("live")
+
+    resp = _client(monkeypatch).delete("/personalities", params={"name": "user_personalities/live"})
+
+    assert resp.status_code == 409
+    assert resp.json()["error"] == "profile_in_use"
+    assert (tmp_path / "user_personalities" / "live").is_dir()
+
+
+def test_route_refuses_deleting_startup_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The persisted startup profile is guarded even when it is not the live one."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+    _make_user_profile("boots")
+
+    client = _client(monkeypatch, persisted="user_personalities/boots")
+    resp = client.delete("/personalities", params={"name": "user_personalities/boots"})
+
+    assert resp.status_code == 409
+    assert resp.json()["error"] == "profile_in_use"
+    assert (tmp_path / "user_personalities" / "boots").is_dir()
+
+
+def test_route_deletes_inactive_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A profile that is neither live nor startup is deleted and returns ok."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "user_personalities/live")
+    _make_user_profile("live")
+    _make_user_profile("spare")
+
+    resp = _client(monkeypatch).delete("/personalities", params={"name": "user_personalities/spare"})
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert not (tmp_path / "user_personalities" / "spare").exists()
+
+
+def test_route_returns_404_for_non_deletable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Built-in/missing deletes report a non-2xx so the UI keeps the card."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
+    resp = _client(monkeypatch).delete("/personalities", params={"name": "mad_scientist_assistant"})
+
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "not_deletable"


### PR DESCRIPTION
The new UI allows to create and edit custom profiles personality, but not delete them.
This adds a small trash icon, a confirmation window.
It applies only to custom profiles (not built-in ones)
There is a guard against deleting the current active profile (icon does not show up).

<img width="863" height="391" alt="image" src="https://github.com/user-attachments/assets/bdf55643-8c5c-4777-9286-d6bf25317473" />
