### PR TITLE
Install private Hugging Face MCP Space tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ play_emotion
 sweep_look
 ```
 Tools are resolved first from Python files in the profile folder (custom tools), then from the core library `src/reachy_mini_conversation_app/tools/` (like `dance`, `camera`).
-Installed public Hugging Face Space tools can also be enabled here after you add them with `tool-spaces`.
+Installed Hugging Face Space tools can also be enabled here after you add them with `tool-spaces`.
 
 **Custom tools:**
 
@@ -325,9 +325,9 @@ This supports both:
 </details>
 
 <details>
-<summary><b>Public Hugging Face Space tools</b></summary>
+<summary><b>Hugging Face Space tools</b></summary>
 
-You can install public MCP-compatible Hugging Face Spaces as remote tool sources for this app.
+You can install MCP-compatible Hugging Face Spaces as remote tool sources for this app. Private Spaces work too, as long as `HF_TOKEN` is set (or you have run `hf auth login`) for an account that can access them.
 
 ```bash
 # install + enable in active profile
@@ -346,7 +346,7 @@ reachy-mini-conversation-app tool-spaces list
 reachy-mini-conversation-app tool-spaces remove owner/space-name
 ```
 
-The app validates the public Space slug through the Hugging Face Hub, probes the standard public MCP endpoint, discovers tools, enables them in the active profile's `tools.txt`, and writes the installed Space to:
+The app validates the Space slug through the Hugging Face Hub, probes the standard MCP endpoint (sending the HF token only to private Spaces), discovers tools, enables them in the active profile's `tools.txt`, and writes the installed Space to:
 
 - `installed_tool_spaces.json` in the managed app instance directory
 - `external_content/installed_tool_spaces.json` in terminal mode

--- a/src/reachy_mini_conversation_app/tool_spaces.py
+++ b/src/reachy_mini_conversation_app/tool_spaces.py
@@ -12,7 +12,8 @@ from collections import Counter
 from dataclasses import field, asdict, dataclass
 from collections.abc import Sequence
 
-from huggingface_hub import HfApi, SpaceInfo
+from huggingface_hub import HfApi, SpaceInfo, get_token
+from huggingface_hub.errors import RepositoryNotFoundError
 
 from reachy_mini_conversation_app.mcp_client import (
     McpClientError,
@@ -32,7 +33,7 @@ _SLUG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._
 
 @dataclass(frozen=True)
 class InstalledToolSpace:
-    """Persisted record for one installed public Space."""
+    """Persisted record for one installed Space."""
 
     slug: str
     alias: str
@@ -40,7 +41,7 @@ class InstalledToolSpace:
 
 @dataclass(frozen=True)
 class InstalledToolSpacesManifest:
-    """Persisted manifest of installed public Space tool sources."""
+    """Persisted manifest of installed Space tool sources."""
 
     version: int = 1
     spaces: list[InstalledToolSpace] = field(default_factory=list)
@@ -59,7 +60,7 @@ class InstalledToolSpaceTool:
 
 @dataclass(frozen=True)
 class ResolvedInstalledToolSpace:
-    """Runtime description of an installed public Space."""
+    """Runtime description of an installed Space."""
 
     slug: str
     alias: str
@@ -228,7 +229,7 @@ def _build_installed_tool_space_tools(
     return tools
 
 
-def _build_public_space_mcp_url(space_info: SpaceInfo, slug: str) -> str:
+def _build_space_mcp_url(space_info: SpaceInfo, slug: str) -> str:
     host = (space_info.host or "").strip()
     if host:
         if host.startswith("http://") or host.startswith("https://"):
@@ -243,27 +244,39 @@ def _build_public_space_mcp_url(space_info: SpaceInfo, slug: str) -> str:
     return f"https://{slug_host}.hf.space/gradio_api/mcp/"
 
 
-def _validate_public_space_info(slug: str, space_info: SpaceInfo) -> None:
-    if bool(space_info.private):
-        raise RuntimeError(f"Space '{slug}' is not public and cannot be installed in this v1 flow.")
+def _validate_space_info(slug: str, space_info: SpaceInfo) -> None:
     if bool(space_info.disabled):
         raise RuntimeError(f"Space '{slug}' is disabled and cannot be installed.")
     if (space_info.sdk or "").strip().lower() != "gradio":
         raise RuntimeError(f"Space '{slug}' is not a Gradio Space and cannot expose the standard MCP endpoint.")
 
 
-async def resolve_public_tool_space(slug: str) -> ResolvedInstalledToolSpace:
-    """Validate and discover tools from one public HF Space."""
+async def resolve_tool_space(slug: str) -> ResolvedInstalledToolSpace:
+    """Validate and discover tools from one HF Space, authenticating private Spaces with the HF token."""
     validated_slug = validate_space_slug(slug)
     alias = normalize_space_alias(validated_slug)
-    space_info = HfApi().space_info(validated_slug, timeout=10.0, token=False)
-    _validate_public_space_info(validated_slug, space_info)
+    token = get_token()
+    try:
+        space_info = HfApi().space_info(validated_slug, timeout=10.0, token=token or False)
+    except RepositoryNotFoundError as exc:
+        if token is None:
+            raise RuntimeError(
+                f"Space '{validated_slug}' was not found. If it is private, set HF_TOKEN "
+                "or run 'hf auth login' for an account that can access it."
+            ) from exc
+        raise RuntimeError(
+            f"Space '{validated_slug}' was not found, or the current Hugging Face token cannot access it."
+        ) from exc
+    _validate_space_info(validated_slug, space_info)
 
-    mcp_url = _build_public_space_mcp_url(space_info, validated_slug)
+    mcp_url = _build_space_mcp_url(space_info, validated_slug)
+    # Only private Spaces get the HF token; never leak it to a public Space's MCP endpoint.
+    headers = {"Authorization": f"Bearer {token}"} if bool(space_info.private) and token else {}
     client = RemoteMcpToolClient(
         RemoteMcpServerConfig(
             alias=alias,
             url=mcp_url,
+            headers=headers,
             request_timeout_s=10.0,
             tool_timeout_s=30.0,
         )
@@ -283,9 +296,9 @@ async def resolve_public_tool_space(slug: str) -> ResolvedInstalledToolSpace:
     )
 
 
-def resolve_public_tool_space_sync(slug: str) -> ResolvedInstalledToolSpace:
-    """Resolve one public Space synchronously."""
-    return asyncio.run(resolve_public_tool_space(slug))
+def resolve_tool_space_sync(slug: str) -> ResolvedInstalledToolSpace:
+    """Resolve one Space synchronously."""
+    return asyncio.run(resolve_tool_space(slug))
 
 
 def format_space_tool_listing(space: ResolvedInstalledToolSpace) -> str:
@@ -306,7 +319,11 @@ def handle_tool_spaces_command(args: argparse.Namespace, *, instance_path: str |
     """Handle tool-spaces subcommands from the main CLI."""
     command = getattr(args, "tool_spaces_command", None)
     if command == "add":
-        resolved_space = resolve_public_tool_space_sync(args.space_slug)
+        try:
+            resolved_space = resolve_tool_space_sync(args.space_slug)
+        except RuntimeError as exc:
+            logger.error("%s", exc)
+            return 1
         manifest = read_installed_tool_spaces(instance_path)
         already_installed = any(space.slug == resolved_space.slug for space in manifest.spaces)
         if already_installed:
@@ -367,7 +384,7 @@ def handle_tool_spaces_command(args: argparse.Namespace, *, instance_path: str |
             return 1
 
         try:
-            removed_space: ResolvedInstalledToolSpace | None = resolve_public_tool_space_sync(validated_slug)
+            removed_space: ResolvedInstalledToolSpace | None = resolve_tool_space_sync(validated_slug)
         except Exception as exc:
             removed_space = None
             logger.warning("Could not refresh tools for '%s' before removal: %s", validated_slug, exc)
@@ -391,7 +408,7 @@ def handle_tool_spaces_command(args: argparse.Namespace, *, instance_path: str |
 
         for installed_space in manifest.spaces:
             try:
-                resolved_space = resolve_public_tool_space_sync(installed_space.slug)
+                resolved_space = resolve_tool_space_sync(installed_space.slug)
             except Exception as exc:
                 logger.warning("Space '%s' (%s) is unavailable: %s", installed_space.slug, installed_space.alias, exc)
                 continue

--- a/src/reachy_mini_conversation_app/tool_spaces.py
+++ b/src/reachy_mini_conversation_app/tool_spaces.py
@@ -162,6 +162,27 @@ def _append_tools_to_profile(profile: str, tool_ids: list[str]) -> list[str]:
     return to_add
 
 
+def _disable_space_tools_in_profiles(alias: str) -> list[tuple[str, list[str]]]:
+    """Strip a Space's tool IDs from every profile's tools.txt. Returns (profile, removed IDs) per profile touched."""
+    prefix = f"{alias}__"
+    removed_by_profile: list[tuple[str, list[str]]] = []
+    seen: set[Path] = set()
+    for root in (config.PROFILES_DIRECTORY, config.user_personalities_root()):
+        for tools_txt in sorted(root.glob("*/tools.txt")):
+            resolved = tools_txt.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            lines = tools_txt.read_text(encoding="utf-8").splitlines()
+            removed = [line.strip() for line in lines if line.strip().startswith(prefix)]
+            if not removed:
+                continue
+            kept = [line for line in lines if not line.strip().startswith(prefix)]
+            tools_txt.write_text("".join(f"{line}\n" for line in kept), encoding="utf-8")
+            removed_by_profile.append((tools_txt.parent.name, removed))
+    return removed_by_profile
+
+
 def validate_space_slug(slug: str) -> str:
     """Validate a public HF Space slug."""
     candidate = slug.strip()
@@ -380,19 +401,13 @@ def handle_tool_spaces_command(args: argparse.Namespace, *, instance_path: str |
             logger.warning("Space not installed: %s", validated_slug)
             return 1
 
-        try:
-            removed_space: ResolvedInstalledToolSpace | None = resolve_tool_space_sync(validated_slug)
-        except Exception as exc:
-            removed_space = None
-            logger.warning("Could not refresh tools for '%s' before removal: %s", validated_slug, exc)
-
         write_installed_tool_spaces(
             instance_path,
             InstalledToolSpacesManifest(version=manifest.version, spaces=remaining_spaces),
         )
         logger.info("Removed Space tool source: %s", validated_slug)
-        if removed_space is not None:
-            logger.info("%s", format_space_tool_listing(removed_space))
+        for profile_name, disabled_tool_ids in _disable_space_tools_in_profiles(normalize_space_alias(validated_slug)):
+            logger.info("Disabled in profile '%s': %s", profile_name, disabled_tool_ids)
         return 0
 
     if command == "list":

--- a/src/reachy_mini_conversation_app/tool_spaces.py
+++ b/src/reachy_mini_conversation_app/tool_spaces.py
@@ -15,6 +15,7 @@ from collections.abc import Sequence
 from huggingface_hub import HfApi, SpaceInfo, get_token
 from huggingface_hub.errors import RepositoryNotFoundError
 
+from reachy_mini_conversation_app.config import config
 from reachy_mini_conversation_app.mcp_client import (
     McpClientError,
     RemoteToolSpec,
@@ -138,8 +139,6 @@ def write_installed_tool_spaces(
 
 def _append_tools_to_profile(profile: str, tool_ids: list[str]) -> list[str]:
     """Append tool IDs to a profile's tools.txt. Returns the IDs that were added."""
-    from reachy_mini_conversation_app.config import config
-
     tools_txt = config.resolve_profile_dir(profile) / "tools.txt"
     if not tools_txt.parent.is_dir():
         raise RuntimeError(
@@ -255,7 +254,7 @@ async def resolve_tool_space(slug: str) -> ResolvedInstalledToolSpace:
     """Validate and discover tools from one HF Space, authenticating private Spaces with the HF token."""
     validated_slug = validate_space_slug(slug)
     alias = normalize_space_alias(validated_slug)
-    token = get_token()
+    token = config.HF_TOKEN or get_token()
     try:
         space_info = HfApi().space_info(validated_slug, timeout=10.0, token=token or False)
     except RepositoryNotFoundError as exc:
@@ -270,7 +269,7 @@ async def resolve_tool_space(slug: str) -> ResolvedInstalledToolSpace:
     _validate_space_info(validated_slug, space_info)
 
     mcp_url = _build_space_mcp_url(space_info, validated_slug)
-    # Only private Spaces get the HF token; never leak it to a public Space's MCP endpoint.
+    # Only private Spaces get the HF token, never leak it to a public Space's MCP endpoint.
     headers = {"Authorization": f"Bearer {token}"} if bool(space_info.private) and token else {}
     client = RemoteMcpToolClient(
         RemoteMcpServerConfig(
@@ -359,8 +358,6 @@ def handle_tool_spaces_command(args: argparse.Namespace, *, instance_path: str |
 
         target_profile = args.profile
         if target_profile is None:
-            from reachy_mini_conversation_app.config import config
-
             target_profile = config.REACHY_MINI_CUSTOM_PROFILE or "default"
 
         tool_ids = [tool.local_name for tool in resolved_space.tools]

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -369,8 +369,8 @@ def _read_profile_tool_names() -> list[str]:
 
 
 def _resolve_remote_tools(tool_names: list[str], instance_path: str | Path | None) -> list[RemoteMcpTool]:
-    """Resolve installed public Space tools enabled by the active profile."""
-    from reachy_mini_conversation_app.tool_spaces import read_installed_tool_spaces, resolve_public_tool_space_sync
+    """Resolve installed Space tools enabled by the active profile."""
+    from reachy_mini_conversation_app.tool_spaces import resolve_tool_space_sync, read_installed_tool_spaces
 
     remote_tools: list[RemoteMcpTool] = []
     for installed_space in read_installed_tool_spaces(instance_path).spaces:
@@ -383,7 +383,7 @@ def _resolve_remote_tools(tool_names: list[str], instance_path: str | Path | Non
             continue
 
         try:
-            resolved_space = resolve_public_tool_space_sync(installed_space.slug)
+            resolved_space = resolve_tool_space_sync(installed_space.slug)
         except Exception as exc:
             logger.warning(
                 "Space '%s' is unavailable, skipping its tools (%s): %s",

--- a/src/reachy_mini_conversation_app/utils.py
+++ b/src/reachy_mini_conversation_app/utils.py
@@ -26,8 +26,8 @@ def parse_args() -> tuple[argparse.Namespace, list]:  # type: ignore
     tool_spaces_parser = subparsers.add_parser("tool-spaces", help="Manage installed Hugging Face Space tool sources")
     tool_spaces_subparsers = tool_spaces_parser.add_subparsers(dest="tool_spaces_command", required=True)
 
-    add_parser = tool_spaces_subparsers.add_parser("add", help="Install one public Space tool source by slug")
-    add_parser.add_argument("space_slug", help="Public Hugging Face Space slug in the form owner/space-name")
+    add_parser = tool_spaces_subparsers.add_parser("add", help="Install one Space tool source by slug")
+    add_parser.add_argument("space_slug", help="Hugging Face Space slug in the form owner/space-name")
     add_parser.add_argument(
         "--install-only",
         action="store_true",

--- a/tests/test_tool_space_runtime.py
+++ b/tests/test_tool_space_runtime.py
@@ -87,7 +87,7 @@ async def test_initialize_tools_loads_enabled_installed_remote_tools_and_dispatc
         "text": "hello",
     }
     resolver = MagicMock(side_effect=lambda _slug: _resolved_remote_space(client))
-    monkeypatch.setattr(tool_spaces_mod, "resolve_public_tool_space_sync", resolver)
+    monkeypatch.setattr(tool_spaces_mod, "resolve_tool_space_sync", resolver)
 
     write_installed_tool_spaces(
         None,
@@ -139,7 +139,7 @@ def test_initialize_tools_warns_when_enabled_remote_tool_is_unavailable(
     monkeypatch.setattr(config_mod.config, "TOOLS_DIRECTORY", None)
     monkeypatch.setattr(config_mod.config, "AUTOLOAD_EXTERNAL_TOOLS", False)
     monkeypatch.setattr(
-        tool_spaces_mod, "resolve_public_tool_space_sync", lambda slug: (_ for _ in ()).throw(RuntimeError("boom"))
+        tool_spaces_mod, "resolve_tool_space_sync", lambda slug: (_ for _ in ()).throw(RuntimeError("boom"))
     )
 
     write_installed_tool_spaces(

--- a/tests/test_tool_spaces.py
+++ b/tests/test_tool_spaces.py
@@ -312,6 +312,24 @@ def test_tool_spaces_add_enables_in_active_profile_by_default(
     assert SEARCH_TOOL_ID in tools_txt.read_text(encoding="utf-8")
 
 
+def test_tool_spaces_remove_disables_tools_in_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing a Space strips its tool IDs from the profile they were enabled in."""
+    _mock_add(monkeypatch, tmp_path)
+    tools_txt = _setup_profile(tmp_path, "default")
+    monkeypatch.setattr(config_mod.config, "PROFILES_DIRECTORY", tmp_path)
+    monkeypatch.setattr(config_mod.config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
+    assert _run_cli(monkeypatch, ["app", "tool-spaces", "add", SEARCH_SPACE_SLUG]) == 0
+    assert SEARCH_TOOL_ID in tools_txt.read_text(encoding="utf-8")
+
+    assert _run_cli(monkeypatch, ["app", "tool-spaces", "remove", SEARCH_SPACE_SLUG]) == 0
+    assert SEARCH_TOOL_ID not in tools_txt.read_text(encoding="utf-8")
+    assert read_installed_tool_spaces(None).spaces == []
+
+
 def test_tool_spaces_add_install_only_skips_tools_txt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_tool_spaces.py
+++ b/tests/test_tool_spaces.py
@@ -131,11 +131,12 @@ def test_tool_spaces_add_installs_private_space_with_token(
 
 
 def test_resolve_tool_space_attaches_auth_header_for_private_space(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A private Space's MCP client must carry the HF bearer token."""
+    """A private Space's MCP client must carry the HF bearer token from the hf-login fallback."""
     monkeypatch.setattr(
         "reachy_mini_conversation_app.tool_spaces.HfApi.space_info",
         lambda self, slug, **kwargs: _mock_private_space_info(slug),
     )
+    monkeypatch.setattr(config_mod.config, "HF_TOKEN", None)
     monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.get_token", lambda: "hf_test_token")
     monkeypatch.setattr(
         "reachy_mini_conversation_app.tool_spaces.RemoteMcpToolClient.list_tool_specs",
@@ -146,12 +147,30 @@ def test_resolve_tool_space_attaches_auth_header_for_private_space(monkeypatch: 
     assert resolved.client.server.headers["Authorization"] == "Bearer hf_test_token"
 
 
+def test_resolve_tool_space_prefers_app_config_hf_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The token must come from the app config (loaded from .env), not only from get_token()."""
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_spaces.HfApi.space_info",
+        lambda self, slug, **kwargs: _mock_private_space_info(slug),
+    )
+    monkeypatch.setattr(config_mod.config, "HF_TOKEN", "hf_env_token")
+    monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.get_token", lambda: None)
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_spaces.RemoteMcpToolClient.list_tool_specs",
+        _mock_list_tool_specs,
+    )
+
+    resolved = resolve_tool_space_sync(PRIVATE_SPACE_SLUG)
+    assert resolved.client.server.headers["Authorization"] == "Bearer hf_env_token"
+
+
 def test_resolve_tool_space_omits_auth_header_for_public_space(monkeypatch: pytest.MonkeyPatch) -> None:
     """A public Space must never receive the HF token, even when one is set."""
     monkeypatch.setattr(
         "reachy_mini_conversation_app.tool_spaces.HfApi.space_info",
         lambda self, slug, **kwargs: _mock_public_space_info(slug),
     )
+    monkeypatch.setattr(config_mod.config, "HF_TOKEN", None)
     monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.get_token", lambda: "hf_test_token")
     monkeypatch.setattr(
         "reachy_mini_conversation_app.tool_spaces.RemoteMcpToolClient.list_tool_specs",
@@ -176,6 +195,7 @@ def test_tool_spaces_add_private_space_without_token_hints_at_auth(
         )
 
     monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.HfApi.space_info", _raise_not_found)
+    monkeypatch.setattr(config_mod.config, "HF_TOKEN", None)
     monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.get_token", lambda: None)
 
     assert _run_cli(monkeypatch, ["app", "tool-spaces", "add", PRIVATE_SPACE_SLUG]) == 1

--- a/tests/test_tool_spaces.py
+++ b/tests/test_tool_spaces.py
@@ -5,12 +5,15 @@ from types import SimpleNamespace
 from pathlib import Path
 from argparse import Namespace
 
+import httpx
 import pytest
+from huggingface_hub.errors import RepositoryNotFoundError
 
 import reachy_mini_conversation_app.config as config_mod
 from reachy_mini_conversation_app.main import main
 from reachy_mini_conversation_app.mcp_client import RemoteToolSpec
 from reachy_mini_conversation_app.tool_spaces import (
+    resolve_tool_space_sync,
     handle_tool_spaces_command,
     read_installed_tool_spaces,
 )
@@ -34,6 +37,12 @@ def _mock_public_space_info(slug: str) -> SimpleNamespace:
         subdomain=slug.replace("/", "-"),
         tags=["reachy-mini-tool", "mcp"],
     )
+
+
+def _mock_private_space_info(slug: str) -> SimpleNamespace:
+    info = _mock_public_space_info(slug)
+    info.private = True
+    return info
 
 
 async def _mock_list_tool_specs(self: object) -> list[RemoteToolSpec]:
@@ -101,26 +110,76 @@ def test_tool_spaces_add_list_remove_round_trip(
     assert read_installed_tool_spaces(None).spaces == []
 
 
-def test_tool_spaces_add_rejects_non_public_space(
+def test_tool_spaces_add_installs_private_space_with_token(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The CLI should reject non-public Spaces before writing the manifest."""
+    """A private Space resolves and installs when an HF token is available."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         "reachy_mini_conversation_app.tool_spaces.HfApi.space_info",
-        lambda self, slug, **kwargs: SimpleNamespace(
-            id=slug,
-            private=True,
-            disabled=False,
-            sdk="gradio",
-            host=None,
-            subdomain=slug.replace("/", "-"),
-            tags=[],
-        ),
+        lambda self, slug, **kwargs: _mock_private_space_info(slug),
+    )
+    monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.get_token", lambda: "hf_test_token")
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_spaces.RemoteMcpToolClient.list_tool_specs",
+        _mock_list_tool_specs,
     )
 
-    assert _run_cli(monkeypatch, ["reachy-mini-conversation-app", "tool-spaces", "add", PRIVATE_SPACE_SLUG]) == 1
+    assert _run_cli(monkeypatch, ["app", "tool-spaces", "add", PRIVATE_SPACE_SLUG, "--install-only"]) == 0
+    assert [space.slug for space in read_installed_tool_spaces(None).spaces] == [PRIVATE_SPACE_SLUG]
+
+
+def test_resolve_tool_space_attaches_auth_header_for_private_space(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A private Space's MCP client must carry the HF bearer token."""
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_spaces.HfApi.space_info",
+        lambda self, slug, **kwargs: _mock_private_space_info(slug),
+    )
+    monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.get_token", lambda: "hf_test_token")
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_spaces.RemoteMcpToolClient.list_tool_specs",
+        _mock_list_tool_specs,
+    )
+
+    resolved = resolve_tool_space_sync(PRIVATE_SPACE_SLUG)
+    assert resolved.client.server.headers["Authorization"] == "Bearer hf_test_token"
+
+
+def test_resolve_tool_space_omits_auth_header_for_public_space(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A public Space must never receive the HF token, even when one is set."""
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_spaces.HfApi.space_info",
+        lambda self, slug, **kwargs: _mock_public_space_info(slug),
+    )
+    monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.get_token", lambda: "hf_test_token")
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_spaces.RemoteMcpToolClient.list_tool_specs",
+        _mock_list_tool_specs,
+    )
+
+    resolved = resolve_tool_space_sync(SEARCH_SPACE_SLUG)
+    assert "Authorization" not in resolved.client.server.headers
+
+
+def test_tool_spaces_add_private_space_without_token_hints_at_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without a token, adding a private Space fails cleanly and points at HF auth."""
+    monkeypatch.chdir(tmp_path)
+
+    def _raise_not_found(self: object, slug: str, **kwargs: object) -> SimpleNamespace:
+        raise RepositoryNotFoundError(
+            "404 Client Error", response=httpx.Response(404, request=httpx.Request("GET", "https://hf.co"))
+        )
+
+    monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.HfApi.space_info", _raise_not_found)
+    monkeypatch.setattr("reachy_mini_conversation_app.tool_spaces.get_token", lambda: None)
+
+    assert _run_cli(monkeypatch, ["app", "tool-spaces", "add", PRIVATE_SPACE_SLUG]) == 1
+    assert "hf auth login" in capsys.readouterr().err
     assert not (tmp_path / "external_content" / "installed_tool_spaces.json").exists()
 
 


### PR DESCRIPTION
## Summary
Closes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/397
Adds support for installing private Hugging Face Spaces as MCP tool sources. `resolve_tool_space` resolves the HF token via `huggingface_hub.get_token()` (env `HF_TOKEN` or `hf auth login`), fetches `space_info` authenticated, and attaches `Authorization`: `Bearer` only to private Spaces . Adding a private Space without a usable token now fails with a clear message pointing at `HF_TOKEN` / `hf auth login`. Drops the "public" naming/v1 restriction across the module, CLI help, and README. Tests cover private install, the public/private auth-header boundary, and the no-token hint

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>
