### PR TITLE
test: raise unit-test coverage for tools, realtime loop, routes and audio

### DIFF
--- a/tests/test_app_lifecycle.py
+++ b/tests/test_app_lifecycle.py
@@ -69,3 +69,68 @@ def test_run_go_to_sleep_tool_uses_runtime_callback() -> None:
 
     assert result == expected
     go_to_sleep.assert_called_once_with()
+
+
+def test_request_stop_current_app_returns_false_on_urlerror(monkeypatch) -> None:
+    """A daemon that is unreachable is reported as a failed stop, not an exception."""
+
+    def fake_urlopen(request, timeout):
+        raise app_lifecycle.urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(app_lifecycle.urllib.request, "urlopen", fake_urlopen)
+    robot = SimpleNamespace(client=SimpleNamespace(host="192.168.1.42", port=8000))
+
+    assert not app_lifecycle.request_stop_current_app(robot, MagicMock())
+
+
+def test_wake_up_if_sleeping_handles_pose_read_failure() -> None:
+    """A robot that cannot report its pose skips the wake-up movement."""
+    robot = MagicMock()
+    robot.get_current_head_pose.side_effect = RuntimeError("no telemetry")
+
+    assert not app_lifecycle.wake_up_if_sleeping(robot, MagicMock())
+    robot.wake_up.assert_not_called()
+
+
+def test_wake_up_if_sleeping_reports_wake_up_failure() -> None:
+    """A wake-up movement that fails is reported without raising."""
+    robot = MagicMock()
+    robot.get_current_head_pose.return_value = SLEEP_HEAD_POSE.copy()
+    robot.wake_up.side_effect = RuntimeError("motor fault")
+
+    assert not app_lifecycle.wake_up_if_sleeping(robot, MagicMock())
+    robot.wake_up.assert_called_once_with()
+
+
+def test_wake_up_if_sleeping_ignores_malformed_pose() -> None:
+    """A pose that cannot be coerced to a float array is treated as not-sleeping."""
+    robot = MagicMock()
+    robot.get_current_head_pose.return_value = "not-a-pose"
+
+    assert not app_lifecycle.wake_up_if_sleeping(robot, MagicMock())
+    robot.wake_up.assert_not_called()
+
+
+def test_wake_up_if_sleeping_ignores_wrong_shape_pose() -> None:
+    """A pose that is not 4x4 is treated as not-sleeping."""
+    robot = MagicMock()
+    robot.get_current_head_pose.return_value = np.eye(3)
+
+    assert not app_lifecycle.wake_up_if_sleeping(robot, MagicMock())
+    robot.wake_up.assert_not_called()
+
+
+def test_run_go_to_sleep_tool_reports_tool_failure(monkeypatch) -> None:
+    """A crash inside the go_to_sleep tool is surfaced as an error dict, not raised."""
+
+    class _BoomTool:
+        async def __call__(self, deps: object) -> dict[str, object]:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(app_lifecycle, "GoToSleep", _BoomTool)
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+
+    result = app_lifecycle.run_go_to_sleep_tool(deps, MagicMock())
+
+    assert "error" in result
+    assert "boom" in str(result["error"])

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -15,6 +16,7 @@ from fastapi.testclient import TestClient
 
 from reachy_mini_conversation_app.config import HF_AVAILABLE_VOICES, config
 from reachy_mini_conversation_app.console import LocalStream
+from reachy_mini_conversation_app.streaming import AdditionalOutputs
 from reachy_mini_conversation_app.startup_settings import (
     StartupSettings,
     load_startup_settings_into_runtime,
@@ -892,3 +894,157 @@ async def test_change_voice_reports_handler_failure() -> None:
     result = await stream.change_voice("Serena")
 
     assert "Failed to change voice" in result
+
+
+def _audio_robot(**media_attrs: Any) -> SimpleNamespace:
+    """Return a robot whose media exposes only the attributes a test drives."""
+    return SimpleNamespace(media=SimpleNamespace(audio=None, backend=None, **media_attrs))
+
+
+def _stop_after(stream: LocalStream, value: Any) -> Callable[[], Any]:
+    """Return a side effect that stops the stream after one iteration, yielding `value`."""
+
+    def _side_effect() -> Any:
+        stream._stop_event.set()
+        return value
+
+    return _side_effect
+
+
+@pytest.mark.asyncio
+async def test_record_loop_forwards_unmuted_frames() -> None:
+    """A recorded frame is forwarded to the handler with the input sample rate."""
+    frame = np.zeros(4, dtype=np.int16)
+    robot = _audio_robot(get_input_audio_samplerate=MagicMock(return_value=16000), get_audio_sample=MagicMock())
+    handler = MagicMock()
+    handler.receive = AsyncMock()
+    stream = LocalStream(handler, robot)
+    robot.media.get_audio_sample.side_effect = _stop_after(stream, frame)
+
+    await stream.record_loop()
+
+    handler.receive.assert_awaited_once_with((16000, frame))
+
+
+@pytest.mark.asyncio
+async def test_record_loop_skips_frames_while_muted() -> None:
+    """No frames are forwarded while the mic is muted."""
+    robot = _audio_robot(get_input_audio_samplerate=MagicMock(return_value=16000), get_audio_sample=MagicMock())
+    handler = MagicMock()
+    handler.receive = AsyncMock()
+    stream = LocalStream(handler, robot)
+    stream._mic_muted = True
+    robot.media.get_audio_sample.side_effect = _stop_after(stream, np.zeros(4, dtype=np.int16))
+
+    await stream.record_loop()
+
+    handler.receive.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_record_loop_skips_missing_frames() -> None:
+    """A None frame from the recorder is not forwarded."""
+    robot = _audio_robot(get_input_audio_samplerate=MagicMock(return_value=16000), get_audio_sample=MagicMock())
+    handler = MagicMock()
+    handler.receive = AsyncMock()
+    stream = LocalStream(handler, robot)
+    robot.media.get_audio_sample.side_effect = _stop_after(stream, None)
+
+    await stream.record_loop()
+
+    handler.receive.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_play_loop_logs_text_outputs() -> None:
+    """Text outputs are logged, not pushed to the speaker."""
+    robot = _audio_robot(push_audio_sample=MagicMock())
+    handler = MagicMock()
+    stream = LocalStream(handler, robot)
+    output = AdditionalOutputs({"role": "assistant", "content": "hi"})
+    handler.emit = AsyncMock(side_effect=_stop_after(stream, output))
+
+    await stream.play_loop()
+
+    robot.media.push_audio_sample.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_play_loop_pushes_mono_audio_as_float32() -> None:
+    """A mono int16 frame is pushed to the speaker as float32."""
+    robot = _audio_robot(push_audio_sample=MagicMock())
+    handler = MagicMock()
+    stream = LocalStream(handler, robot)
+    handler.emit = AsyncMock(side_effect=_stop_after(stream, (24000, np.zeros(4, dtype=np.int16))))
+
+    await stream.play_loop()
+
+    robot.media.push_audio_sample.assert_called_once()
+    pushed = robot.media.push_audio_sample.call_args.args[0]
+    assert pushed.ndim == 1
+    assert pushed.dtype == np.float32
+
+
+@pytest.mark.asyncio
+async def test_play_loop_downmixes_stereo_before_pushing() -> None:
+    """A stereo frame is reduced to a single mono channel before playback."""
+    robot = _audio_robot(push_audio_sample=MagicMock())
+    handler = MagicMock()
+    stream = LocalStream(handler, robot)
+    stereo = np.zeros((4, 2), dtype=np.int16)
+    handler.emit = AsyncMock(side_effect=_stop_after(stream, (24000, stereo)))
+
+    await stream.play_loop()
+
+    pushed = robot.media.push_audio_sample.call_args.args[0]
+    assert pushed.ndim == 1
+
+
+@pytest.mark.asyncio
+async def test_play_loop_skips_empty_audio() -> None:
+    """An empty audio frame is skipped, not pushed."""
+    robot = _audio_robot(push_audio_sample=MagicMock())
+    handler = MagicMock()
+    stream = LocalStream(handler, robot)
+    handler.emit = AsyncMock(side_effect=_stop_after(stream, (24000, np.array([], dtype=np.int16))))
+
+    await stream.play_loop()
+
+    robot.media.push_audio_sample.assert_not_called()
+
+
+def test_close_without_running_loop_stops_media() -> None:
+    """Closing without a running loop stops the media pipelines and sets the stop event."""
+    robot = _audio_robot(stop_recording=MagicMock(), stop_playing=MagicMock())
+    stream = LocalStream(MagicMock(), robot)
+    stream._asyncio_loop = None
+
+    stream.close()
+
+    robot.media.stop_recording.assert_called_once()
+    robot.media.stop_playing.assert_called_once()
+    assert stream._stop_event.is_set()
+
+
+def test_drain_output_queue_empties_in_place() -> None:
+    """The output queue is drained without being replaced."""
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    queue.put_nowait("a")
+    queue.put_nowait("b")
+    handler = MagicMock()
+    handler.output_queue = queue
+    stream = LocalStream(handler, _audio_robot())
+
+    stream._drain_output_queue()
+
+    assert stream.handler.output_queue is queue
+    assert queue.empty()
+
+
+def test_drain_output_queue_tolerates_missing_queue() -> None:
+    """Draining is a no-op when the handler has no output queue."""
+    handler = MagicMock()
+    handler.output_queue = None
+    stream = LocalStream(handler, _audio_robot())
+
+    stream._drain_output_queue()  # must not raise

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,5 +1,6 @@
 """Tests for the headless console stream."""
 
+import time
 import asyncio
 import threading
 from types import SimpleNamespace
@@ -841,3 +842,53 @@ def test_local_stream_launch_waits_for_missing_hf_target_without_starting_media(
     init_settings_ui.assert_called_once()
     media.start_recording.assert_not_called()
     media.start_playing.assert_not_called()
+
+
+def _bare_stream() -> LocalStream:
+    """Return a LocalStream with a no-audio robot, enough for helper-method tests."""
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    return LocalStream(MagicMock(), robot)
+
+
+def test_read_env_lines_prefers_existing_file(tmp_path: Path) -> None:
+    """An existing .env is read verbatim, ignoring the template."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("A=1\nB=2\n", encoding="utf-8")
+
+    assert _bare_stream()._read_env_lines(env_path) == ["A=1", "B=2"]
+
+
+def test_read_env_lines_falls_back_to_example_template(tmp_path: Path) -> None:
+    """When no .env exists, the sibling .env.example is used as the template."""
+    (tmp_path / ".env.example").write_text("OPENAI_API_KEY=\n", encoding="utf-8")
+
+    assert _bare_stream()._read_env_lines(tmp_path / ".env") == ["OPENAI_API_KEY="]
+
+
+def test_seconds_since_activity_reads_handler() -> None:
+    """seconds_since_activity is measured from the handler's last activity time."""
+    stream = _bare_stream()
+    stream.handler.last_activity_time = time.monotonic() - 5.0
+
+    assert stream.seconds_since_activity() >= 5.0
+
+
+def test_get_current_voice_prefers_override() -> None:
+    """A manual voice override wins over the profile voice."""
+    stream = _bare_stream()
+    stream._voice_override = "Serena"
+
+    assert stream.get_current_voice() == "Serena"
+
+
+@pytest.mark.asyncio
+async def test_change_voice_reports_handler_failure() -> None:
+    """A failing handler voice change is surfaced as an error string, not raised."""
+    handler = MagicMock()
+    handler.change_voice = AsyncMock(side_effect=RuntimeError("backend down"))
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    stream = LocalStream(handler, robot)
+
+    result = await stream.change_voice("Serena")
+
+    assert "Failed to change voice" in result

--- a/tests/test_dance_emotion_moves.py
+++ b/tests/test_dance_emotion_moves.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from reachy_mini.utils import create_head_pose
+from reachy_mini_conversation_app.dance_emotion_moves import GotoQueueMove, DanceQueueMove
+
+
+def test_goto_evaluate_at_start_returns_start_state() -> None:
+    """At t=0 the goto move sits at its start antennas and body yaw."""
+    move = GotoQueueMove(
+        target_head_pose=create_head_pose(0, 0, 0, 0, 0, 40, degrees=True),
+        start_head_pose=create_head_pose(0, 0, 0, 0, 0, 0, degrees=True),
+        target_antennas=(1.0, 1.0),
+        start_antennas=(0.0, 0.0),
+        target_body_yaw=10.0,
+        start_body_yaw=0.0,
+        duration=2.0,
+    )
+    _, antennas, body_yaw = move.evaluate(0.0)
+    assert antennas is not None
+    np.testing.assert_allclose(antennas, [0.0, 0.0])
+    assert body_yaw == 0.0
+
+
+def test_goto_evaluate_midpoint_interpolates_linearly() -> None:
+    """Halfway through the duration antennas and body yaw are halfway to target."""
+    move = GotoQueueMove(
+        target_head_pose=create_head_pose(0, 0, 0, 0, 0, 40, degrees=True),
+        target_antennas=(1.0, 1.0),
+        start_antennas=(0.0, 0.0),
+        target_body_yaw=10.0,
+        start_body_yaw=0.0,
+        duration=2.0,
+    )
+    _, antennas, body_yaw = move.evaluate(1.0)
+    assert antennas is not None
+    np.testing.assert_allclose(antennas, [0.5, 0.5])
+    assert body_yaw == 5.0
+
+
+def test_goto_evaluate_clamps_past_duration() -> None:
+    """Past the duration t is clamped so antennas reach the target."""
+    move = GotoQueueMove(
+        target_head_pose=create_head_pose(0, 0, 0, 0, 0, 40, degrees=True),
+        target_antennas=(1.0, 1.0),
+        start_antennas=(0.0, 0.0),
+        target_body_yaw=10.0,
+        start_body_yaw=0.0,
+        duration=2.0,
+    )
+    _, antennas, body_yaw = move.evaluate(99.0)
+    assert antennas is not None
+    np.testing.assert_allclose(antennas, [1.0, 1.0])
+    assert body_yaw == 10.0
+
+
+def test_dance_queue_move_falls_back_to_neutral_on_error() -> None:
+    """A failing wrapped dance move yields a neutral pose instead of raising."""
+    move = DanceQueueMove.__new__(DanceQueueMove)
+    move.move_name = "broken"
+    move.dance_move = MagicMock()
+    move.dance_move.evaluate.side_effect = RuntimeError("boom")
+    head_pose, antennas, body_yaw = move.evaluate(0.5)
+    assert head_pose is not None
+    np.testing.assert_allclose(antennas, [0.0, 0.0])
+    assert body_yaw == 0.0
+
+
+def test_dance_queue_move_converts_tuple_antennas() -> None:
+    """Tuple antennas from the wrapped move are converted to a numpy array."""
+    move = DanceQueueMove.__new__(DanceQueueMove)
+    move.move_name = "ok"
+    move.dance_move = MagicMock()
+    head = create_head_pose(0, 0, 0, 0, 0, 0, degrees=True)
+    move.dance_move.evaluate.return_value = (head, (0.1, 0.2), 0.5)
+    _, antennas, body_yaw = move.evaluate(0.0)
+    assert isinstance(antennas, np.ndarray)
+    np.testing.assert_allclose(antennas, [0.1, 0.2])
+    assert body_yaw == 0.5

--- a/tests/test_huggingface_realtime.py
+++ b/tests/test_huggingface_realtime.py
@@ -1,13 +1,18 @@
+import json
 import time
+import base64
 import asyncio
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import numpy as np
 import pytest
 
 import reachy_mini_conversation_app.conversation_handler as conv_mod
 import reachy_mini_conversation_app.huggingface_realtime as hf_mod
 from reachy_mini_conversation_app.config import config, get_default_voice
+from reachy_mini_conversation_app.streaming import AdditionalOutputs
 from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
 from reachy_mini_conversation_app.huggingface_realtime import HuggingFaceRealtimeHandler
 from reachy_mini_conversation_app.tools.background_tool_manager import ToolState, ToolNotification
@@ -129,6 +134,34 @@ def _fake_allocator(connect_url: str, posts: list[tuple[str, dict[str, str] | No
             return FakeResponse()
 
     return FakeAsyncClient
+
+
+def _plain_handler() -> HuggingFaceRealtimeHandler:
+    return HuggingFaceRealtimeHandler(ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock()))
+
+
+def _session_handler(monkeypatch: Any, events: tuple[_FakeEvent, ...]) -> HuggingFaceRealtimeHandler:
+    """Build a handler wired to a fake realtime client yielding `events`, ready to run a session."""
+    monkeypatch.setattr(hf_mod, "get_session_instructions", lambda _instance_path=None: "test")
+    monkeypatch.setattr(hf_mod, "get_session_voice", lambda default=HF_DEFAULT_VOICE: default)
+    monkeypatch.setattr(hf_mod, "get_tool_specs", lambda: [])
+    monkeypatch.setattr(hf_mod, "get_session_greeting_prompt", lambda: "")
+    handler = _plain_handler()
+    handler.client = _make_fake_realtime_client(events=events)
+    monkeypatch.setattr(type(handler.tool_manager), "start_up", MagicMock())
+    monkeypatch.setattr(type(handler.tool_manager), "shutdown", AsyncMock())
+    return handler
+
+
+def _drain(handler: HuggingFaceRealtimeHandler) -> list[Any]:
+    items: list[Any] = []
+    while not handler.output_queue.empty():
+        items.append(handler.output_queue.get_nowait())
+    return items
+
+
+def _messages(items: list[Any]) -> list[dict[str, Any]]:
+    return [item.args[0] for item in items if isinstance(item, AdditionalOutputs)]
 
 
 @pytest.mark.asyncio
@@ -408,3 +441,356 @@ async def test_change_voice_updates_live_hf_session_without_restart(monkeypatch:
     restart.assert_not_awaited()
     session = captured_update["session"]
     assert session["audio"]["output"]["voice"] == "Serena"
+
+
+@pytest.mark.asyncio
+async def test_run_session_decodes_audio_delta(monkeypatch: Any) -> None:
+    """An audio delta is base64-decoded and enqueued as an (rate, int16) frame."""
+    pcm = np.array([1, 2, 3, 4], dtype=np.int16)
+    delta = base64.b64encode(pcm.tobytes()).decode("utf-8")
+    handler = _session_handler(monkeypatch, (_FakeEvent("response.output_audio.delta", delta=delta),))
+
+    await handler._run_realtime_session()
+
+    frames = [item for item in _drain(handler) if isinstance(item, tuple)]
+    assert len(frames) == 1
+    rate, array = frames[0]
+    assert rate == handler.SAMPLE_RATE
+    np.testing.assert_array_equal(array.reshape(-1), pcm)
+
+
+@pytest.mark.asyncio
+async def test_run_session_emits_completed_transcript(monkeypatch: Any) -> None:
+    """A non-empty completed transcript is enqueued as a user message and stops listening."""
+    handler = _session_handler(
+        monkeypatch,
+        (_FakeEvent("conversation.item.input_audio_transcription.completed", transcript="Hello there"),),
+    )
+
+    await handler._run_realtime_session()
+
+    assert {"role": "user", "content": "Hello there"} in _messages(_drain(handler))
+    handler.deps.movement_manager.set_listening.assert_any_call(False)
+
+
+@pytest.mark.asyncio
+async def test_run_session_skips_empty_completed_transcript(monkeypatch: Any) -> None:
+    """An empty completed transcript is ignored but still stops listening."""
+    handler = _session_handler(
+        monkeypatch,
+        (_FakeEvent("conversation.item.input_audio_transcription.completed", transcript="   "),),
+    )
+
+    await handler._run_realtime_session()
+
+    assert [msg for msg in _messages(_drain(handler)) if msg.get("role") == "user"] == []
+    handler.deps.movement_manager.set_listening.assert_any_call(False)
+
+
+@pytest.mark.asyncio
+async def test_run_session_generic_error_is_surfaced(monkeypatch: Any) -> None:
+    """A generic realtime error is forwarded to the UI as an assistant message."""
+    handler = _session_handler(
+        monkeypatch,
+        (_FakeEvent("error", error=SimpleNamespace(message="bad", code="server_error")),),
+    )
+
+    await handler._run_realtime_session()
+
+    assert {"role": "assistant", "content": "[error] bad"} in _messages(_drain(handler))
+
+
+@pytest.mark.asyncio
+async def test_run_session_commit_empty_error_is_internal(monkeypatch: Any) -> None:
+    """A commit-empty error stops listening and is not surfaced to the UI."""
+    handler = _session_handler(
+        monkeypatch,
+        (_FakeEvent("error", error=SimpleNamespace(message="empty", code="input_audio_buffer_commit_empty")),),
+    )
+
+    await handler._run_realtime_session()
+
+    assert _messages(_drain(handler)) == []
+    handler.deps.movement_manager.set_listening.assert_any_call(False)
+
+
+@pytest.mark.asyncio
+async def test_run_session_active_response_error_flags_rejection(monkeypatch: Any) -> None:
+    """A duplicate-response error is recorded for the sender worker, not surfaced."""
+    handler = _session_handler(
+        monkeypatch,
+        (_FakeEvent("error", error=SimpleNamespace(message="x", code="conversation_already_has_active_response")),),
+    )
+
+    await handler._run_realtime_session()
+
+    assert handler._last_response_rejected is True
+    assert _messages(_drain(handler)) == []
+
+
+@pytest.mark.asyncio
+async def test_run_session_dispatches_valid_tool_call(monkeypatch: Any) -> None:
+    """A valid function call starts a background tool and announces it."""
+    handler = _session_handler(
+        monkeypatch,
+        (_FakeEvent("response.function_call_arguments.done", name="dance", arguments="{}", call_id="c1"),),
+    )
+    start_tool = AsyncMock(return_value=SimpleNamespace(tool_id="dance-1"))
+    monkeypatch.setattr(type(handler.tool_manager), "start_tool", start_tool)
+
+    await handler._run_realtime_session()
+
+    start_tool.assert_awaited_once()
+    assert any("Used tool dance" in msg["content"] for msg in _messages(_drain(handler)))
+
+
+@pytest.mark.asyncio
+async def test_run_session_ignores_invalid_tool_call(monkeypatch: Any) -> None:
+    """A function call with a non-string name is ignored."""
+    handler = _session_handler(
+        monkeypatch,
+        (_FakeEvent("response.function_call_arguments.done", name=None, arguments="{}", call_id="c1"),),
+    )
+    start_tool = AsyncMock()
+    monkeypatch.setattr(type(handler.tool_manager), "start_tool", start_tool)
+
+    await handler._run_realtime_session()
+
+    start_tool.assert_not_awaited()
+    assert not any("Used tool" in msg["content"] for msg in _messages(_drain(handler)))
+
+
+def test_sanitize_tool_result_strips_camera_image() -> None:
+    """Camera results drop the raw image bytes and flag that an image was attached."""
+    sanitized = HuggingFaceRealtimeHandler._sanitize_tool_result_for_model("camera", {"b64_im": "x", "seen": "cat"})
+    assert sanitized == {"seen": "cat", "image_attached": True}
+
+
+def test_sanitize_tool_result_passthrough_for_non_camera() -> None:
+    """Non-camera results are returned unchanged."""
+    result = {"status": "ok"}
+    assert HuggingFaceRealtimeHandler._sanitize_tool_result_for_model("dance", result) == result
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.conversation = SimpleNamespace(item=SimpleNamespace(create=AsyncMock()))
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_result_error_is_reported_and_prompts_response() -> None:
+    """A failed tool reports its error to the UI and requests a spoken follow-up."""
+    handler = _plain_handler()
+    handler.connection = _FakeConnection()
+    note = ToolNotification(id="c1", tool_name="dance", is_idle_tool_call=False, status=ToolState.FAILED, error="boom")
+
+    await handler._handle_tool_result(note)
+
+    assert {"role": "assistant", "content": json.dumps({"error": "boom"})} in _messages(_drain(handler))
+    assert not handler._pending_responses.empty()
+    handler.connection.conversation.item.create.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_result_no_connection_is_dropped() -> None:
+    """With no connection the tool result is dropped without enqueuing anything."""
+    handler = _plain_handler()
+    handler.connection = None
+    note = ToolNotification(
+        id="c1", tool_name="dance", is_idle_tool_call=False, status=ToolState.COMPLETED, result={"ok": 1}
+    )
+
+    await handler._handle_tool_result(note)
+
+    assert handler.output_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_result_missing_result_reports_error() -> None:
+    """A tool that returns neither result nor error is reported as a failure."""
+    handler = _plain_handler()
+    handler.connection = _FakeConnection()
+    note = ToolNotification(id="c1", tool_name="dance", is_idle_tool_call=False, status=ToolState.COMPLETED)
+
+    await handler._handle_tool_result(note)
+
+    expected = json.dumps({"error": "No result returned from tool execution"})
+    assert {"role": "assistant", "content": expected} in _messages(_drain(handler))
+
+
+@pytest.mark.asyncio
+async def test_wait_for_response_done_returns_true_when_set() -> None:
+    """The tool-result gate passes immediately when no response is active."""
+    handler = _plain_handler()
+    handler._response_done_event.set()
+    assert await handler._wait_for_response_done_before_tool_result() is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_response_done_times_out(monkeypatch: Any) -> None:
+    """The tool-result gate fails when the active response never finishes."""
+    monkeypatch.setattr(hf_mod, "_RESPONSE_DONE_TIMEOUT", 0.01)
+    handler = _plain_handler()
+    handler._response_done_event.clear()
+    assert await handler._wait_for_response_done_before_tool_result() is False
+
+
+@pytest.mark.asyncio
+async def test_emit_debounced_partial_emits_current_snapshot() -> None:
+    """A partial transcript is emitted when it is still the latest snapshot."""
+    handler = _plain_handler()
+    handler.partial_debounce_delay = 0
+    handler.input_transcript_chunks_by_item.item_id = "item-1"
+    handler.input_transcript_chunks_by_item.deltas = ["hi"]
+
+    await handler._emit_debounced_partial("hi", "item-1", 0)
+
+    assert {"role": "user_partial", "content": "hi"} in _messages(_drain(handler))
+
+
+@pytest.mark.asyncio
+async def test_emit_debounced_partial_skips_stale_snapshot() -> None:
+    """A partial transcript is dropped once a newer delta has arrived."""
+    handler = _plain_handler()
+    handler.partial_debounce_delay = 0
+    handler.input_transcript_chunks_by_item.item_id = "item-1"
+    handler.input_transcript_chunks_by_item.deltas = ["hi", "hi there"]
+
+    await handler._emit_debounced_partial("hi", "item-1", 0)
+
+    assert handler.output_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_emit_runs_idle_behavior_when_due(monkeypatch: Any) -> None:
+    """Emit runs the idle behavior once the idle thresholds are exceeded and the robot is idle."""
+    handler = _plain_handler()
+    handler.last_activity_time = time.monotonic() - (handler.IDLE_BEHAVIOR_THRESHOLD_S + 10.0)
+    handler.last_idle_behavior_time = handler.last_activity_time
+    handler.deps.movement_manager.is_idle.return_value = True
+    handler._response_done_event.set()
+    send_idle_signal = AsyncMock()
+    monkeypatch.setattr(handler, "send_idle_signal", send_idle_signal)
+    monkeypatch.setattr(conv_mod, "wait_for_item", AsyncMock(return_value=None))
+
+    before = time.monotonic()
+    await handler.emit()
+
+    send_idle_signal.assert_awaited_once()
+    assert handler.last_idle_behavior_time >= before
+
+
+@pytest.mark.asyncio
+async def test_emit_keeps_idle_timer_when_idle_behavior_fails(monkeypatch: Any) -> None:
+    """A failing idle behavior returns None and does not advance the idle-behavior timer."""
+    handler = _plain_handler()
+    handler.last_activity_time = time.monotonic() - (handler.IDLE_BEHAVIOR_THRESHOLD_S + 10.0)
+    handler.last_idle_behavior_time = handler.last_activity_time
+    handler.deps.movement_manager.is_idle.return_value = True
+    handler._response_done_event.set()
+    monkeypatch.setattr(handler, "send_idle_signal", AsyncMock(side_effect=RuntimeError("closed")))
+
+    previous = handler.last_idle_behavior_time
+    result = await handler.emit()
+
+    assert result is None
+    assert handler.last_idle_behavior_time == previous
+
+
+def test_mark_activity_swallows_observer_errors() -> None:
+    """The activity observer is notified, and a raising observer is ignored."""
+    handler = _plain_handler()
+    seen: list[str] = []
+    handler.set_activity_observer(seen.append)
+    handler._mark_activity("user_speech_started")
+    assert seen == ["user_speech_started"]
+
+    def _raise(_reason: str) -> None:
+        raise RuntimeError("observer boom")
+
+    handler.set_activity_observer(_raise)
+    handler._mark_activity("later")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_send_idle_signal_noop_without_connection(monkeypatch: Any) -> None:
+    """No idle tool runs when there is no active connection."""
+    handler = _plain_handler()
+    handler.connection = None
+    start_idle = AsyncMock()
+    monkeypatch.setattr(conv_mod, "start_idle_tool_call", start_idle)
+
+    await handler.send_idle_signal(200.0)
+
+    start_idle.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_idle_signal_dispatches_idle_tool(monkeypatch: Any) -> None:
+    """With an active connection the locally selected idle tool is dispatched."""
+    handler = _plain_handler()
+    handler.connection = _FakeConnection()
+    monkeypatch.setattr(conv_mod, "get_tool_specs", lambda: [{"name": "dance"}])
+    start_idle = AsyncMock()
+    monkeypatch.setattr(conv_mod, "start_idle_tool_call", start_idle)
+
+    await handler.send_idle_signal(200.0)
+
+    start_idle.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_receive_without_connection_is_dropped() -> None:
+    """A frame received before the connection opens is dropped."""
+    handler = _plain_handler()
+    handler.connection = None
+    await handler.receive((16000, np.zeros(4, dtype=np.int16)))  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_receive_ignores_empty_frame() -> None:
+    """An empty audio frame is not forwarded to the realtime buffer."""
+    handler = _plain_handler()
+    append = AsyncMock()
+    handler.connection = SimpleNamespace(input_audio_buffer=SimpleNamespace(append=append))
+    await handler.receive((16000, np.array([], dtype=np.int16)))
+    append.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_receive_downmixes_stereo_and_forwards() -> None:
+    """A stereo frame is reduced to mono and appended to the realtime buffer."""
+    handler = _plain_handler()
+    append = AsyncMock()
+    handler.connection = SimpleNamespace(input_audio_buffer=SimpleNamespace(append=append))
+    stereo = np.array([[1, 10], [2, 20], [3, 30], [4, 40]], dtype=np.int16)
+    await handler.receive((16000, stereo))
+    append.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_session_speech_started_clears_queue_and_listens(monkeypatch: Any) -> None:
+    """User speech start clears the playback queue and enters listening mode."""
+    handler = _session_handler(monkeypatch, (_FakeEvent("input_audio_buffer.speech_started"),))
+    clear_queue = MagicMock()
+    handler._clear_queue = clear_queue
+
+    await handler._run_realtime_session()
+
+    clear_queue.assert_called_once()
+    handler.deps.movement_manager.set_listening.assert_any_call(True)
+
+
+@pytest.mark.asyncio
+async def test_run_session_response_lifecycle_toggles_done_event(monkeypatch: Any) -> None:
+    """response.created clears the done gate and response.done sets it again."""
+    handler = _session_handler(
+        monkeypatch,
+        (_FakeEvent("response.created"), _FakeEvent("response.done")),
+    )
+
+    await handler._run_realtime_session()
+
+    assert handler._response_done_event.is_set()
+    handler.deps.movement_manager.set_speaking.assert_any_call(True)
+    handler.deps.movement_manager.set_speaking.assert_any_call(False)

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -8,8 +8,13 @@ import pytest
 
 from reachy_mini.utils import create_head_pose
 from reachy_mini.utils.interpolation import compose_world_offset
-from reachy_mini_conversation_app.moves import MovementManager
-from reachy_mini_conversation_app.dance_emotion_moves import EmotionQueueMove
+from reachy_mini_conversation_app.moves import (
+    BreathingMove,
+    MovementManager,
+    LoopFrequencyStats,
+    clone_full_body_pose,
+)
+from reachy_mini_conversation_app.dance_emotion_moves import GotoQueueMove, EmotionQueueMove
 
 
 class _FakeMove:
@@ -109,3 +114,76 @@ def test_speaking_anchor_composes_emotions_and_holds_dances_from_neutral() -> No
     manager.state.move_start_time = manager._now()
     head, _, _ = manager._get_primary_pose(manager._now())
     assert np.allclose(head, dance_head)
+
+
+def test_clone_full_body_pose_is_a_deep_copy() -> None:
+    """Cloning a pose must not alias the head-pose array of the original."""
+    head = create_head_pose(0, 0, 0, 0, 0, 0, degrees=True)
+    original = (head, (1.0, 2.0), 3.0)
+    clone = clone_full_body_pose(original)
+    head[0, 0] = 999.0
+    assert clone[0][0, 0] != 999.0
+    assert clone[1] == (1.0, 2.0)
+    assert clone[2] == 3.0
+
+
+def test_loop_frequency_stats_reset_keeps_last_potential() -> None:
+    """Reset clears accumulators but preserves last/potential frequency."""
+    stats = LoopFrequencyStats(mean=5.0, m2=2.0, min_freq=1.0, count=10, last_freq=59.0, potential_freq=61.0)
+    stats.reset()
+    assert stats.mean == 0.0
+    assert stats.m2 == 0.0
+    assert stats.count == 0
+    assert stats.min_freq == float("inf")
+    assert stats.last_freq == 59.0
+    assert stats.potential_freq == 61.0
+
+
+def test_breathing_move_interpolates_then_breathes() -> None:
+    """Phase 1 starts at the given antennas; phase 2 keeps body yaw neutral."""
+    move = BreathingMove(
+        interpolation_start_pose=create_head_pose(0, 0, 0, 0, 0, 0, degrees=True),
+        interpolation_start_antennas=(0.3, -0.3),
+        interpolation_duration=1.0,
+    )
+    head_start, antennas_start, body_yaw_start = move.evaluate(0.0)
+    assert head_start is not None
+    np.testing.assert_allclose(antennas_start, [0.3, -0.3])
+    assert body_yaw_start == 0.0
+
+    head_breathe, antennas_breathe, body_yaw_breathe = move.evaluate(5.0)
+    assert head_breathe is not None
+    assert antennas_breathe is not None and antennas_breathe.shape == (2,)
+    assert body_yaw_breathe == 0.0
+
+
+def test_is_idle_reflects_listening_and_activity() -> None:
+    """is_idle is False while listening and True once past the inactivity delay."""
+    manager = MovementManager(MagicMock())
+
+    manager._shared_is_listening = True
+    assert manager.is_idle() is False
+
+    manager._shared_is_listening = False
+    manager._shared_last_activity_time = manager._now()
+    assert manager.is_idle() is False
+
+    manager._shared_last_activity_time = manager._now() - 10.0
+    assert manager.is_idle() is True
+
+
+def test_handle_command_queue_and_clear() -> None:
+    """queue_move appends real moves, ignores bad payloads, and clear empties the queue."""
+    manager = MovementManager(MagicMock())
+    now = manager._now()
+    move = GotoQueueMove(target_head_pose=create_head_pose(0, 0, 0, 0, 0, 0, degrees=True))
+
+    manager._handle_command("queue_move", move, now)
+    assert list(manager.move_queue) == [move]
+
+    manager._handle_command("queue_move", "not-a-move", now)
+    assert list(manager.move_queue) == [move]
+
+    manager._handle_command("clear_queue", None, now)
+    assert len(manager.move_queue) == 0
+    assert manager.state.current_move is None

--- a/tests/test_personality_routes.py
+++ b/tests/test_personality_routes.py
@@ -1,0 +1,198 @@
+"""Route-level coverage for personality/voice endpoints not exercised elsewhere.
+
+`test_personality_delete.py` covers the delete guards and `test_console.py` the
+apply/voice happy paths; this pins down save, the error branches of apply/apply
+voice, the current-voice fallback, and the non-default load path.
+"""
+
+import asyncio
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import reachy_mini_conversation_app.personality as personality_mod
+import reachy_mini_conversation_app.personality_routes as routes_mod
+from reachy_mini_conversation_app.config import config, get_default_voice
+from reachy_mini_conversation_app.personality_routes import mount_personality_routes
+
+
+def _client(handler: object | None = None, get_loop=lambda: None, **kwargs) -> TestClient:
+    app = FastAPI()
+    mount_personality_routes(app, handler=handler or MagicMock(), get_loop=get_loop, **kwargs)
+    return TestClient(app)
+
+
+@pytest.fixture
+def running_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """Provide an event loop running in a background thread, for run_coroutine_threadsafe routes."""
+    loop = asyncio.new_event_loop()
+    started = threading.Event()
+
+    def _run() -> None:
+        asyncio.set_event_loop(loop)
+        started.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    started.wait(timeout=1.0)
+    try:
+        yield loop
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=1.0)
+        loop.close()
+
+
+def test_save_writes_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Saving a valid profile writes it under the user root and returns its selection value."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+
+    resp = _client().post(
+        "/personalities/save",
+        json={"name": "Chatty Bot", "instructions": "Be brief.", "tools_text": "", "voice": get_default_voice()},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["value"] == "user_personalities/Chatty_Bot"
+    assert (tmp_path / "user_personalities" / "Chatty_Bot").is_dir()
+
+
+def test_save_rejects_invalid_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A name that sanitizes to empty is rejected with 400."""
+    resp = _client().post("/personalities/save", json={"name": "***", "instructions": "x"})
+
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_name"
+
+
+def test_save_reports_write_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure while writing the profile is surfaced as a 500."""
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(routes_mod, "_write_profile", _boom)
+
+    resp = _client().post("/personalities/save", json={"name": "ok_name", "instructions": "x"})
+
+    assert resp.status_code == 500
+    assert "disk full" in resp.json()["error"]
+
+
+def test_current_voice_uses_callback() -> None:
+    """The current-voice endpoint returns the backend voice."""
+    resp = _client(get_current_voice=lambda: "Serena").get("/voices/current")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"voice": "Serena"}
+
+
+def test_current_voice_falls_back_on_error() -> None:
+    """A failing voice lookup falls back to the default voice."""
+
+    def _boom() -> str:
+        raise RuntimeError("backend down")
+
+    resp = _client(get_current_voice=_boom).get("/voices/current")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"voice": get_default_voice()}
+
+
+def test_apply_rejects_locked_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a profile is locked, apply is refused with 403."""
+    monkeypatch.setattr(routes_mod, "LOCKED_PROFILE", "user_personalities/locked")
+
+    resp = _client().post("/personalities/apply", json={"name": "user_personalities/other"})
+
+    assert resp.status_code == 403
+    assert resp.json()["error"] == "profile_locked"
+
+
+def test_apply_returns_503_without_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Applying a different profile without a running loop returns 503."""
+    monkeypatch.setattr(routes_mod, "LOCKED_PROFILE", None)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
+    resp = _client(get_loop=lambda: None).post("/personalities/apply", json={"name": "user_personalities/other"})
+
+    assert resp.status_code == 503
+    assert resp.json()["error"] == "loop_unavailable"
+
+
+def test_apply_reports_backend_failure(
+    monkeypatch: pytest.MonkeyPatch, running_loop: asyncio.AbstractEventLoop
+) -> None:
+    """A backend apply that raises is surfaced as a 500."""
+    monkeypatch.setattr(routes_mod, "LOCKED_PROFILE", None)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
+    async def _boom(_profile: str | None) -> str:
+        raise RuntimeError("apply failed")
+
+    resp = _client(get_loop=lambda: running_loop, apply_personality=_boom).post(
+        "/personalities/apply", json={"name": "user_personalities/other"}
+    )
+
+    assert resp.status_code == 500
+    assert "apply failed" in resp.json()["error"]
+
+
+def test_apply_voice_requires_a_voice(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A voice-apply request with no voice is rejected with 400."""
+    resp = _client().post("/voices/apply", json={})
+
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "missing_voice"
+
+
+def test_apply_voice_returns_503_without_loop() -> None:
+    """A voice-apply request without a running loop returns 503."""
+    resp = _client(get_loop=lambda: None).post("/voices/apply?voice=Serena")
+
+    assert resp.status_code == 503
+    assert resp.json()["error"] == "loop_unavailable"
+
+
+def test_apply_voice_uses_json_body(running_loop: asyncio.AbstractEventLoop) -> None:
+    """A voice supplied in the JSON body (not the query) is applied."""
+    change_voice = AsyncMock(return_value="Voice changed to Serena.")
+
+    resp = _client(get_loop=lambda: running_loop, change_voice=change_voice).post(
+        "/voices/apply", json={"voice": "Serena"}
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "status": "Voice changed to Serena."}
+    change_voice.assert_awaited_once_with("Serena")
+
+
+def test_voices_uses_running_loop(running_loop: asyncio.AbstractEventLoop) -> None:
+    """The voices endpoint resolves through the running loop when one is available."""
+    get_voices = AsyncMock(return_value=["Serena", "Aiden"])
+
+    resp = _client(get_loop=lambda: running_loop, get_voices=get_voices).get("/voices")
+
+    assert resp.status_code == 200
+    assert resp.json() == ["Serena", "Aiden"]
+
+
+def test_load_reads_profile_voice(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loading a user profile with a saved voice reports that voice, not the default."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+    personality_mod._write_profile("voiced", "Be brief.", "", "Serena")
+
+    resp = _client().get("/personalities/load", params={"name": "user_personalities/voiced"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["voice"] == "Serena"
+    assert body["uses_default_voice"] is False

--- a/tests/tools/test_dance.py
+++ b/tests/tools/test_dance.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools import dance as dance_module
+from reachy_mini_conversation_app.tools.dance import Dance, get_available_dances_and_descriptions
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+
+
+class _FakeDanceQueueMove:
+    def __init__(self, move_name: str) -> None:
+        self.move_name = move_name
+
+
+def _install_moves(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dance_module, "DANCE_AVAILABLE", True)
+    monkeypatch.setattr(dance_module, "AVAILABLE_MOVES", {"wave": (None, None, {"description": "waves"})})
+    monkeypatch.setattr(dance_module, "DanceQueueMove", _FakeDanceQueueMove)
+
+
+def _deps() -> ToolDependencies:
+    return ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+
+
+def test_descriptions_lists_available_moves(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The formatter renders each move name with its description."""
+    _install_moves(monkeypatch)
+    assert get_available_dances_and_descriptions() == "wave: waves\n"
+
+
+def test_descriptions_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The formatter degrades gracefully when the dance library is missing."""
+    monkeypatch.setattr(dance_module, "DANCE_AVAILABLE", False)
+    assert get_available_dances_and_descriptions() == "Moves not available."
+
+
+@pytest.mark.asyncio
+async def test_dance_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tool errors cleanly when the dance system is unavailable."""
+    monkeypatch.setattr(dance_module, "DANCE_AVAILABLE", False)
+    result = await Dance()(_deps())
+    assert result == {"error": "Dance system not available"}
+
+
+@pytest.mark.asyncio
+async def test_dance_unknown_move(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unknown move name is rejected."""
+    _install_moves(monkeypatch)
+    result = await Dance()(_deps(), move="moonwalk")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_dance_queues_named_move_with_repeat(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A named move is queued once per repeat."""
+    _install_moves(monkeypatch)
+    deps = _deps()
+    result = await Dance()(deps, move="wave", repeat=3)
+    assert result == {"status": "queued", "move": "wave", "repeat": 3}
+    assert deps.movement_manager.queue_move.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_dance_picks_random_when_no_move(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitting a move name selects one at random."""
+    _install_moves(monkeypatch)
+    monkeypatch.setattr(dance_module.random, "choice", lambda moves: "wave")
+    deps = _deps()
+    result = await Dance()(deps)
+    assert result["move"] == "wave"

--- a/tests/tools/test_forget.py
+++ b/tests/tools/test_forget.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools import forget as forget_module
+from reachy_mini_conversation_app.memory import MemoryFact, ForgetMemoryResult
+from reachy_mini_conversation_app.tools.forget import Forget
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+
+
+def _deps() -> ToolDependencies:
+    return ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+
+
+def _fact(text: str, fact_id: str = "1") -> MemoryFact:
+    return MemoryFact(id=fact_id, text=text, created_at=0)
+
+
+@pytest.mark.asyncio
+async def test_forget_rejects_empty_query() -> None:
+    """A blank query is rejected before touching the store."""
+    result = await Forget()(_deps(), query="  ")
+    assert result == {"error": "query must be a non-empty string"}
+
+
+@pytest.mark.asyncio
+async def test_forget_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When nothing matches the query the tool reports it without removing anything."""
+    monkeypatch.setattr(
+        forget_module, "forget_memory_fact", lambda path, query: ForgetMemoryResult(removed=None, candidates=())
+    )
+    result = await Forget()(_deps(), query="pizza")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_forget_removes_and_lists_other_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful removal returns the removed fact and any other matches."""
+    removed = _fact("likes pizza", "a")
+    other = _fact("likes pizza too", "b")
+    monkeypatch.setattr(
+        forget_module,
+        "forget_memory_fact",
+        lambda path, query: ForgetMemoryResult(removed=removed, candidates=(removed, other)),
+    )
+    result = await Forget()(_deps(), query="pizza")
+    assert result["removed"] == "likes pizza"
+    assert result["memory_id"] == "a"
+    assert result["other_matches"] == ["likes pizza too"]

--- a/tests/tools/test_idle_do_nothing.py
+++ b/tests/tools/test_idle_do_nothing.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.idle_do_nothing import IdleDoNothing
+
+
+def _deps() -> ToolDependencies:
+    return ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_idle_do_nothing_default_reason() -> None:
+    """Without a reason the tool reports the default idle turn."""
+    result = await IdleDoNothing()(_deps())
+    assert result == {"status": "idle", "reason": "idle turn"}
+
+
+@pytest.mark.asyncio
+async def test_idle_do_nothing_custom_reason() -> None:
+    """A provided reason is echoed back."""
+    result = await IdleDoNothing()(_deps(), reason="user is thinking")
+    assert result == {"status": "idle", "reason": "user is thinking"}

--- a/tests/tools/test_move_head.py
+++ b/tests/tools/test_move_head.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools.move_head import MoveHead
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.dance_emotion_moves import GotoQueueMove
+
+
+def _deps() -> ToolDependencies:
+    reachy_mini = MagicMock()
+    reachy_mini.get_current_joint_positions.return_value = (0.0, (0.1, 0.2))
+    return ToolDependencies(reachy_mini=reachy_mini, movement_manager=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_move_head_rejects_non_string_direction() -> None:
+    """A non-string direction is rejected without touching the robot."""
+    result = await MoveHead()(_deps(), direction=42)
+    assert result == {"error": "direction must be a string"}
+
+
+@pytest.mark.asyncio
+async def test_move_head_queues_goto_move() -> None:
+    """A valid direction queues a GotoQueueMove and marks the robot moving."""
+    deps = _deps()
+    result = await MoveHead()(deps, direction="left")
+    assert result == {"status": "looking left"}
+    queued_move = deps.movement_manager.queue_move.call_args.args[0]
+    assert isinstance(queued_move, GotoQueueMove)
+    deps.movement_manager.set_moving_state.assert_called_once_with(deps.motion_duration_s)
+
+
+@pytest.mark.asyncio
+async def test_move_head_reports_robot_failure() -> None:
+    """A robot read failure is returned as an error, not raised into the loop."""
+    deps = _deps()
+    deps.reachy_mini.get_current_head_pose.side_effect = RuntimeError("boom")
+    result = await MoveHead()(deps, direction="up")
+    assert "error" in result
+    assert "RuntimeError" in result["error"]

--- a/tests/tools/test_stop_dance.py
+++ b/tests/tools/test_stop_dance.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.stop_dance import StopDance
+
+
+@pytest.mark.asyncio
+async def test_stop_dance_clears_queue() -> None:
+    """Stopping a dance clears the movement queue and reports it."""
+    movement_manager = MagicMock()
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=movement_manager)
+    result = await StopDance()(deps)
+    assert result == {"status": "stopped dance and cleared queue"}
+    movement_manager.clear_move_queue.assert_called_once_with()

--- a/tests/tools/test_stop_emotion.py
+++ b/tests/tools/test_stop_emotion.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.stop_emotion import StopEmotion
+
+
+@pytest.mark.asyncio
+async def test_stop_emotion_clears_queue() -> None:
+    """Stopping an emotion clears the movement queue and reports it."""
+    movement_manager = MagicMock()
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=movement_manager)
+    result = await StopEmotion()(deps)
+    assert result == {"status": "stopped emotion and cleared queue"}
+    movement_manager.clear_move_queue.assert_called_once_with()

--- a/tests/tools/test_task_cancel.py
+++ b/tests/tools/test_task_cancel.py
@@ -1,0 +1,71 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.task_cancel import TaskCancel
+from reachy_mini_conversation_app.tools.tool_constants import ToolState
+from reachy_mini_conversation_app.tools.background_tool_manager import BackgroundTool
+
+
+def _deps() -> ToolDependencies:
+    return ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+
+
+def _tool(status: ToolState = ToolState.RUNNING) -> BackgroundTool:
+    return BackgroundTool(id="1", tool_name="long_job", is_idle_tool_call=False, status=status)
+
+
+@pytest.mark.asyncio
+async def test_task_cancel_requires_tool_manager() -> None:
+    """Without an injected tool manager the tool reports an error."""
+    result = await TaskCancel()(_deps(), tool_id="x")
+    assert result == {"error": "Tool manager is required."}
+
+
+@pytest.mark.asyncio
+async def test_task_cancel_requires_tool_id() -> None:
+    """An empty tool id is rejected."""
+    result = await TaskCancel()(_deps(), tool_id="", tool_manager=MagicMock())
+    assert result == {"error": "Tool ID is required."}
+
+
+@pytest.mark.asyncio
+async def test_task_cancel_unknown_tool() -> None:
+    """Cancelling a missing tool returns a not-found error."""
+    manager = MagicMock()
+    manager.get_tool.return_value = None
+    result = await TaskCancel()(_deps(), tool_id="nope", tool_manager=manager)
+    assert result == {"error": "Tool nope not found."}
+
+
+@pytest.mark.asyncio
+async def test_task_cancel_not_running() -> None:
+    """A tool that already finished is reported, not cancelled."""
+    manager = MagicMock()
+    manager.get_tool.return_value = _tool(ToolState.COMPLETED)
+    manager.cancel_tool = AsyncMock()
+    result = await TaskCancel()(_deps(), tool_id="1", tool_manager=manager)
+    assert result["status"] == "completed"
+    manager.cancel_tool.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_task_cancel_success() -> None:
+    """A running tool that cancels cleanly returns cancelled status."""
+    manager = MagicMock()
+    manager.get_tool.return_value = _tool(ToolState.RUNNING)
+    manager.cancel_tool = AsyncMock(return_value=True)
+    result = await TaskCancel()(_deps(), tool_id="1", tool_manager=manager)
+    assert result["status"] == "cancelled"
+    manager.cancel_tool.assert_awaited_once_with("1")
+
+
+@pytest.mark.asyncio
+async def test_task_cancel_failure() -> None:
+    """A running tool that fails to cancel returns an error."""
+    manager = MagicMock()
+    manager.get_tool.return_value = _tool(ToolState.RUNNING)
+    manager.cancel_tool = AsyncMock(return_value=False)
+    result = await TaskCancel()(_deps(), tool_id="1", tool_manager=manager)
+    assert "error" in result

--- a/tests/tools/test_task_status.py
+++ b/tests/tools/test_task_status.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.tools.task_status import TaskStatus
+from reachy_mini_conversation_app.tools.tool_constants import ToolState
+from reachy_mini_conversation_app.tools.background_tool_manager import ToolProgress, BackgroundTool
+
+
+def _deps() -> ToolDependencies:
+    return ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+
+
+def _tool(name: str = "long_job", status: ToolState = ToolState.RUNNING, **kwargs: object) -> BackgroundTool:
+    return BackgroundTool(id="1", tool_name=name, is_idle_tool_call=False, status=status, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_task_status_requires_tool_manager() -> None:
+    """Without an injected tool manager the tool reports an error instead of crashing."""
+    result = await TaskStatus()(_deps())
+    assert result == {"error": "Tool manager is required."}
+
+
+@pytest.mark.asyncio
+async def test_task_status_unknown_tool_id() -> None:
+    """Querying a missing tool id returns a not-found error."""
+    manager = MagicMock()
+    manager.get_tool.return_value = None
+    result = await TaskStatus()(_deps(), tool_id="nope", tool_manager=manager)
+    assert result == {"error": "Tool nope not found."}
+
+
+@pytest.mark.asyncio
+async def test_task_status_single_tool_formats_progress_and_result() -> None:
+    """A specific tool query surfaces progress percent, message and result."""
+    tool = _tool(progress=ToolProgress(progress=0.25, message="working"), result={"ok": True})
+    manager = MagicMock()
+    manager.get_tool.return_value = tool
+    result = await TaskStatus()(_deps(), tool_id=tool.tool_id, tool_manager=manager)
+    assert result["name"] == "long_job"
+    assert result["status"] == "running"
+    assert result["progress_percent"] == "25%"
+    assert result["progress_message"] == "working"
+    assert result["result"] == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_task_status_no_running_tools_is_idle() -> None:
+    """With nothing running the tool reports idle."""
+    manager = MagicMock()
+    manager.get_running_tools.return_value = []
+    result = await TaskStatus()(_deps(), tool_manager=manager)
+    assert result == {"status": "idle", "message": "No tools running in the background."}
+
+
+@pytest.mark.asyncio
+async def test_task_status_lists_running_and_filters_system_tools() -> None:
+    """System tools (task_status/task_cancel) are excluded from the running list."""
+    manager = MagicMock()
+    manager.get_running_tools.return_value = [_tool("long_job"), _tool("task_status")]
+    result = await TaskStatus()(_deps(), tool_manager=manager)
+    assert result["status"] == "running"
+    assert result["count"] == 1
+    assert [tool["name"] for tool in result["tools"]] == ["long_job"]


### PR DESCRIPTION
## Summary
Raise unit-test coverage from **70% to 79%** by testing behavior in previously thin areas. Tests only — no production code changed. Reuses the existing patterns (`ToolDependencies` mocks, the `_FakeEvent`/fake realtime client, FastAPI `TestClient`, the loop-in-a-thread helper); no new dependencies.

Per-module coverage:
- tools `task_status` 24→89%, `task_cancel`/`move_head`/`stop_*`/`idle_do_nothing`/`forget` → 100%, `dance` 51→87%
- `huggingface_realtime` 52→70%, `conversation_handler` 78→99%
- `personality_routes` 61→86%, `app_lifecycle` 74→100%, `console` 68→76%
- `dance_emotion_moves` 41→72%, plus pure movement helpers in `moves.py`

Deliberately left uncovered (hardware/entry glue better suited to integration): `main.run()`, the realtime worker loops (`_response_sender_loop`, `start_up` retry, `_restart_session`, `shutdown`), and the console backend-startup orchestration. The console audio loops mock `robot.media` (the media pipeline itself is the SDK's concern).

## Category
- [x] Other (tests)

## Pre-merge checklist
- [x] CI is green (lint, types, tests — verified locally on Linux; CI confirms macOS/Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (no new config vars)
- [ ] Installation from the desktop app tested (not applicable)

## Notes
Full suite: 334 passing.