### PR TITLE
Add set as default action for personalities

### DIFF
--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -62,8 +62,8 @@ def mount_personality_routes(
     """Register personality management endpoints on a FastAPI app."""
     from fastapi.responses import JSONResponse
 
-    def _startup_choice() -> Any:
-        """Return the persisted startup personality or default."""
+    def _configured_startup_choice() -> Any:
+        """Return the startup personality configured when routes mount."""
         try:
             if get_persisted_personality is not None:
                 stored = get_persisted_personality()
@@ -75,6 +75,23 @@ def mount_personality_routes(
         except Exception:
             pass
         return DEFAULT_OPTION
+
+    startup_choice = _configured_startup_choice()
+
+    def _startup_choice() -> Any:
+        """Return the persisted startup personality or default."""
+        try:
+            if get_persisted_personality is not None:
+                stored = get_persisted_personality()
+                if stored:
+                    return stored
+        except Exception:
+            pass
+        return startup_choice
+
+    def _set_startup_choice(selected_name: str) -> None:
+        nonlocal startup_choice
+        startup_choice = DEFAULT_OPTION if selected_name == DEFAULT_OPTION else selected_name
 
     def _current_choice() -> str:
         try:
@@ -182,6 +199,7 @@ def mount_personality_routes(
                 try:
                     voice_override = _voice_override()
                     persist_personality(None if selected_name == DEFAULT_OPTION else selected_name, voice_override)
+                    _set_startup_choice(selected_name)
                     persisted_choice = _startup_choice()
                 except Exception as e:
                     logger.warning("Failed to persist startup personality: %s", e)
@@ -210,6 +228,7 @@ def mount_personality_routes(
             if persist and persist_personality is not None:
                 try:
                     persist_personality(None if selected_name == DEFAULT_OPTION else selected_name, voice_override)
+                    _set_startup_choice(selected_name)
                     persisted_choice = _startup_choice()
                 except Exception as e:
                     logger.warning("Failed to persist startup personality: %s", e)

--- a/src/reachy_mini_conversation_app/static/index.html
+++ b/src/reachy_mini_conversation_app/static/index.html
@@ -43,22 +43,31 @@
         </svg>
       </button>
     </header>
-    <button
-      type="button"
-      class="app-shell__personality"
-      data-component="personality-badge"
-      data-action="open-personalities"
-      aria-label="Change personality"
-      hidden
-    >
-      <span class="app-shell__personality-avatar" aria-hidden="true">
-        <img src="/static/avatars/default.svg" alt="" draggable="false" />
-      </span>
-      <span class="app-shell__personality-text">
-        <span class="app-shell__personality-label">Personality</span>
-        <span class="app-shell__personality-name" aria-live="polite"></span>
-      </span>
-    </button>
+    <div class="app-shell__personality-row" data-component="personality-row" hidden>
+      <button
+        type="button"
+        class="app-shell__personality"
+        data-component="personality-badge"
+        data-action="open-personalities"
+        aria-label="Change personality"
+      >
+        <span class="app-shell__personality-avatar" aria-hidden="true">
+          <img src="/static/avatars/default.svg" alt="" draggable="false" />
+        </span>
+        <span class="app-shell__personality-text">
+          <span class="app-shell__personality-label">Personality</span>
+          <span class="app-shell__personality-name" aria-live="polite"></span>
+        </span>
+      </button>
+      <button
+        type="button"
+        class="app-shell__default-personality"
+        data-component="default-personality-action"
+        hidden
+      >
+        Set as default
+      </button>
+    </div>
     <main id="view-outlet" class="app-shell__outlet" role="main"></main>
   </body>
 </html>

--- a/src/reachy_mini_conversation_app/static/js/personality-badge.js
+++ b/src/reachy_mini_conversation_app/static/js/personality-badge.js
@@ -7,6 +7,7 @@ import { avatarFor } from "./constants.js";
 import { prettifyProfileName } from "./ui.js";
 
 let rootEl = null;
+let rowEl = null;
 let nameEl = null;
 let avatarImg = null;
 
@@ -15,6 +16,7 @@ export function mountPersonalityBadge(headerRoot = document) {
   const next = headerRoot.querySelector('[data-component="personality-badge"]');
   if (!next) return;
   rootEl = next;
+  rowEl = next.closest('[data-component="personality-row"]');
   nameEl = next.querySelector(".app-shell__personality-name");
   avatarImg = next.querySelector(".app-shell__personality-avatar img");
 }
@@ -29,9 +31,11 @@ export function setPersonality(rawName) {
 }
 
 export function showPersonalityBadge() {
-  if (rootEl) rootEl.hidden = false;
+  if (rowEl) rowEl.hidden = false;
+  else if (rootEl) rootEl.hidden = false;
 }
 
 export function hidePersonalityBadge() {
-  if (rootEl) rootEl.hidden = true;
+  if (rowEl) rowEl.hidden = true;
+  else if (rootEl) rootEl.hidden = true;
 }

--- a/src/reachy_mini_conversation_app/static/js/personality-badge.js
+++ b/src/reachy_mini_conversation_app/static/js/personality-badge.js
@@ -11,6 +11,8 @@ let rowEl = null;
 let nameEl = null;
 let avatarImg = null;
 
+const DEBUG_PREFIX = "[personality-badge]";
+
 /** Bind setters to the static markup. Safe to call multiple times. */
 export function mountPersonalityBadge(headerRoot = document) {
   const next = headerRoot.querySelector('[data-component="personality-badge"]');
@@ -19,6 +21,11 @@ export function mountPersonalityBadge(headerRoot = document) {
   rowEl = next.closest('[data-component="personality-row"]');
   nameEl = next.querySelector(".app-shell__personality-name");
   avatarImg = next.querySelector(".app-shell__personality-avatar img");
+  console.info(DEBUG_PREFIX, "mounted", JSON.stringify({
+    hasBadge: Boolean(rootEl),
+    hasRow: Boolean(rowEl),
+    hasDefaultAction: Boolean(headerRoot.querySelector('[data-component="default-personality-action"]')),
+  }));
 }
 
 /** Update the badge content. Pass a falsy name to keep the previous value. */
@@ -33,9 +40,17 @@ export function setPersonality(rawName) {
 export function showPersonalityBadge() {
   if (rowEl) rowEl.hidden = false;
   else if (rootEl) rootEl.hidden = false;
+  console.info(DEBUG_PREFIX, "show", JSON.stringify({
+    rowHidden: rowEl?.hidden,
+    badgeHidden: rootEl?.hidden,
+  }));
 }
 
 export function hidePersonalityBadge() {
   if (rowEl) rowEl.hidden = true;
   else if (rootEl) rootEl.hidden = true;
+  console.info(DEBUG_PREFIX, "hide", JSON.stringify({
+    rowHidden: rowEl?.hidden,
+    badgeHidden: rootEl?.hidden,
+  }));
 }

--- a/src/reachy_mini_conversation_app/static/js/personality-badge.js
+++ b/src/reachy_mini_conversation_app/static/js/personality-badge.js
@@ -11,8 +11,6 @@ let rowEl = null;
 let nameEl = null;
 let avatarImg = null;
 
-const DEBUG_PREFIX = "[personality-badge]";
-
 /** Bind setters to the static markup. Safe to call multiple times. */
 export function mountPersonalityBadge(headerRoot = document) {
   const next = headerRoot.querySelector('[data-component="personality-badge"]');
@@ -21,11 +19,6 @@ export function mountPersonalityBadge(headerRoot = document) {
   rowEl = next.closest('[data-component="personality-row"]');
   nameEl = next.querySelector(".app-shell__personality-name");
   avatarImg = next.querySelector(".app-shell__personality-avatar img");
-  console.info(DEBUG_PREFIX, "mounted", JSON.stringify({
-    hasBadge: Boolean(rootEl),
-    hasRow: Boolean(rowEl),
-    hasDefaultAction: Boolean(headerRoot.querySelector('[data-component="default-personality-action"]')),
-  }));
 }
 
 /** Update the badge content. Pass a falsy name to keep the previous value. */
@@ -40,17 +33,9 @@ export function setPersonality(rawName) {
 export function showPersonalityBadge() {
   if (rowEl) rowEl.hidden = false;
   else if (rootEl) rootEl.hidden = false;
-  console.info(DEBUG_PREFIX, "show", JSON.stringify({
-    rowHidden: rowEl?.hidden,
-    badgeHidden: rootEl?.hidden,
-  }));
 }
 
 export function hidePersonalityBadge() {
   if (rowEl) rowEl.hidden = true;
   else if (rootEl) rootEl.hidden = true;
-  console.info(DEBUG_PREFIX, "hide", JSON.stringify({
-    rowHidden: rowEl?.hidden,
-    badgeHidden: rootEl?.hidden,
-  }));
 }

--- a/src/reachy_mini_conversation_app/static/js/views/home.js
+++ b/src/reachy_mini_conversation_app/static/js/views/home.js
@@ -58,7 +58,6 @@ export async function mountHomeView({ outlet, signal, navigate }) {
   const choices = (personalities?.choices || []).filter((name) => name !== BUILT_IN_DEFAULT_OPTION);
   const current = personalities?.current;
   const lockedTo = personalities?.locked ? personalities.locked_to : null;
-  let startupChoice = personalities?.startup || BUILT_IN_DEFAULT_OPTION;
 
   renderGrid();
   if (lockedTo) {
@@ -77,10 +76,8 @@ export async function mountHomeView({ outlet, signal, navigate }) {
           name,
           isActive,
           disabled,
-          showDefaultAction: isActive && !disabled && name !== startupChoice,
           onSelect: () => handleSelection(name),
           onEdit: editable ? () => handleEditClick(name) : null,
-          onSetDefault: () => handleSetDefault(name),
         })
       );
     }
@@ -101,22 +98,6 @@ export async function mountHomeView({ outlet, signal, navigate }) {
     // the orb in CONNECTING immediately instead of waiting on home.
     setPendingApply({ name, promise: applyPersonality(name, { persist: false }) });
     navigate(ROUTES.TALK);
-  }
-
-  async function handleSetDefault(name) {
-    status.classList.remove("is-warning", "is-error");
-    status.textContent = `Saving "${prettifyProfileName(name)}" as default…`;
-    try {
-      const result = await applyPersonality(name, { persist: true });
-      if (signal.aborted) return;
-      startupChoice = result?.startup || name;
-      renderGrid();
-      status.textContent = `"${prettifyProfileName(name)}" will be used at startup.`;
-    } catch (error) {
-      if (signal.aborted) return;
-      status.textContent = `Failed to save default: ${describeError(error)}`;
-      status.classList.add("is-error");
-    }
   }
 
   async function handleCustomClick() {
@@ -218,7 +199,7 @@ export async function mountHomeView({ outlet, signal, navigate }) {
   }
 }
 
-function buildPersonalityCard({ name, isActive, disabled, showDefaultAction, onSelect, onEdit, onSetDefault }) {
+function buildPersonalityCard({ name, isActive, disabled, onSelect, onEdit }) {
   const hasAvatar = Object.prototype.hasOwnProperty.call(AVATAR_BY_PROFILE, stripUserPrefix(name));
   const card = h(
     "button",
@@ -248,10 +229,9 @@ function buildPersonalityCard({ name, isActive, disabled, showDefaultAction, onS
   // Wrap so the edit button is a sibling, not a nested <button> inside the card button.
   return h(
     "div",
-    { class: ["personality-card-slot", showDefaultAction && "has-default-action"], role: "listitem" },
+    { class: "personality-card-slot", role: "listitem" },
     card,
-    onEdit ? buildEditButton({ name, onEdit }) : null,
-    showDefaultAction ? buildSetDefaultButton({ name, onSetDefault }) : null
+    onEdit ? buildEditButton({ name, onEdit }) : null
   );
 }
 
@@ -268,19 +248,6 @@ function buildEditButton({ name, onEdit }) {
         <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/>
       </svg>`,
   });
-}
-
-function buildSetDefaultButton({ name, onSetDefault }) {
-  return h(
-    "button",
-    {
-      type: "button",
-      class: "personality-card__default",
-      "aria-label": `Use ${prettifyProfileName(name)} at startup`,
-      onClick: onSetDefault,
-    },
-    "Set as default"
-  );
 }
 
 function checkBadge() {

--- a/src/reachy_mini_conversation_app/static/js/views/home.js
+++ b/src/reachy_mini_conversation_app/static/js/views/home.js
@@ -58,26 +58,33 @@ export async function mountHomeView({ outlet, signal, navigate }) {
   const choices = (personalities?.choices || []).filter((name) => name !== BUILT_IN_DEFAULT_OPTION);
   const current = personalities?.current;
   const lockedTo = personalities?.locked ? personalities.locked_to : null;
+  let startupChoice = personalities?.startup || BUILT_IN_DEFAULT_OPTION;
 
-  grid.replaceChildren();
-  for (const name of choices) {
-    const disabled = Boolean(lockedTo) && name !== lockedTo;
-    const editable = name.startsWith("user_personalities/") && !disabled;
-    grid.appendChild(
-      buildPersonalityCard({
-        name,
-        isActive: name === current,
-        disabled,
-        onSelect: () => handleSelection(name),
-        onEdit: editable ? () => handleEditClick(name) : null,
-      })
-    );
-  }
-  grid.appendChild(buildCustomCard({ onClick: handleCustomClick }));
-
+  renderGrid();
   if (lockedTo) {
     status.textContent = `Profile locked to "${lockedTo}" by REACHY_MINI_LOCKED_PROFILE; switching is disabled.`;
     status.classList.add("is-warning");
+  }
+
+  function renderGrid() {
+    grid.replaceChildren();
+    for (const name of choices) {
+      const disabled = Boolean(lockedTo) && name !== lockedTo;
+      const isActive = name === current;
+      const editable = name.startsWith("user_personalities/") && !disabled;
+      grid.appendChild(
+        buildPersonalityCard({
+          name,
+          isActive,
+          disabled,
+          showDefaultAction: isActive && !disabled && name !== startupChoice,
+          onSelect: () => handleSelection(name),
+          onEdit: editable ? () => handleEditClick(name) : null,
+          onSetDefault: () => handleSetDefault(name),
+        })
+      );
+    }
+    grid.appendChild(buildCustomCard({ onClick: handleCustomClick }));
   }
 
   function handleSelection(name) {
@@ -94,6 +101,22 @@ export async function mountHomeView({ outlet, signal, navigate }) {
     // the orb in CONNECTING immediately instead of waiting on home.
     setPendingApply({ name, promise: applyPersonality(name, { persist: false }) });
     navigate(ROUTES.TALK);
+  }
+
+  async function handleSetDefault(name) {
+    status.classList.remove("is-warning", "is-error");
+    status.textContent = `Saving "${prettifyProfileName(name)}" as default…`;
+    try {
+      const result = await applyPersonality(name, { persist: true });
+      if (signal.aborted) return;
+      startupChoice = result?.startup || name;
+      renderGrid();
+      status.textContent = `"${prettifyProfileName(name)}" will be used at startup.`;
+    } catch (error) {
+      if (signal.aborted) return;
+      status.textContent = `Failed to save default: ${describeError(error)}`;
+      status.classList.add("is-error");
+    }
   }
 
   async function handleCustomClick() {
@@ -195,7 +218,7 @@ export async function mountHomeView({ outlet, signal, navigate }) {
   }
 }
 
-function buildPersonalityCard({ name, isActive, disabled, onSelect, onEdit }) {
+function buildPersonalityCard({ name, isActive, disabled, showDefaultAction, onSelect, onEdit, onSetDefault }) {
   const hasAvatar = Object.prototype.hasOwnProperty.call(AVATAR_BY_PROFILE, stripUserPrefix(name));
   const card = h(
     "button",
@@ -225,9 +248,10 @@ function buildPersonalityCard({ name, isActive, disabled, onSelect, onEdit }) {
   // Wrap so the edit button is a sibling, not a nested <button> inside the card button.
   return h(
     "div",
-    { class: "personality-card-slot", role: "listitem" },
+    { class: ["personality-card-slot", showDefaultAction && "has-default-action"], role: "listitem" },
     card,
-    onEdit ? buildEditButton({ name, onEdit }) : null
+    onEdit ? buildEditButton({ name, onEdit }) : null,
+    showDefaultAction ? buildSetDefaultButton({ name, onSetDefault }) : null
   );
 }
 
@@ -244,6 +268,19 @@ function buildEditButton({ name, onEdit }) {
         <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/>
       </svg>`,
   });
+}
+
+function buildSetDefaultButton({ name, onSetDefault }) {
+  return h(
+    "button",
+    {
+      type: "button",
+      class: "personality-card__default",
+      "aria-label": `Use ${prettifyProfileName(name)} at startup`,
+      onClick: onSetDefault,
+    },
+    "Set as default"
+  );
 }
 
 function checkBadge() {

--- a/src/reachy_mini_conversation_app/static/js/views/talk.js
+++ b/src/reachy_mini_conversation_app/static/js/views/talk.js
@@ -31,16 +31,11 @@ export async function mountTalkView({ outlet, signal }) {
   let activePersonality = null;
 
   const caption = h("p", { class: "talk__caption" }, CAPTION_BY_STATE[ORB_STATES.CONNECTING]);
-  const defaultAction = h(
-    "button",
-    {
-      type: "button",
-      class: "talk__default-action",
-      hidden: "hidden",
-      onClick: onSetDefault,
-    },
-    "Set as default"
-  );
+  const defaultAction = document.querySelector('[data-component="default-personality-action"]');
+  if (defaultAction) {
+    defaultAction.hidden = true;
+    defaultAction.addEventListener("click", onSetDefault);
+  }
   const orb = createOrb({
     initialState: ORB_STATES.CONNECTING,
     onStateChange: (state) => {
@@ -54,8 +49,7 @@ export async function mountTalkView({ outlet, signal }) {
     "section",
     { class: "view view--talk" },
     h("div", { class: "talk__orb-wrap" }, orb.root),
-    caption,
-    defaultAction
+    caption
   );
   outlet.replaceChildren(view);
 
@@ -119,6 +113,10 @@ export async function mountTalkView({ outlet, signal }) {
   signal.addEventListener("abort", () => {
     subscription.close();
     orb.dispose();
+    if (defaultAction) {
+      defaultAction.hidden = true;
+      defaultAction.removeEventListener("click", onSetDefault);
+    }
   });
 
   function restingState() {
@@ -151,12 +149,14 @@ export async function mountTalkView({ outlet, signal }) {
     if (signal.aborted || personalityState == null) return;
     activePersonality = personalityState.current;
     setPersonality(personalityState.badgeName);
-    defaultAction.hidden =
-      personalityState.locked || personalityState.current === personalityState.startup;
+    if (defaultAction) {
+      defaultAction.hidden =
+        personalityState.locked || personalityState.current === personalityState.startup;
+    }
   }
 
   async function onSetDefault() {
-    if (!activePersonality) return;
+    if (!defaultAction || !activePersonality) return;
     defaultAction.disabled = true;
     caption.textContent = `Saving "${displayPersonalityName(activePersonality)}" as default...`;
     try {

--- a/src/reachy_mini_conversation_app/static/js/views/talk.js
+++ b/src/reachy_mini_conversation_app/static/js/views/talk.js
@@ -12,6 +12,7 @@ import { setPersonality } from "../personality-badge.js";
 import { h, prettifyProfileName } from "../ui.js";
 
 const SSE_ENDPOINT = "/conversation_events";
+const DEBUG_PREFIX = "[default-personality]";
 
 const CAPTION_BY_STATE = Object.freeze({
   [ORB_STATES.MUTED]: "Muted",
@@ -36,6 +37,7 @@ export async function mountTalkView({ outlet, signal }) {
     defaultAction.hidden = true;
     defaultAction.addEventListener("click", onSetDefault);
   }
+  logDefaultAction("mount", { hasDefaultAction: Boolean(defaultAction) });
   const orb = createOrb({
     initialState: ORB_STATES.CONNECTING,
     onStateChange: (state) => {
@@ -146,31 +148,67 @@ export async function mountTalkView({ outlet, signal }) {
 
   async function refreshPersonalityState() {
     const personalityState = await fetchPersonalityState();
-    if (signal.aborted || personalityState == null) return;
+    if (signal.aborted) {
+      logDefaultAction("refresh skipped", { reason: "signal_aborted" });
+      return;
+    }
+    if (personalityState == null) {
+      logDefaultAction("refresh skipped", { reason: "personality_state_unavailable" });
+      return;
+    }
     activePersonality = personalityState.current;
     setPersonality(personalityState.badgeName);
+    const shouldHide = personalityState.locked || personalityState.current === personalityState.startup;
     if (defaultAction) {
-      defaultAction.hidden =
-        personalityState.locked || personalityState.current === personalityState.startup;
+      defaultAction.hidden = shouldHide;
     }
+    logDefaultAction("refresh", {
+      current: personalityState.current,
+      startup: personalityState.startup,
+      locked: personalityState.locked,
+      shouldHide,
+      shouldShow: !shouldHide,
+    });
   }
 
   async function onSetDefault() {
-    if (!defaultAction || !activePersonality) return;
+    if (!defaultAction || !activePersonality) {
+      logDefaultAction("set default skipped", {
+        hasDefaultAction: Boolean(defaultAction),
+        activePersonality,
+      });
+      return;
+    }
     defaultAction.disabled = true;
+    logDefaultAction("set default requested", { activePersonality });
     caption.textContent = `Saving "${displayPersonalityName(activePersonality)}" as default...`;
     try {
       await applyPersonality(activePersonality, { persist: true });
       if (signal.aborted) return;
       defaultAction.hidden = true;
       caption.textContent = `"${displayPersonalityName(activePersonality)}" will be used at startup.`;
+      logDefaultAction("set default saved", { activePersonality });
     } catch (error) {
       if (!signal.aborted) {
         caption.textContent = `Failed to save default: ${error?.message || error}`;
       }
+      logDefaultAction("set default failed", { error: error?.message || String(error) });
     } finally {
       defaultAction.disabled = false;
     }
+  }
+
+  function logDefaultAction(event, details = {}) {
+    const row = defaultAction?.closest('[data-component="personality-row"]');
+    console.info(DEBUG_PREFIX, event, JSON.stringify({
+      route: window.location.hash || "#/",
+      hasDefaultAction: Boolean(defaultAction),
+      defaultActionHidden: defaultAction?.hidden,
+      defaultActionDisabled: defaultAction?.disabled,
+      hasPersonalityRow: Boolean(row),
+      personalityRowHidden: row?.hidden,
+      ...details,
+    }));
   }
 
   function syncMicAria() {
@@ -194,7 +232,8 @@ async function fetchPersonalityState() {
       locked: Boolean(data?.locked),
       badgeName: current === BUILT_IN_DEFAULT_OPTION ? "default" : current,
     };
-  } catch {
+  } catch (error) {
+    console.info(DEBUG_PREFIX, "list personalities failed", JSON.stringify({ error: error?.message || String(error) }));
     return null;
   }
 }

--- a/src/reachy_mini_conversation_app/static/js/views/talk.js
+++ b/src/reachy_mini_conversation_app/static/js/views/talk.js
@@ -4,7 +4,7 @@
  * Robot stays live, tapping the orb only mutes or unmutes the user's mic.
  */
 
-import { getMicState, listPersonalities, setMicMuted } from "../api.js";
+import { applyPersonality, getMicState, listPersonalities, setMicMuted } from "../api.js";
 import { BUILT_IN_DEFAULT_OPTION, ORB_STATES } from "../constants.js";
 import { createOrb, mapActivityToState } from "../orb.js";
 import { consumePendingApply } from "../pending-apply.js";
@@ -28,8 +28,19 @@ export async function mountTalkView({ outlet, signal }) {
   const micStatePromise = getMicState();
   let muted = true;
   let togglePending = false;
+  let activePersonality = null;
 
   const caption = h("p", { class: "talk__caption" }, CAPTION_BY_STATE[ORB_STATES.CONNECTING]);
+  const defaultAction = h(
+    "button",
+    {
+      type: "button",
+      class: "talk__default-action",
+      hidden: "hidden",
+      onClick: onSetDefault,
+    },
+    "Set as default"
+  );
   const orb = createOrb({
     initialState: ORB_STATES.CONNECTING,
     onStateChange: (state) => {
@@ -43,7 +54,8 @@ export async function mountTalkView({ outlet, signal }) {
     "section",
     { class: "view view--talk" },
     h("div", { class: "talk__orb-wrap" }, orb.root),
-    caption
+    caption,
+    defaultAction
   );
   outlet.replaceChildren(view);
 
@@ -60,12 +72,10 @@ export async function mountTalkView({ outlet, signal }) {
     if (signal.aborted) return;
     // SSE "ready" will flip the orb to its resting state next tick.
     caption.textContent = CAPTION_BY_STATE[ORB_STATES.CONNECTING];
+    void refreshPersonalityState();
   } else {
     // Deep link to /talk with no pending apply: refresh the header badge.
-    fetchActivePersonality().then((name) => {
-      if (signal.aborted) return;
-      if (name) setPersonality(name);
-    });
+    void refreshPersonalityState();
   }
 
   try {
@@ -136,18 +146,54 @@ export async function mountTalkView({ outlet, signal }) {
     syncMicAria();
   }
 
+  async function refreshPersonalityState() {
+    const personalityState = await fetchPersonalityState();
+    if (signal.aborted || personalityState == null) return;
+    activePersonality = personalityState.current;
+    setPersonality(personalityState.badgeName);
+    defaultAction.hidden =
+      personalityState.locked || personalityState.current === personalityState.startup;
+  }
+
+  async function onSetDefault() {
+    if (!activePersonality) return;
+    defaultAction.disabled = true;
+    caption.textContent = `Saving "${displayPersonalityName(activePersonality)}" as default...`;
+    try {
+      await applyPersonality(activePersonality, { persist: true });
+      if (signal.aborted) return;
+      defaultAction.hidden = true;
+      caption.textContent = `"${displayPersonalityName(activePersonality)}" will be used at startup.`;
+    } catch (error) {
+      if (!signal.aborted) {
+        caption.textContent = `Failed to save default: ${error?.message || error}`;
+      }
+    } finally {
+      defaultAction.disabled = false;
+    }
+  }
+
   function syncMicAria() {
     orb.root.setAttribute("aria-pressed", String(!muted));
     orb.root.setAttribute("aria-label", muted ? "Unmute microphone" : "Mute microphone");
   }
 }
 
-async function fetchActivePersonality() {
+function displayPersonalityName(name) {
+  return name === BUILT_IN_DEFAULT_OPTION ? "Default" : prettifyProfileName(name);
+}
+
+async function fetchPersonalityState() {
   try {
     const data = await listPersonalities();
     const current = data?.current;
-    if (!current || current === BUILT_IN_DEFAULT_OPTION) return "default";
-    return current;
+    if (!current) return null;
+    return {
+      current,
+      startup: data?.startup || BUILT_IN_DEFAULT_OPTION,
+      locked: Boolean(data?.locked),
+      badgeName: current === BUILT_IN_DEFAULT_OPTION ? "default" : current,
+    };
   } catch {
     return null;
   }

--- a/src/reachy_mini_conversation_app/static/js/views/talk.js
+++ b/src/reachy_mini_conversation_app/static/js/views/talk.js
@@ -12,7 +12,6 @@ import { setPersonality } from "../personality-badge.js";
 import { h, prettifyProfileName } from "../ui.js";
 
 const SSE_ENDPOINT = "/conversation_events";
-const DEBUG_PREFIX = "[default-personality]";
 
 const CAPTION_BY_STATE = Object.freeze({
   [ORB_STATES.MUTED]: "Muted",
@@ -37,7 +36,6 @@ export async function mountTalkView({ outlet, signal }) {
     defaultAction.hidden = true;
     defaultAction.addEventListener("click", onSetDefault);
   }
-  logDefaultAction("mount", { hasDefaultAction: Boolean(defaultAction) });
   const orb = createOrb({
     initialState: ORB_STATES.CONNECTING,
     onStateChange: (state) => {
@@ -148,67 +146,31 @@ export async function mountTalkView({ outlet, signal }) {
 
   async function refreshPersonalityState() {
     const personalityState = await fetchPersonalityState();
-    if (signal.aborted) {
-      logDefaultAction("refresh skipped", { reason: "signal_aborted" });
-      return;
-    }
-    if (personalityState == null) {
-      logDefaultAction("refresh skipped", { reason: "personality_state_unavailable" });
-      return;
-    }
+    if (signal.aborted || personalityState == null) return;
     activePersonality = personalityState.current;
     setPersonality(personalityState.badgeName);
     const shouldHide = personalityState.locked || personalityState.current === personalityState.startup;
     if (defaultAction) {
       defaultAction.hidden = shouldHide;
     }
-    logDefaultAction("refresh", {
-      current: personalityState.current,
-      startup: personalityState.startup,
-      locked: personalityState.locked,
-      shouldHide,
-      shouldShow: !shouldHide,
-    });
   }
 
   async function onSetDefault() {
-    if (!defaultAction || !activePersonality) {
-      logDefaultAction("set default skipped", {
-        hasDefaultAction: Boolean(defaultAction),
-        activePersonality,
-      });
-      return;
-    }
+    if (!defaultAction || !activePersonality) return;
     defaultAction.disabled = true;
-    logDefaultAction("set default requested", { activePersonality });
     caption.textContent = `Saving "${displayPersonalityName(activePersonality)}" as default...`;
     try {
       await applyPersonality(activePersonality, { persist: true });
       if (signal.aborted) return;
       defaultAction.hidden = true;
       caption.textContent = `"${displayPersonalityName(activePersonality)}" will be used at startup.`;
-      logDefaultAction("set default saved", { activePersonality });
     } catch (error) {
       if (!signal.aborted) {
         caption.textContent = `Failed to save default: ${error?.message || error}`;
       }
-      logDefaultAction("set default failed", { error: error?.message || String(error) });
     } finally {
       defaultAction.disabled = false;
     }
-  }
-
-  function logDefaultAction(event, details = {}) {
-    const row = defaultAction?.closest('[data-component="personality-row"]');
-    console.info(DEBUG_PREFIX, event, JSON.stringify({
-      route: window.location.hash || "#/",
-      hasDefaultAction: Boolean(defaultAction),
-      defaultActionHidden: defaultAction?.hidden,
-      defaultActionDisabled: defaultAction?.disabled,
-      hasPersonalityRow: Boolean(row),
-      personalityRowHidden: row?.hidden,
-      ...details,
-    }));
   }
 
   function syncMicAria() {
@@ -232,8 +194,7 @@ async function fetchPersonalityState() {
       locked: Boolean(data?.locked),
       badgeName: current === BUILT_IN_DEFAULT_OPTION ? "default" : current,
     };
-  } catch (error) {
-    console.info(DEBUG_PREFIX, "list personalities failed", JSON.stringify({ error: error?.message || String(error) }));
+  } catch {
     return null;
   }
 }

--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -450,6 +450,10 @@ button {
   width: 100%;
 }
 
+.personality-card-slot.has-default-action .personality-card {
+  padding-bottom: 62px;
+}
+
 .personality-card__edit {
   position: absolute;
   top: 8px;
@@ -483,6 +487,36 @@ button {
 .personality-card__edit svg {
   width: 15px;
   height: 15px;
+}
+
+.personality-card__default {
+  position: absolute;
+  right: 14px;
+  bottom: 14px;
+  left: 14px;
+  min-height: 34px;
+  padding: 7px 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elev));
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.2;
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.personality-card__default:hover {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #17130c;
+}
+
+.personality-card__default:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 .personality-card {

--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -167,12 +167,22 @@ button {
 }
 
 /* Fixed below the topbar, outside the header, so the lead/gear layout
-   stays untouched. Borderless so it reads as a label, not a control. */
-.app-shell__personality {
+   stays untouched. */
+.app-shell__personality-row {
   position: fixed;
   top: 90px;
   left: 32px;
   z-index: 9;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.app-shell__personality-row[hidden] {
+  display: none;
+}
+
+.app-shell__personality {
   display: inline-flex;
   align-items: center;
   gap: 16px;
@@ -197,10 +207,6 @@ button {
 .app-shell__personality:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-}
-
-.app-shell__personality[hidden] {
-  display: none;
 }
 
 .app-shell__personality-text {
@@ -254,6 +260,42 @@ button {
   user-select: none;
   -webkit-user-drag: none;
   display: block;
+}
+
+.app-shell__default-personality {
+  min-height: 36px;
+  padding: 8px 14px;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elev));
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.app-shell__default-personality[hidden] {
+  display: none;
+}
+
+.app-shell__default-personality:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #17130c;
+}
+
+.app-shell__default-personality:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.app-shell__default-personality:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 /* Shared by the Back and gear buttons so both read as the same control. */
@@ -671,37 +713,6 @@ button {
   min-height: 1.4em;
 }
 
-.talk__default-action {
-  min-height: 38px;
-  padding: 8px 18px;
-  border: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elev));
-  color: var(--accent);
-  cursor: pointer;
-  font-size: 0.9rem;
-  font-weight: 700;
-  line-height: 1.2;
-  transition: background var(--transition-fast), border-color var(--transition-fast),
-    color var(--transition-fast), opacity var(--transition-fast);
-}
-
-.talk__default-action:hover:not(:disabled) {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: #17130c;
-}
-
-.talk__default-action:disabled {
-  cursor: wait;
-  opacity: 0.65;
-}
-
-.talk__default-action:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
-}
-
 /* 6. Settings view */
 
 .view--settings {
@@ -827,6 +838,23 @@ button {
 }
 
 @media (max-width: 620px) {
+  .app-shell__personality-row {
+    right: 20px;
+    left: 20px;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .app-shell__personality-name {
+    max-width: calc(100vw - 140px);
+    font-size: 1.12rem;
+  }
+
+  .app-shell__personality-avatar {
+    width: 52px;
+    height: 52px;
+  }
+
   .settings-field-row,
   .settings-status-row {
     grid-template-columns: 1fr;

--- a/src/reachy_mini_conversation_app/static/style.css
+++ b/src/reachy_mini_conversation_app/static/style.css
@@ -450,10 +450,6 @@ button {
   width: 100%;
 }
 
-.personality-card-slot.has-default-action .personality-card {
-  padding-bottom: 62px;
-}
-
 .personality-card__edit {
   position: absolute;
   top: 8px;
@@ -487,36 +483,6 @@ button {
 .personality-card__edit svg {
   width: 15px;
   height: 15px;
-}
-
-.personality-card__default {
-  position: absolute;
-  right: 14px;
-  bottom: 14px;
-  left: 14px;
-  min-height: 34px;
-  padding: 7px 12px;
-  border: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elev));
-  color: var(--accent);
-  cursor: pointer;
-  font-size: 0.82rem;
-  font-weight: 700;
-  line-height: 1.2;
-  transition: background var(--transition-fast), border-color var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.personality-card__default:hover {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: #17130c;
-}
-
-.personality-card__default:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 .personality-card {
@@ -703,6 +669,37 @@ button {
   font-size: 1rem;
   text-align: center;
   min-height: 1.4em;
+}
+
+.talk__default-action {
+  min-height: 38px;
+  padding: 8px 18px;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elev));
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1.2;
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.talk__default-action:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #17130c;
+}
+
+.talk__default-action:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.talk__default-action:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 /* 6. Settings view */

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -747,6 +747,29 @@ def test_personality_routes_apply_same_profile_does_not_restart(monkeypatch: pyt
     handler.get_current_voice.assert_not_called()
 
 
+def test_personality_routes_startup_choice_survives_runtime_profile_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime profile switching should not redefine the saved startup personality."""
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "captain_circuit")
+    app = FastAPI()
+    handler = MagicMock()
+    mount_personality_routes(app, handler, lambda: None)
+    client = TestClient(app)
+
+    initial_response = client.get("/personalities")
+    assert initial_response.status_code == 200
+    assert initial_response.json()["current"] == "captain_circuit"
+    assert initial_response.json()["startup"] == "captain_circuit"
+
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "chess_coach")
+
+    switched_response = client.get("/personalities")
+    assert switched_response.status_code == 200
+    assert switched_response.json()["current"] == "chess_coach"
+    assert switched_response.json()["startup"] == "captain_circuit"
+
+
 def test_headless_personality_routes_can_use_stream_callbacks() -> None:
     """Headless personality routes can delegate apply/restart ownership to LocalStream."""
     app = FastAPI()


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
Adds a `Set as default` action beside the main Talk view personality badge when the active personality differs from the saved startup personality. The button reuses the existing personality apply endpoint with `persist: true`, hides after saving, and leaves the personality picker focused on selecting/editing personalities.

This also fixes the startup/current comparison used by `/personalities`: runtime personality switching no longer redefines the reported startup personality.

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [x] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>

## Notes
Root cause from real-app logs:
- `/personalities` was reporting `startup` from the mutable runtime profile fallback.
- Switching from `captain_circuit` to `chess_coach` changed both `current` and `startup` to `chess_coach`, so the UI correctly hid the button based on bad backend state.
- The route now captures the configured startup choice when routes mount and only updates it after an explicit persist action.

Validation:
- `node --check src/reachy_mini_conversation_app/static/js/views/talk.js && node --check src/reachy_mini_conversation_app/static/js/personality-badge.js && node --check src/reachy_mini_conversation_app/static/js/views/home.js`
- `.venv/bin/ruff check src/reachy_mini_conversation_app/personality_routes.py tests/test_console.py --fix`
- `.venv/bin/ruff format src/reachy_mini_conversation_app/personality_routes.py tests/test_console.py`
- `.venv/bin/mypy --pretty --show-error-codes src/reachy_mini_conversation_app/personality_routes.py`
- `.venv/bin/python -m pytest tests/test_console.py::test_personality_routes_startup_choice_survives_runtime_profile_change tests/test_console.py::test_personality_routes_persist_startup_with_voice_override tests/test_console.py::test_local_stream_persist_personality_stores_voice_override tests/test_startup_settings.py -q`
- Mocked browser check: button appears beside the main Talk view personality badge for the active non-startup personality and hides after saving.

Full `pytest tests/ -v` reached 253 passed, 1 failed. The failing test was `tests/test_profile_paths.py::test_wheel_file_paths_stay_within_windows_budget`, where the test's internal `uv build` could not fetch `setuptools` from `https://pypi.registries.huggingface.tech/`. A focused retry reproduced the same external dependency fetch timeout.