### PR TITLE
Fall back to default instructions for incomplete profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ For normal usage, select a profile from the UI and save it for startup. That sel
 
 If no startup settings have been saved yet, you can still seed startup from the environment with `REACHY_MINI_CUSTOM_PROFILE=<name>` to load `profiles/<name>/`. If neither is set, the `default` profile is used.
 
-Each profile should include `instructions.txt` (prompt text). `greeting.txt` is optional and controls how the robot should start the conversation after the backend connects. `tools.txt` (list of allowed tools) is recommended. If missing for a non-default profile, the app falls back to `profiles/default/tools.txt`. Profiles can optionally contain custom tool implementations.
+Each profile should include `instructions.txt` (prompt text). If that file is missing or empty, the app logs a warning and falls back to `profiles/default/instructions.txt`. `greeting.txt` is optional and controls how the robot should start the conversation after the backend connects. `tools.txt` (list of allowed tools) is recommended. If missing for a non-default profile, the app falls back to `profiles/default/tools.txt`. Profiles can optionally contain custom tool implementations.
 
 **Startup greeting:**
 

--- a/src/reachy_mini_conversation_app/base_realtime.py
+++ b/src/reachy_mini_conversation_app/base_realtime.py
@@ -305,7 +305,7 @@ class BaseRealtimeHandler(ConversationHandler, ABC):
             try:
                 instructions = self._get_session_instructions()
                 voice = self.get_current_voice()
-            except BaseException as e:  # catch SystemExit from prompt loader without crashing
+            except Exception as e:
                 logger.error("Failed to resolve personality content: %s", e)
                 return f"Failed to apply personality: {e}"
 

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -526,14 +526,11 @@ class LocalStream:
             try:
                 get_session_instructions()
                 get_session_voice(default=get_default_voice_for_backend(get_backend_choice()))
-            except BaseException:
+            except Exception:
                 set_custom_profile(previous_profile)
                 raise
         except Exception as e:
             logger.error("Error applying personality '%s': %s", profile, e)
-            return f"Failed to apply personality: {e}"
-        except BaseException as e:
-            logger.error("Failed to resolve personality content: %s", e)
             return f"Failed to apply personality: {e}"
 
         # Rebuild the tool registry

--- a/src/reachy_mini_conversation_app/gemini_live.py
+++ b/src/reachy_mini_conversation_app/gemini_live.py
@@ -247,7 +247,7 @@ class GeminiLiveHandler(ConversationHandler):
             try:
                 _ = get_session_instructions(self.instance_path)
                 _ = get_session_voice()
-            except BaseException as e:
+            except Exception as e:
                 logger.error("Failed to resolve personality content: %s", e)
                 return f"Failed to apply personality: {e}"
 

--- a/src/reachy_mini_conversation_app/prompts.py
+++ b/src/reachy_mini_conversation_app/prompts.py
@@ -1,4 +1,3 @@
-import sys
 import logging
 from pathlib import Path
 
@@ -24,6 +23,22 @@ def _default_instructions_file() -> Path:
     return DEFAULT_PROFILES_DIRECTORY / DEFAULT_PROFILE_NAME / INSTRUCTIONS_FILENAME
 
 
+def _read_instructions_file(instructions_file: Path, profile_name: str) -> str | None:
+    try:
+        if not instructions_file.exists():
+            logger.warning("Profile '%s' has no %s", profile_name, INSTRUCTIONS_FILENAME)
+            return None
+        instructions = instructions_file.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeError) as e:
+        logger.warning("Failed to load instructions from profile '%s': %s", profile_name, e)
+        return None
+
+    if not instructions:
+        logger.warning("Profile '%s' has empty %s", profile_name, INSTRUCTIONS_FILENAME)
+        return None
+    return instructions
+
+
 def get_session_instructions(instance_path: str | Path | None = None) -> str:
     """Get session instructions, loading from REACHY_MINI_CUSTOM_PROFILE if set."""
     profile = config.REACHY_MINI_CUSTOM_PROFILE
@@ -42,21 +57,23 @@ def get_session_instructions(instance_path: str | Path | None = None) -> str:
             logger.info("Loading prompt from profile '%s'", profile)
         instructions_file = config.resolve_profile_dir(profile) / INSTRUCTIONS_FILENAME
 
-    try:
-        if instructions_file.exists():
-            instructions = instructions_file.read_text(encoding="utf-8").strip()
-            if instructions:
-                memory_prompt = format_memory_for_prompt(instance_path)
-                if memory_prompt:
-                    return f"{memory_prompt}\n\n{instructions}"
-                return instructions
-            logger.error("Profile '%s' has empty %s", profile_name, INSTRUCTIONS_FILENAME)
-            sys.exit(1)
-        logger.error("Profile '%s' has no %s", profile_name, INSTRUCTIONS_FILENAME)
-        sys.exit(1)
-    except Exception as e:
-        logger.error("Failed to load instructions from profile '%s': %s", profile_name, e)
-        sys.exit(1)
+    instructions = _read_instructions_file(instructions_file, profile_name)
+    if instructions is None and profile:
+        default_instructions_file = _default_instructions_file()
+        logger.warning(
+            "Using default profile instructions from %s because profile '%s' is incomplete",
+            default_instructions_file,
+            profile,
+        )
+        instructions = _read_instructions_file(default_instructions_file, DEFAULT_PROFILE_NAME)
+
+    if instructions is None:
+        raise RuntimeError(f"Default profile has no usable {INSTRUCTIONS_FILENAME}")
+
+    memory_prompt = format_memory_for_prompt(instance_path)
+    if memory_prompt:
+        return f"{memory_prompt}\n\n{instructions}"
+    return instructions
 
 
 def get_session_voice(default: str | None = None) -> str:

--- a/src/reachy_mini_conversation_app/prompts.py
+++ b/src/reachy_mini_conversation_app/prompts.py
@@ -58,7 +58,7 @@ def get_session_instructions(instance_path: str | Path | None = None) -> str:
         instructions_file = config.resolve_profile_dir(profile) / INSTRUCTIONS_FILENAME
 
     instructions = _read_instructions_file(instructions_file, profile_name)
-    if instructions is None and profile:
+    if instructions is None and profile and profile != DEFAULT_PROFILE_NAME:
         default_instructions_file = _default_instructions_file()
         logger.warning(
             "Using default profile instructions from %s because profile '%s' is incomplete",

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -114,6 +114,22 @@ def test_bracketed_prompt_line_stays_plain_text(
     assert prompts_mod.get_session_instructions(instance_path=tmp_path) == "[custom_prompt]\n\nStay extra brief."
 
 
+def test_session_instructions_fall_back_to_default_for_incomplete_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Incomplete selected profiles should not stop session startup."""
+    profile_dir = tmp_path / "incomplete_prompt"
+    profile_dir.mkdir()
+
+    monkeypatch.setattr(config, "PROFILES_DIRECTORY", tmp_path)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "incomplete_prompt")
+
+    expected = (DEFAULT_PROFILES_DIRECTORY / "default" / "instructions.txt").read_text(encoding="utf-8").strip()
+
+    assert prompts_mod.get_session_instructions(instance_path=tmp_path) == expected
+
+
 def test_builtin_default_profile_tools_load_for_ui() -> None:
     """The UI should read built-in default tools from the packaged default profile."""
     expected = (DEFAULT_PROFILES_DIRECTORY / "default" / "tools.txt").read_text(encoding="utf-8")

--- a/tests/test_profile_paths.py
+++ b/tests/test_profile_paths.py
@@ -1,4 +1,5 @@
 import shutil
+import logging
 import zipfile
 import subprocess
 from pathlib import Path, PurePosixPath
@@ -128,6 +129,26 @@ def test_session_instructions_fall_back_to_default_for_incomplete_profile(
     expected = (DEFAULT_PROFILES_DIRECTORY / "default" / "instructions.txt").read_text(encoding="utf-8").strip()
 
     assert prompts_mod.get_session_instructions(instance_path=tmp_path) == expected
+
+
+def test_explicit_default_profile_does_not_fall_back_to_itself(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A broken explicit default profile should fail without a self-fallback log."""
+    default_dir = tmp_path / "default"
+    default_dir.mkdir()
+
+    monkeypatch.setattr(config, "PROFILES_DIRECTORY", tmp_path)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", "default")
+    monkeypatch.setattr(prompts_mod, "DEFAULT_PROFILES_DIRECTORY", tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="reachy_mini_conversation_app.prompts"):
+        with pytest.raises(RuntimeError, match="Default profile has no usable instructions.txt"):
+            prompts_mod.get_session_instructions(instance_path=tmp_path)
+
+    assert "Using default profile instructions" not in caplog.text
 
 
 def test_builtin_default_profile_tools_load_for_ui() -> None:


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
Missing or empty `instructions.txt` files in a selected profile used to call `sys.exit(1)` during session startup. This makes the prompt loader warn and fall back to `profiles/default/instructions.txt` so an incomplete profile does not tear down the conversation app.

The PR also tightens the runtime personality error path now that the prompt loader no longer exits, adds a regression test, and documents the fallback behavior.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [x] Profiles or custom tools
</details>

## Notes
Validated locally with:

- `.venv/bin/pytest tests/ -v` (266 passed)
- `.venv/bin/mypy --pretty --show-error-codes`
- `.venv/bin/ruff check src/reachy_mini_conversation_app/prompts.py src/reachy_mini_conversation_app/base_realtime.py tests/test_profile_paths.py`
- `.venv/bin/ruff format --check src/reachy_mini_conversation_app/prompts.py src/reachy_mini_conversation_app/base_realtime.py tests/test_profile_paths.py`

`ruff check .` is currently blocked by unrelated local-only files outside this PR (`talk_to_backend_no_robot.py` is untracked and fails public-docstring rules).
