### PR TITLE
Start backend connection concurrently with media warmup

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -771,15 +771,17 @@ class LocalStream:
         # Start media after key is set/available
         self._robot.media.start_recording()
         self._robot.media.start_playing()
-        time.sleep(1)  # give some time to the pipelines to start
-        apply_audio_startup_config(self._robot, logger=logger)
 
         async def runner() -> None:
             # Capture loop for cross-thread personality actions
             loop = asyncio.get_running_loop()
             self._asyncio_loop = loop  # type: ignore[assignment]
-            self._tasks = [
-                asyncio.create_task(self._run_handler_startup_loop(), name="realtime-handler"),
+            # Connect the backend first so it overlaps the warmup and audio config below.
+            handler_task = asyncio.create_task(self._run_handler_startup_loop(), name="realtime-handler")
+            self._tasks = [handler_task]
+            await asyncio.sleep(1)  # give the pipelines time to start
+            await asyncio.to_thread(apply_audio_startup_config, self._robot, logger=logger)
+            self._tasks += [
                 asyncio.create_task(self.record_loop(), name="stream-record-loop"),
                 asyncio.create_task(self.play_loop(), name="stream-play-loop"),
             ]


### PR DESCRIPTION
## Summary
Starts the realtime backend connection before the audio pipeline warmup and `apply_audio_startup_config`, overlapping the ~0.9s connect with the ~1.7s of local startup work instead of running them sequentially. Media start stays on the main thread (fast set_state) and the 1s warmup and the blocking audio-config writes run off the event loop. `record`/`play` loops still start after the config, so mic input is unchanged

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>