### PR TITLE
Cache space tool specs in the manifest so startup does no network

### DIFF
--- a/src/reachy_mini_conversation_app/mcp_client.py
+++ b/src/reachy_mini_conversation_app/mcp_client.py
@@ -7,7 +7,7 @@ downloading third-party Python code.
 
 from __future__ import annotations
 import re
-from typing import TYPE_CHECKING, Any, Mapping, AsyncIterator
+from typing import TYPE_CHECKING, Any, Mapping, Sequence, AsyncIterator
 from datetime import timedelta
 from contextlib import asynccontextmanager
 from dataclasses import field, dataclass
@@ -273,10 +273,10 @@ class RemoteToolCallResponse:
 class RemoteMcpToolClient:
     """Minimal async client for allowlisted remote MCP tool servers."""
 
-    def __init__(self, server: RemoteMcpServerConfig) -> None:
+    def __init__(self, server: RemoteMcpServerConfig, known_tools: Sequence[RemoteToolSpec] = ()) -> None:
         """Store one allowlisted server configuration and an in-memory tool cache."""
         self.server = server
-        self._tool_index: dict[str, RemoteToolSpec] = {}
+        self._tool_index = _index_remote_tools(list(known_tools))
 
     async def list_tool_specs(self) -> list[RemoteToolSpec]:
         """Discover remote tools and translate them into app-facing specs."""

--- a/src/reachy_mini_conversation_app/tool_spaces.py
+++ b/src/reachy_mini_conversation_app/tool_spaces.py
@@ -28,24 +28,9 @@ from reachy_mini_conversation_app.mcp_client import (
 logger = logging.getLogger(__name__)
 
 INSTALLED_TOOL_SPACES_FILENAME = "installed_tool_spaces.json"
+INSTALLED_TOOL_SPACES_VERSION = 2
 TERMINAL_EXTERNAL_CONTENT_DIRECTORY = Path("external_content")
 _SLUG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
-
-
-@dataclass(frozen=True)
-class InstalledToolSpace:
-    """Persisted record for one installed Space."""
-
-    slug: str
-    alias: str
-
-
-@dataclass(frozen=True)
-class InstalledToolSpacesManifest:
-    """Persisted manifest of installed Space tool sources."""
-
-    version: int = 1
-    spaces: list[InstalledToolSpace] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -60,12 +45,32 @@ class InstalledToolSpaceTool:
 
 
 @dataclass(frozen=True)
+class InstalledToolSpace:
+    """Persisted record for one installed Space and the tools discovered at install time."""
+
+    slug: str
+    alias: str
+    mcp_url: str
+    private: bool
+    tools: list[InstalledToolSpaceTool] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class InstalledToolSpacesManifest:
+    """Persisted manifest of installed Space tool sources."""
+
+    version: int = INSTALLED_TOOL_SPACES_VERSION
+    spaces: list[InstalledToolSpace] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class ResolvedInstalledToolSpace:
     """Runtime description of an installed Space."""
 
     slug: str
     alias: str
     mcp_url: str
+    private: bool
     tags: list[str]
     tools: list[InstalledToolSpaceTool]
     client: RemoteMcpToolClient
@@ -112,9 +117,36 @@ def read_installed_tool_spaces(instance_path: str | Path | None) -> InstalledToo
                 f"Installed tool spaces manifest contains alias collision '{alias}' in {manifest_path}. "
                 "Remove one of the conflicting spaces with 'tool-spaces remove'."
             )
+        mcp_url = str(raw_space.get("mcp_url", "")).strip()
+        if not mcp_url:
+            logger.warning(
+                "Installed Space '%s' predates cached tool metadata and will be skipped. Re-run 'tool-spaces add %s'.",
+                slug,
+                slug,
+            )
+            continue
+        cached_tools = [
+            InstalledToolSpaceTool(
+                local_name=str(tool["local_name"]),
+                client_tool_name=str(tool["client_tool_name"]),
+                remote_name=str(tool.get("remote_name", "")),
+                description=str(tool.get("description", "")),
+                parameters_schema=dict(tool.get("parameters_schema") or {}),
+            )
+            for tool in raw_space.get("tools", [])
+            if isinstance(tool, dict) and tool.get("local_name") and tool.get("client_tool_name")
+        ]
         seen_slugs.add(slug)
         seen_aliases.add(alias)
-        spaces.append(InstalledToolSpace(slug=slug, alias=alias))
+        spaces.append(
+            InstalledToolSpace(
+                slug=slug,
+                alias=alias,
+                mcp_url=mcp_url,
+                private=bool(raw_space.get("private", False)),
+                tools=cached_tools,
+            )
+        )
 
     version = payload.get("version", 1)
     if not isinstance(version, int):
@@ -271,6 +303,21 @@ def _validate_space_info(slug: str, space_info: SpaceInfo) -> None:
         raise RuntimeError(f"Space '{slug}' is not a Gradio Space and cannot expose the standard MCP endpoint.")
 
 
+def build_remote_client(alias: str, mcp_url: str, *, private: bool) -> RemoteMcpToolClient:
+    """Build an MCP client for an installed Space, sending the HF token only to private Spaces."""
+    token = config.HF_TOKEN or get_token()
+    headers = {"Authorization": f"Bearer {token}"} if private and token else {}
+    return RemoteMcpToolClient(
+        RemoteMcpServerConfig(
+            alias=alias,
+            url=mcp_url,
+            headers=headers,
+            request_timeout_s=10.0,
+            tool_timeout_s=30.0,
+        )
+    )
+
+
 async def resolve_tool_space(slug: str) -> ResolvedInstalledToolSpace:
     """Validate and discover tools from one HF Space, authenticating private Spaces with the HF token."""
     validated_slug = validate_space_slug(slug)
@@ -290,17 +337,8 @@ async def resolve_tool_space(slug: str) -> ResolvedInstalledToolSpace:
     _validate_space_info(validated_slug, space_info)
 
     mcp_url = _build_space_mcp_url(space_info, validated_slug)
-    # Only private Spaces get the HF token, never leak it to a public Space's MCP endpoint.
-    headers = {"Authorization": f"Bearer {token}"} if bool(space_info.private) and token else {}
-    client = RemoteMcpToolClient(
-        RemoteMcpServerConfig(
-            alias=alias,
-            url=mcp_url,
-            headers=headers,
-            request_timeout_s=10.0,
-            tool_timeout_s=30.0,
-        )
-    )
+    private = bool(space_info.private)
+    client = build_remote_client(alias, mcp_url, private=private)
     try:
         remote_specs = await client.list_tool_specs()
     except McpClientError as exc:
@@ -310,6 +348,7 @@ async def resolve_tool_space(slug: str) -> ResolvedInstalledToolSpace:
         slug=validated_slug,
         alias=alias,
         mcp_url=mcp_url,
+        private=private,
         tags=sorted(space_info.tags or []),
         tools=_build_installed_tool_space_tools(slug=validated_slug, alias=alias, remote_specs=remote_specs),
         client=client,
@@ -361,13 +400,20 @@ def handle_tool_spaces_command(args: argparse.Namespace, *, instance_path: str |
                 )
                 return 1
 
+            installed = InstalledToolSpace(
+                slug=resolved_space.slug,
+                alias=resolved_space.alias,
+                mcp_url=resolved_space.mcp_url,
+                private=resolved_space.private,
+                tools=resolved_space.tools,
+            )
             updated_spaces = sorted(
-                [*manifest.spaces, InstalledToolSpace(slug=resolved_space.slug, alias=resolved_space.alias)],
+                [*manifest.spaces, installed],
                 key=lambda space: space.slug,
             )
             manifest_path = write_installed_tool_spaces(
                 instance_path,
-                InstalledToolSpacesManifest(version=manifest.version, spaces=updated_spaces),
+                InstalledToolSpacesManifest(version=INSTALLED_TOOL_SPACES_VERSION, spaces=updated_spaces),
             )
             logger.info("Installed Space tool source: %s", resolved_space.slug)
             logger.info("Manifest: %s", manifest_path)

--- a/src/reachy_mini_conversation_app/tool_spaces.py
+++ b/src/reachy_mini_conversation_app/tool_spaces.py
@@ -303,7 +303,13 @@ def _validate_space_info(slug: str, space_info: SpaceInfo) -> None:
         raise RuntimeError(f"Space '{slug}' is not a Gradio Space and cannot expose the standard MCP endpoint.")
 
 
-def build_remote_client(alias: str, mcp_url: str, *, private: bool) -> RemoteMcpToolClient:
+def build_remote_client(
+    alias: str,
+    mcp_url: str,
+    *,
+    private: bool,
+    cached_tools: Sequence[InstalledToolSpaceTool] = (),
+) -> RemoteMcpToolClient:
     """Build an MCP client for an installed Space, sending the HF token only to private Spaces."""
     token = config.HF_TOKEN or get_token()
     headers = {"Authorization": f"Bearer {token}"} if private and token else {}
@@ -314,7 +320,18 @@ def build_remote_client(alias: str, mcp_url: str, *, private: bool) -> RemoteMcp
             headers=headers,
             request_timeout_s=10.0,
             tool_timeout_s=30.0,
-        )
+        ),
+        known_tools=[
+            RemoteToolSpec(
+                server_alias=alias,
+                remote_name=tool.remote_name,
+                namespaced_name=tool.client_tool_name,
+                description=tool.description,
+                parameters_schema=tool.parameters_schema,
+            )
+            for tool in cached_tools
+            if tool.remote_name
+        ],
     )
 
 

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -388,7 +388,12 @@ def _resolve_remote_tools(tool_names: list[str], instance_path: str | Path | Non
                 installed_space.slug,
             )
 
-        client = build_remote_client(installed_space.alias, installed_space.mcp_url, private=installed_space.private)
+        client = build_remote_client(
+            installed_space.alias,
+            installed_space.mcp_url,
+            private=installed_space.private,
+            cached_tools=installed_space.tools,
+        )
         for remote_tool in installed_space.tools:
             if remote_tool.local_name not in enabled_tool_names:
                 continue

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -369,53 +369,40 @@ def _read_profile_tool_names() -> list[str]:
 
 
 def _resolve_remote_tools(tool_names: list[str], instance_path: str | Path | None) -> list[RemoteMcpTool]:
-    """Resolve installed Space tools enabled by the active profile."""
-    from reachy_mini_conversation_app.tool_spaces import resolve_tool_space_sync, read_installed_tool_spaces
+    """Build Space tools enabled by the active profile from the cached install manifest, without any network calls."""
+    from reachy_mini_conversation_app.tool_spaces import build_remote_client, read_installed_tool_spaces
 
     remote_tools: list[RemoteMcpTool] = []
     for installed_space in read_installed_tool_spaces(instance_path).spaces:
-        enabled_space_tools = sorted(name for name in tool_names if name.startswith(f"{installed_space.alias}__"))
-        if not enabled_space_tools:
-            logger.debug(
-                "Installed Space '%s' has no enabled tools in the active profile; skipping discovery.",
-                installed_space.slug,
-            )
+        enabled_tool_names = {name for name in tool_names if name.startswith(f"{installed_space.alias}__")}
+        if not enabled_tool_names:
             continue
 
-        try:
-            resolved_space = resolve_tool_space_sync(installed_space.slug)
-        except Exception as exc:
-            logger.warning(
-                "Space '%s' is unavailable, skipping its tools (%s): %s",
-                installed_space.slug,
-                ", ".join(enabled_space_tools),
-                exc,
-            )
-            continue
-
-        enabled_tool_names = set(enabled_space_tools)
-        discovered_tool_names = {tool.local_name for tool in resolved_space.tools}
+        discovered_tool_names = {tool.local_name for tool in installed_space.tools}
         missing_tool_names = sorted(enabled_tool_names - discovered_tool_names)
         if missing_tool_names:
             logger.warning(
-                "Enabled tools from '%s' not found in Space and will be skipped: %s",
+                "Tools enabled from '%s' are missing from the install manifest and will be skipped: %s. "
+                "Re-run 'tool-spaces add %s' to refresh.",
                 installed_space.slug,
                 ", ".join(missing_tool_names),
+                installed_space.slug,
             )
 
-        for remote_tool in resolved_space.tools:
+        client = build_remote_client(installed_space.alias, installed_space.mcp_url, private=installed_space.private)
+        for remote_tool in installed_space.tools:
             if remote_tool.local_name not in enabled_tool_names:
                 continue
-            cache_key = ("remote", f"{resolved_space.slug}:{remote_tool.local_name}:{remote_tool.client_tool_name}")
+            cache_key = ("remote", f"{installed_space.slug}:{remote_tool.local_name}:{remote_tool.client_tool_name}")
             cached_tool = _LOADED_REMOTE_TOOL_CACHE.get(cache_key)
             if cached_tool is None:
                 cached_tool = RemoteMcpTool(
-                    slug=resolved_space.slug,
+                    slug=installed_space.slug,
                     name=remote_tool.local_name,
                     description=remote_tool.description,
                     parameters_schema=remote_tool.parameters_schema,
                     client_tool_name=remote_tool.client_tool_name,
-                    client=resolved_space.client,
+                    client=client,
                 )
                 _LOADED_REMOTE_TOOL_CACHE[cache_key] = cached_tool
             remote_tools.append(cached_tool)

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -18,6 +18,7 @@ from reachy_mini_conversation_app.config import DEFAULT_PROFILES_DIRECTORY as DE
 
 # Import config to ensure .env is loaded before reading REACHY_MINI_CUSTOM_PROFILE
 from reachy_mini_conversation_app.config import config
+from reachy_mini_conversation_app.tool_spaces import build_remote_client, read_installed_tool_spaces
 from reachy_mini_conversation_app.tools.tool_constants import SystemTool
 
 
@@ -370,8 +371,6 @@ def _read_profile_tool_names() -> list[str]:
 
 def _resolve_remote_tools(tool_names: list[str], instance_path: str | Path | None) -> list[RemoteMcpTool]:
     """Build Space tools enabled by the active profile from the cached install manifest, without any network calls."""
-    from reachy_mini_conversation_app.tool_spaces import build_remote_client, read_installed_tool_spaces
-
     remote_tools: list[RemoteMcpTool] = []
     for installed_space in read_installed_tool_spaces(instance_path).spaces:
         enabled_tool_names = {name for name in tool_names if name.startswith(f"{installed_space.alias}__")}

--- a/tests/test_mcp_client_integration.py
+++ b/tests/test_mcp_client_integration.py
@@ -16,6 +16,7 @@ pytest.importorskip("mcp.server.fastmcp")
 from mcp.server.fastmcp import FastMCP
 
 from reachy_mini_conversation_app.mcp_client import (
+    RemoteToolSpec,
     McpTransportError,
     McpToolTimeoutError,
     RemoteMcpToolClient,
@@ -104,6 +105,47 @@ async def local_mcp_server(unused_tcp_port: int) -> AsyncIterator[tuple[str, str
     finally:
         server.should_exit = True
         await task
+
+
+@pytest.mark.asyncio
+async def test_remote_mcp_tool_client_calls_known_tool_without_discovery(
+    local_mcp_server: tuple[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cached tool spec should let the first call skip remote discovery."""
+    server_url, token = local_mcp_server
+    client = RemoteMcpToolClient(
+        RemoteMcpServerConfig(
+            alias="gradio_docs",
+            url=server_url,
+            headers={"Authorization": f"Bearer {token}"},
+            request_timeout_s=2.0,
+            tool_timeout_s=1.0,
+        ),
+        known_tools=[
+            RemoteToolSpec(
+                server_alias="gradio_docs",
+                remote_name="echo_text",
+                namespaced_name="gradio_docs__echo_text",
+                description="Echo text",
+                parameters_schema={
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                },
+            )
+        ],
+    )
+
+    async def _fail_list_tool_specs() -> list[RemoteToolSpec]:
+        raise AssertionError("discovery should not run")
+
+    monkeypatch.setattr(client, "list_tool_specs", _fail_list_tool_specs)
+
+    result = await client.call_tool("gradio_docs__echo_text", {"message": "hello"})
+
+    assert result["status"] == "ok"
+    assert result["structured_content"] == {"echo": "hello"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_space_runtime.py
+++ b/tests/test_tool_space_runtime.py
@@ -83,7 +83,23 @@ async def test_initialize_tools_loads_enabled_installed_remote_tools_and_dispatc
         "content_blocks": [],
         "text": "hello",
     }
-    monkeypatch.setattr(tool_spaces_mod, "build_remote_client", lambda *args, **kwargs: client)
+    captured_cached_tools: list[InstalledToolSpaceTool] | None = None
+
+    def _build_remote_client(
+        alias: str,
+        mcp_url: str,
+        *,
+        private: bool,
+        cached_tools: list[InstalledToolSpaceTool],
+    ) -> AsyncMock:
+        nonlocal captured_cached_tools
+        assert alias == SEARCH_ALIAS
+        assert mcp_url == SEARCH_MCP_URL
+        assert private is False
+        captured_cached_tools = cached_tools
+        return client
+
+    monkeypatch.setattr(tool_spaces_mod, "build_remote_client", _build_remote_client)
 
     write_installed_tool_spaces(
         None,
@@ -94,6 +110,7 @@ async def test_initialize_tools_loads_enabled_installed_remote_tools_and_dispatc
     core_tools_mod.initialize_tools()
 
     assert SEARCH_TOOL_ID in core_tools_mod.ALL_TOOLS
+    assert captured_cached_tools == _installed_search_space().tools
     tool_specs = core_tools_mod.get_tool_specs()
     assert any(spec["name"] == SEARCH_TOOL_ID for spec in tool_specs)
 

--- a/tests/test_tool_space_runtime.py
+++ b/tests/test_tool_space_runtime.py
@@ -4,7 +4,7 @@ import json
 import importlib
 from types import ModuleType
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -13,18 +13,16 @@ import reachy_mini_conversation_app.tool_spaces as tool_spaces_mod
 from reachy_mini_conversation_app.tool_spaces import (
     InstalledToolSpace,
     InstalledToolSpaceTool,
-    ResolvedInstalledToolSpace,
     InstalledToolSpacesManifest,
     write_installed_tool_spaces,
 )
 
 
-SEARCH_SPACE_SLUG = "pollen-robotics/reachy-mini-search-tool"
-WEATHER_SPACE_SLUG = "pollen-robotics/reachy-mini-weather-tool"
-SEARCH_ALIAS = "pollen_robotics_reachy_mini_search_tool"
-WEATHER_ALIAS = "pollen_robotics_reachy_mini_weather_tool"
+SEARCH_SPACE_SLUG = "example/search-tool"
+SEARCH_ALIAS = "example_search_tool"
 SEARCH_TOOL_ID = f"{SEARCH_ALIAS}__search_web"
-SEARCH_CLIENT_TOOL_ID = f"{SEARCH_ALIAS}__reachy_mini_search_tool_search_web"
+SEARCH_CLIENT_TOOL_ID = f"{SEARCH_ALIAS}__search_tool_search_web"
+SEARCH_MCP_URL = "https://example-search-tool.hf.space/gradio_api/mcp/"
 
 
 def _reload_core_tools() -> ModuleType:
@@ -36,17 +34,17 @@ def _reload_core_tools() -> ModuleType:
     return importlib.import_module("reachy_mini_conversation_app.tools.core_tools")
 
 
-def _resolved_remote_space(client: AsyncMock) -> ResolvedInstalledToolSpace:
-    return ResolvedInstalledToolSpace(
+def _installed_search_space() -> InstalledToolSpace:
+    return InstalledToolSpace(
         slug=SEARCH_SPACE_SLUG,
         alias=SEARCH_ALIAS,
-        mcp_url="https://pollen-robotics-reachy-mini-search-tool.hf.space/gradio_api/mcp/",
-        tags=["mcp", "reachy-mini-tool"],
+        mcp_url=SEARCH_MCP_URL,
+        private=False,
         tools=[
             InstalledToolSpaceTool(
                 local_name=SEARCH_TOOL_ID,
                 client_tool_name=SEARCH_CLIENT_TOOL_ID,
-                remote_name="reachy_mini_search_tool_search_web",
+                remote_name="search_tool_search_web",
                 description="Search the web",
                 parameters_schema={
                     "type": "object",
@@ -55,7 +53,6 @@ def _resolved_remote_space(client: AsyncMock) -> ResolvedInstalledToolSpace:
                 },
             )
         ],
-        client=client,
     )
 
 
@@ -86,23 +83,16 @@ async def test_initialize_tools_loads_enabled_installed_remote_tools_and_dispatc
         "content_blocks": [],
         "text": "hello",
     }
-    resolver = MagicMock(side_effect=lambda _slug: _resolved_remote_space(client))
-    monkeypatch.setattr(tool_spaces_mod, "resolve_tool_space_sync", resolver)
+    monkeypatch.setattr(tool_spaces_mod, "build_remote_client", lambda *args, **kwargs: client)
 
     write_installed_tool_spaces(
         None,
-        InstalledToolSpacesManifest(
-            spaces=[
-                InstalledToolSpace(slug=SEARCH_SPACE_SLUG, alias=SEARCH_ALIAS),
-                InstalledToolSpace(slug=WEATHER_SPACE_SLUG, alias=WEATHER_ALIAS),
-            ]
-        ),
+        InstalledToolSpacesManifest(spaces=[_installed_search_space()]),
     )
 
     core_tools_mod = _reload_core_tools()
     core_tools_mod.initialize_tools()
 
-    resolver.assert_called_once_with(SEARCH_SPACE_SLUG)
     assert SEARCH_TOOL_ID in core_tools_mod.ALL_TOOLS
     tool_specs = core_tools_mod.get_tool_specs()
     assert any(spec["name"] == SEARCH_TOOL_ID for spec in tool_specs)
@@ -121,12 +111,12 @@ async def test_initialize_tools_loads_enabled_installed_remote_tools_and_dispatc
     client.call_tool.assert_awaited_once_with(SEARCH_CLIENT_TOOL_ID, {"query": "hello"})
 
 
-def test_initialize_tools_warns_when_enabled_remote_tool_is_unavailable(
+def test_initialize_tools_warns_when_enabled_tool_missing_from_manifest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Startup should warn and skip tools from an unavailable Space, not crash."""
+    """A tool enabled in the profile but absent from the cached manifest is skipped with a warning."""
     monkeypatch.chdir(tmp_path)
     external_profiles_root = tmp_path / "external_profiles"
     profile_dir = external_profiles_root / "remote_profile"
@@ -138,15 +128,17 @@ def test_initialize_tools_warns_when_enabled_remote_tool_is_unavailable(
     monkeypatch.setattr(config_mod.config, "PROFILES_DIRECTORY", external_profiles_root)
     monkeypatch.setattr(config_mod.config, "TOOLS_DIRECTORY", None)
     monkeypatch.setattr(config_mod.config, "AUTOLOAD_EXTERNAL_TOOLS", False)
-    monkeypatch.setattr(
-        tool_spaces_mod, "resolve_tool_space_sync", lambda slug: (_ for _ in ()).throw(RuntimeError("boom"))
-    )
 
     write_installed_tool_spaces(
         None,
         InstalledToolSpacesManifest(
             spaces=[
-                InstalledToolSpace(slug=SEARCH_SPACE_SLUG, alias=SEARCH_ALIAS),
+                InstalledToolSpace(
+                    slug=SEARCH_SPACE_SLUG,
+                    alias=SEARCH_ALIAS,
+                    mcp_url=SEARCH_MCP_URL,
+                    private=False,
+                ),
             ]
         ),
     )

--- a/tests/test_tool_spaces.py
+++ b/tests/test_tool_spaces.py
@@ -19,12 +19,13 @@ from reachy_mini_conversation_app.tool_spaces import (
 )
 
 
-SEARCH_SPACE_SLUG = "pollen-robotics/reachy-mini-search-tool"
-COLLIDING_SEARCH_SPACE_SLUG = "pollen_robotics/reachy-mini-search-tool"
-PRIVATE_SPACE_SLUG = "pollen-robotics/private-space"
-SEARCH_ALIAS = "pollen_robotics_reachy_mini_search_tool"
+SEARCH_SPACE_SLUG = "example/search-tool"
+COLLIDING_SEARCH_SPACE_SLUG = "example/search_tool"
+PRIVATE_SPACE_SLUG = "example/private-space"
+SEARCH_ALIAS = "example_search_tool"
+SEARCH_REMOTE_NAME = "search_tool_search_web"
 SEARCH_TOOL_ID = f"{SEARCH_ALIAS}__search_web"
-SEARCH_CLIENT_TOOL_ID = f"{SEARCH_ALIAS}__reachy_mini_search_tool_search_web"
+SEARCH_CLIENT_TOOL_ID = f"{SEARCH_ALIAS}__{SEARCH_REMOTE_NAME}"
 
 
 def _mock_public_space_info(slug: str) -> SimpleNamespace:
@@ -49,7 +50,7 @@ async def _mock_list_tool_specs(self: object) -> list[RemoteToolSpec]:
     return [
         RemoteToolSpec(
             server_alias=SEARCH_ALIAS,
-            remote_name="reachy_mini_search_tool_search_web",
+            remote_name=SEARCH_REMOTE_NAME,
             namespaced_name=SEARCH_CLIENT_TOOL_ID,
             description="Search the web",
             parameters_schema={
@@ -100,8 +101,28 @@ def test_tool_spaces_add_list_remove_round_trip(
     manifest_path = tmp_path / "external_content" / "installed_tool_spaces.json"
     assert manifest_path.is_file()
     assert json.loads(manifest_path.read_text(encoding="utf-8")) == {
-        "version": 1,
-        "spaces": [{"alias": SEARCH_ALIAS, "slug": SEARCH_SPACE_SLUG}],
+        "version": 2,
+        "spaces": [
+            {
+                "slug": SEARCH_SPACE_SLUG,
+                "alias": SEARCH_ALIAS,
+                "mcp_url": "https://example-search-tool.hf.space/gradio_api/mcp/",
+                "private": False,
+                "tools": [
+                    {
+                        "local_name": SEARCH_TOOL_ID,
+                        "client_tool_name": SEARCH_CLIENT_TOOL_ID,
+                        "remote_name": SEARCH_REMOTE_NAME,
+                        "description": "Search the web",
+                        "parameters_schema": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                            "required": ["query"],
+                        },
+                    }
+                ],
+            }
+        ],
     }
 
     assert _run_cli(monkeypatch, ["reachy-mini-conversation-app", "tool-spaces", "list"]) == 0
@@ -230,11 +251,12 @@ def test_tool_spaces_manifest_uses_instance_path_when_provided(
 
 def test_read_installed_tool_spaces_raises_on_alias_collision_in_manifest(tmp_path: Path) -> None:
     """A manifest with two slugs that normalize to the same alias must be rejected on read."""
+    mcp_url = "https://example.hf.space/gradio_api/mcp/"
     payload = {
-        "version": 1,
+        "version": 2,
         "spaces": [
-            {"slug": "owner/my-tool", "alias": "owner_my_tool"},
-            {"slug": "owner/my_tool", "alias": "owner_my_tool"},
+            {"slug": "owner/my-tool", "alias": "owner_my_tool", "mcp_url": mcp_url, "private": False, "tools": []},
+            {"slug": "owner/my_tool", "alias": "owner_my_tool", "mcp_url": mcp_url, "private": False, "tools": []},
         ],
     }
     (tmp_path / "installed_tool_spaces.json").write_text(json.dumps(payload), encoding="utf-8")


### PR DESCRIPTION
## Summary
Installed space tools are now resolved once at tool-spaces add and their specs (tools, mcp_url, private) cached in `installed_tool_spaces.json` (manifest v2). Startup builds Space tools from that cache with zero network calls, the Space is only contacted when a tool is actually called.

Closes https://github.com/pollen-robotics/reachy_mini_conversation_app/issues/450

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>
