### PR TITLE
Add support for configuring custom MCP servers (#434)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ HF_TOKEN=
 
 # Minutes of inactivity before Reachy goes to sleep and the app stops. Default 1440 (one day), 0 disables.
 # REACHY_MINI_APP_TIMEOUT_MINUTES=1440
+
+# Bearer tokens for custom MCP servers configured with 'mcp-servers add --token-env NAME'.
+# The manifest stores only the variable NAME; set its value here (or in the environment,
+# or through the token field in Tools -> MCP servers).
+# MY_SERVER_TOKEN=

--- a/README.md
+++ b/README.md
@@ -361,6 +361,39 @@ Tags are advisory; installation still requires successful MCP validation.
 </details>
 
 <details>
+<summary>Custom MCP server tools</summary>
+
+Any HTTP(S) MCP server can be a tool source, not just Hugging Face Spaces. Tools → MCP servers adds one by alias and endpoint URL; its tools then appear under Tools → Tool access for per-profile selection, exactly like Space tools.
+
+The alias namespaces the server's tools, so a server added as `weather` contributes `weather__get_forecast`. It must be a valid identifier that does not contain `__` or end in `_`, since that would blur the namespace separator. An alias cannot be shared with an installed Space.
+
+```bash
+# add + enable in active profile
+reachy-mini-conversation-app mcp-servers add <alias> <https://example.com/mcp>
+
+# add a server that needs a bearer token, read from an environment variable
+reachy-mini-conversation-app mcp-servers add <alias> <url> --token-env MY_SERVER_TOKEN
+
+# add without enabling, or enable in a specific profile
+reachy-mini-conversation-app mcp-servers add <alias> <url> --install-only
+reachy-mini-conversation-app mcp-servers add <alias> <url> --profile NAME
+
+# list configured servers, and remove one
+reachy-mini-conversation-app mcp-servers list
+reachy-mini-conversation-app mcp-servers remove <alias>
+```
+
+Re-running `add` for a configured alias refreshes its cached tools and keeps stored options that are not repeated.
+
+**Tokens are never written to the manifest.** `--token-env` records only the *name* of the environment variable; the value is read from the environment when a client is built. Set it in the instance `.env`, in the environment, or through the token field the UI shows for servers that declare one. A server whose token is missing has its tools skipped with a warning rather than registered as guaranteed-to-fail.
+
+Endpoints must be HTTPS, except on the local network — loopback, private, and link-local addresses plus `*.local` names may use plain HTTP. Sending a bearer token over plain HTTP to anything but loopback additionally requires `--allow-insecure-token`, because the token is then visible to everyone on the network.
+
+Tool metadata is cached in `mcp_servers.json`, beside `installed_tool_spaces.json` (the managed app instance directory, or `external_content/` in terminal mode). Startup reads that cache with no network access; discovery happens only on add or refresh.
+
+</details>
+
+<details>
 <summary>Multiple robots on the same subnet</summary>
 
 If you run multiple Reachy Mini daemons on the same network, use:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,14 @@ dependencies = [
     #Reachy mini
     "reachy_mini_dances_library",
     "reachy-mini>=1.10.0rc2",
-    "mcp>=1.27.1",
+    # MCP v2 (2026-07-28 spec). The v1 client exposed the wire's camelCase field
+    # names; v2 exposes snake_case attributes with camelCase aliases, so an
+    # unpinned "mcp>=1.x" floor silently reads empty tool schemas once it
+    # resolves to 2.x. mcp exact-pins mcp-types, so both move in lockstep.
+    "mcp==2.0.0",
+    "mcp-types==2.0.0",
+    # The transport the v2 SDK is built on; plain httpx stays for the HF backend.
+    "httpx2>=2.5.0",
 ]
 
 [dependency-groups]

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -8,7 +8,7 @@ import os
 import time
 import asyncio
 import logging
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 from pathlib import Path
 from collections.abc import Callable
 
@@ -41,6 +41,7 @@ from reachy_mini_conversation_app.prompts import get_session_voice, get_session_
 from reachy_mini_conversation_app.streaming import AdditionalOutputs, audio_to_float32
 from reachy_mini_conversation_app.startup_settings import read_startup_settings, write_startup_settings
 from reachy_mini_conversation_app.tools.core_tools import initialize_tools
+from reachy_mini_conversation_app.mcp_server_routes import register_mcp_server_methods
 from reachy_mini_conversation_app.tool_space_routes import register_tool_space_methods
 from reachy_mini_conversation_app.personality_routes import (
     build_personality_ops,
@@ -64,6 +65,23 @@ except Exception:  # pragma: no cover - only loaded when settings_app is used
     BaseModel = object  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+# Unquoted, these make python-dotenv return a different value than was written:
+# `#` starts an inline comment, quotes are stripped, and backslash/whitespace
+# parsing varies. Quoting keeps the value literal — except `${VAR}`, which
+# python-dotenv interpolates in any quoting style, so those values are refused
+# in `_persist_env_values` instead. Not dotenv.set_key: it escapes quotes but
+# not backslashes, so values containing `\\` do not round-trip.
+_ENV_VALUE_CHARS_NEEDING_QUOTES = " \t#'\"$\\"
+
+
+def _format_env_line(name: str, value: str) -> str:
+    """Format a `.env` line so the value round-trips through python-dotenv unchanged."""
+    if any(char in value for char in _ENV_VALUE_CHARS_NEEDING_QUOTES):
+        escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+        return f"{name}='{escaped}'"
+    return f"{name}={value}"
 
 
 def _detach_framework_root_routes(app: "FastAPI") -> None:
@@ -336,12 +354,25 @@ class LocalStream:
             "backend_error": None if connected else self._backend_error,
         }
 
-    def _persist_env_values(self, updates: dict[str, str]) -> None:
-        """Persist non-empty environment values in memory and in the instance `.env`."""
+    def _persist_env_values(self, updates: dict[str, str]) -> Literal["persisted", "session", "failed"]:
+        """Apply non-empty environment values to the runtime and the instance `.env`.
+
+        Raises ValueError before anything is applied if a value cannot round-trip
+        through the `.env`: line breaks corrupt the file, and `${` triggers
+        python-dotenv interpolation that has no escape syntax. Returns "persisted"
+        when the `.env` was written, "session" when there is nothing to write to
+        (terminal mode), and "failed" when the `.env` write errored — so callers
+        can warn that the value will not survive a restart.
+        """
         normalized_updates = {name: (value or "").strip() for name, value in updates.items()}
+        unsafe_names = sorted(
+            name for name, value in normalized_updates.items() if "\n" in value or "\r" in value or "${" in value
+        )
+        if unsafe_names:
+            raise ValueError(f"Values must not contain line breaks or '${{': {', '.join(unsafe_names)}.")
         normalized_updates = {name: value for name, value in normalized_updates.items() if value}
         if not normalized_updates:
-            return
+            return "session"
 
         for env_name, value in normalized_updates.items():
             try:
@@ -351,7 +382,7 @@ class LocalStream:
         refresh_runtime_config_from_env()
 
         if not self._instance_path:
-            return
+            return "session"
         try:
             inst = Path(self._instance_path)
             env_path = inst / ".env"
@@ -360,11 +391,11 @@ class LocalStream:
                 replaced = False
                 for i, ln in enumerate(lines):
                     if ln.strip().startswith(f"{env_name}="):
-                        lines[i] = f"{env_name}={value}"
+                        lines[i] = _format_env_line(env_name, value)
                         replaced = True
                         break
                 if not replaced:
-                    lines.append(f"{env_name}={value}")
+                    lines.append(_format_env_line(env_name, value))
             final_text = "\n".join(lines) + "\n"
             env_path.write_text(final_text, encoding="utf-8")
             logger.info("Persisted %s to %s", ", ".join(sorted(normalized_updates)), env_path)
@@ -376,8 +407,10 @@ class LocalStream:
             except Exception:
                 pass
             refresh_runtime_config_from_env()
+            return "persisted"
         except Exception as e:
             logger.warning("Failed to persist %s: %s", ", ".join(sorted(normalized_updates)), e)
+            return "failed"
 
     def _remove_persisted_env_values(self, env_names: tuple[str, ...]) -> None:
         """Remove keys from the instance `.env` without mutating the current runtime."""
@@ -662,6 +695,17 @@ class LocalStream:
             )
         except Exception:
             logger.exception("Failed to register Tool Space methods; remote tool settings will be unavailable")
+
+        try:
+            register_mcp_server_methods(
+                rpc,
+                lambda: self._asyncio_loop,
+                self.request_backend_restart,
+                self._persist_env_values,
+                instance_path=self._instance_path,
+            )
+        except Exception:
+            logger.exception("Failed to register MCP server methods; custom MCP settings will be unavailable")
 
         try:
             register_profile_tool_methods(

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -649,7 +649,12 @@ class LocalStream:
                 port = int(raw_port) if isinstance(raw_port, (int, float, str)) else (existing_port or 8765)
                 if port < 1 or port > 65535:
                     raise JsonRpcError("invalid Hugging Face port", reason="invalid_hf_port", code=-32602)
-                self._persist_hf_direct_connection(host, port)
+                try:
+                    self._persist_hf_direct_connection(host, port)
+                except ValueError as exc:
+                    # A host carrying a line break would otherwise write extra
+                    # lines into the instance `.env`, setting variables nobody asked for.
+                    raise JsonRpcError("invalid Hugging Face host", reason="invalid_hf_host", code=-32602) from exc
             elif hf_mode == HF_DEPLOYED_CONNECTION_MODE:
                 if not bool(get_hf_session_url()):
                     raise JsonRpcError(

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -73,6 +73,15 @@ def main() -> None:
         except Exception as exc:
             logger.error("tool-spaces command failed: %s", exc)
             raise SystemExit(1) from exc
+    if args.command == "mcp-servers":
+        from reachy_mini_conversation_app.mcp_servers import handle_mcp_servers_command
+
+        logger = setup_logger(args.debug)
+        try:
+            raise SystemExit(handle_mcp_servers_command(args))
+        except Exception as exc:
+            logger.error("mcp-servers command failed: %s", exc)
+            raise SystemExit(1) from exc
     run(args)
 
 

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -63,11 +63,18 @@ def _start_inactivity_timeout_thread(
 
 def main() -> None:
     """Entrypoint for the Reachy Mini conversation app."""
-    args, _ = parse_args()
+    args, unknown_args = parse_args()
+    if args.command in ("tool-spaces", "mcp-servers"):
+        logger = setup_logger(args.debug)
+        # The app itself tolerates unknown args (parse_known_args, for launcher
+        # extras), but a typo in a CLI flag like --token-env must not silently
+        # configure a server without the intended auth or opt-in.
+        if unknown_args:
+            logger.error("Unrecognized arguments: %s", " ".join(str(arg) for arg in unknown_args))
+            raise SystemExit(2)
     if args.command == "tool-spaces":
         from reachy_mini_conversation_app.tool_spaces import handle_tool_spaces_command
 
-        logger = setup_logger(args.debug)
         try:
             raise SystemExit(handle_tool_spaces_command(args))
         except Exception as exc:
@@ -76,7 +83,6 @@ def main() -> None:
     if args.command == "mcp-servers":
         from reachy_mini_conversation_app.mcp_servers import handle_mcp_servers_command
 
-        logger = setup_logger(args.debug)
         try:
             raise SystemExit(handle_mcp_servers_command(args))
         except Exception as exc:

--- a/src/reachy_mini_conversation_app/mcp_client.py
+++ b/src/reachy_mini_conversation_app/mcp_client.py
@@ -8,16 +8,15 @@ downloading third-party Python code.
 from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, AsyncIterator
-from datetime import timedelta
 from contextlib import asynccontextmanager
 from dataclasses import field, dataclass
 from urllib.parse import urlparse
 
 
 if TYPE_CHECKING:
-    from mcp import ClientSession
-    from mcp.types import Tool as McpTool
-    from mcp.types import CallToolResult as McpCallToolResult
+    from mcp import Client
+    from mcp_types import Tool as McpTool
+    from mcp_types import CallToolResult as McpCallToolResult
 
 
 _NAME_SEGMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -110,9 +109,21 @@ def _join_text_content(content_blocks: list[dict[str, Any]]) -> str | None:
     return "\n\n".join(text_parts)
 
 
+def _is_timeout_mcp_error(exc: BaseException) -> bool:
+    """Whether this is the SDK's request-timeout error (JSON-RPC -32001)."""
+    try:
+        from mcp import MCPError
+        from mcp_types import REQUEST_TIMEOUT
+    except ImportError:
+        return False
+    return isinstance(exc, MCPError) and getattr(exc, "code", None) == REQUEST_TIMEOUT
+
+
 def _exception_contains_timeout(exc: BaseException) -> bool:
     timeout_exception = _httpx_timeout_exception_type()
     if isinstance(exc, timeout_exception):
+        return True
+    if _is_timeout_mcp_error(exc):
         return True
 
     if "timed out" in str(exc).lower() or "deadline exceeded" in str(exc).lower():
@@ -130,30 +141,30 @@ def _exception_contains_timeout(exc: BaseException) -> bool:
     return any(_exception_contains_timeout(item) for item in nested)
 
 
-def _load_mcp_sdk() -> tuple[type["ClientSession"], Any]:
+def _load_mcp_sdk() -> tuple[type["Client"], Any]:
     try:
-        from mcp import ClientSession
+        from mcp import Client
         from mcp.client.streamable_http import streamable_http_client
     except ImportError as exc:
         raise McpDependencyError(
             "Remote MCP tools require the app's MCP client dependencies. Reinstall or update the app environment."
         ) from exc
-    return ClientSession, streamable_http_client
+    return Client, streamable_http_client
 
 
-def _load_httpx() -> Any:
+def _load_httpx2() -> Any:
     try:
-        import httpx
+        import httpx2
     except ImportError as exc:
         raise McpDependencyError(
             "Remote MCP tools require the app's HTTP client dependencies. Reinstall or update the app environment."
         ) from exc
-    return httpx
+    return httpx2
 
 
 def _httpx_timeout_exception_type() -> tuple[type[BaseException], ...]:
     try:
-        timeout_exception = _load_httpx().TimeoutException
+        timeout_exception = _load_httpx2().TimeoutException
     except McpDependencyError:
         return (TimeoutError,)
     return (TimeoutError, timeout_exception)
@@ -194,7 +205,7 @@ class RemoteToolSpec:
     def from_mcp_tool(cls, server_alias: str, tool: "McpTool") -> "RemoteToolSpec":
         """Build an app-facing spec from an MCP SDK tool descriptor."""
         description = (getattr(tool, "description", None) or "").strip()
-        parameters_schema = getattr(tool, "inputSchema", None)
+        parameters_schema = getattr(tool, "input_schema", None)
         if not isinstance(parameters_schema, dict):
             parameters_schema = {"type": "object", "properties": {}, "required": []}
 
@@ -246,10 +257,10 @@ class RemoteToolCallResponse:
             server_alias=server_alias,
             remote_tool_name=remote_tool_name,
             namespaced_tool_name=build_namespaced_tool_name(server_alias, remote_tool_name),
-            status="error" if bool(getattr(result, "isError", False)) else "ok",
+            status="error" if bool(getattr(result, "is_error", False)) else "ok",
             content_blocks=content_blocks,
             text=_join_text_content(content_blocks),
-            structured_content=getattr(result, "structuredContent", None),
+            structured_content=getattr(result, "structured_content", None),
         )
 
     def to_tool_result(self) -> dict[str, Any]:
@@ -279,8 +290,8 @@ class RemoteMcpToolClient:
     async def list_tool_specs(self) -> list[RemoteToolSpec]:
         """Discover remote tools and translate them into app-facing specs."""
         try:
-            async with self._session() as session:
-                discovered = await self._list_all_tools(session)
+            async with self._connected_client() as client:
+                discovered = await self._list_all_tools(client)
         except McpDependencyError:
             raise
         except Exception as exc:
@@ -302,11 +313,11 @@ class RemoteMcpToolClient:
         timeout_exception = _httpx_timeout_exception_type()
 
         try:
-            async with self._session() as session:
-                result = await session.call_tool(
+            async with self._connected_client() as client:
+                result = await client.call_tool(
                     spec.remote_name,
                     arguments=dict(arguments or {}),
-                    read_timeout_seconds=timedelta(seconds=self.server.tool_timeout_s),
+                    read_timeout_seconds=self.server.tool_timeout_s,
                 )
         except McpDependencyError:
             raise
@@ -340,32 +351,32 @@ class RemoteMcpToolClient:
             raise ValueError(f"Unknown remote MCP tool '{namespaced_tool_name}' for server '{self.server.alias}'.")
         return spec
 
-    async def _list_all_tools(self, session: "ClientSession") -> list["McpTool"]:
+    async def _list_all_tools(self, client: "Client") -> list["McpTool"]:
         tools: list[McpTool] = []
         cursor: str | None = None
         while True:
-            page = await session.list_tools(cursor=cursor)
+            page = await client.list_tools(cursor=cursor)
             tools.extend(page.tools)
-            cursor = getattr(page, "nextCursor", None)
+            cursor = getattr(page, "next_cursor", None)
             if cursor is None:
                 return tools
 
     @asynccontextmanager
-    async def _session(self) -> AsyncIterator["ClientSession"]:
-        client_session_cls, streamable_http_client = _load_mcp_sdk()
-        httpx = _load_httpx()
+    async def _connected_client(self) -> AsyncIterator["Client"]:
+        client_cls, streamable_http_client = _load_mcp_sdk()
+        httpx2 = _load_httpx2()
         client_timeout = max(self.server.request_timeout_s, self.server.tool_timeout_s)
 
-        async with httpx.AsyncClient(
+        async with httpx2.AsyncClient(
             headers=self.server.headers,
             follow_redirects=False,
             timeout=client_timeout,
         ) as http_client:
-            async with streamable_http_client(self.server.url, http_client=http_client) as transport:
-                read_stream, write_stream, _ = transport
-                async with client_session_cls(read_stream, write_stream) as session:
-                    await session.initialize()
-                    yield session
+            transport = streamable_http_client(self.server.url, http_client=http_client)
+            # The default mode='auto' probes `server/discover` and falls back to the
+            # `initialize` handshake, so one client speaks every protocol revision.
+            async with client_cls(transport) as client:
+                yield client
 
 
 def _index_remote_tools(specs: list[RemoteToolSpec]) -> dict[str, RemoteToolSpec]:

--- a/src/reachy_mini_conversation_app/mcp_client.py
+++ b/src/reachy_mini_conversation_app/mcp_client.py
@@ -7,6 +7,7 @@ downloading third-party Python code.
 
 from __future__ import annotations
 import re
+import ipaddress
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import field, dataclass
@@ -52,6 +53,18 @@ def _require_name_segment(label: str, value: str) -> str:
     return candidate
 
 
+def _require_alias_segment(label: str, value: str) -> str:
+    candidate = _require_name_segment(label, value)
+    # '__' separates the alias from the tool segment in namespaced tool names, so an
+    # alias containing '__' or ending in '_' makes prefix matches (e.g. profile
+    # cleanup on remove) claim a sibling alias's tools.
+    if _NAMESPACE_SEPARATOR in candidate or candidate.endswith("_"):
+        raise ValueError(
+            f"Invalid {label} '{value}'. Aliases cannot contain '{_NAMESPACE_SEPARATOR}' or end with '_'."
+        )
+    return candidate
+
+
 def apply_name_normalization(value: str) -> str:
     """Replace non-identifier characters with underscores and collapse runs."""
     normalized = _NAME_NORMALIZER_PATTERN.sub("_", value).strip("_")
@@ -71,6 +84,54 @@ def _normalize_name_segment(label: str, value: str) -> str:
     return _require_name_segment(label, normalized)
 
 
+def _is_loopback_name(host: str) -> bool:
+    """Whether the hostname itself pins to loopback. '*.localhost' subdomains do not count: RFC 6761 pinning is only a SHOULD, so a resolver may send them off-machine."""
+    return host in _LOCAL_HTTP_HOSTS
+
+
+def _parse_host_ip(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Parse a URL host into an IP address, tolerating IPv6 brackets and zone ids."""
+    candidate = host.strip("[]").split("%", 1)[0]
+    try:
+        ip = ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        # Classify by the embedded IPv4 address: before CPython 3.11.10/3.12.4
+        # (CVE-2024-4032) is_private is true for the whole ::ffff:0:0/96 range,
+        # which would let plain HTTP through to mapped *public* addresses.
+        return ip.ipv4_mapped
+    return ip
+
+
+def _is_local_http_host(host: str) -> bool:
+    """Return whether plain HTTP is acceptable for this host (local network only)."""
+    if not host:
+        return False
+    if _is_loopback_name(host):
+        return True
+    if host.endswith((".local", ".localhost")):  # mDNS names, and *.localhost dev hosts
+        return True
+    ip = _parse_host_ip(host)
+    return ip is not None and (ip.is_private or ip.is_loopback or ip.is_link_local)
+
+
+def is_loopback_mcp_url(url: str) -> bool:
+    """Return whether the MCP URL points at a loopback host, where cleartext credentials never leave the machine."""
+    host = (urlparse(url).hostname or "").lower()
+    if not host:
+        return False
+    if _is_loopback_name(host):
+        return True
+    ip = _parse_host_ip(host)
+    return ip is not None and ip.is_loopback
+
+
+def is_plaintext_remote_url(url: str) -> bool:
+    """Return whether the URL sends traffic in cleartext beyond the local machine (plain HTTP to a non-loopback host). Single home of the classification both credential guards rely on."""
+    return url.lower().startswith("http://") and not is_loopback_mcp_url(url)
+
+
 def validate_http_mcp_url(url: str) -> str:
     """Validate that the MCP endpoint uses HTTP(S)."""
     parsed = urlparse(url)
@@ -80,14 +141,17 @@ def validate_http_mcp_url(url: str) -> str:
         raise ValueError(f"Invalid MCP URL '{url}'. Missing host.")
 
     host = (parsed.hostname or "").lower()
-    if parsed.scheme == "http" and host not in _LOCAL_HTTP_HOSTS:
-        raise ValueError("Remote MCP servers must use HTTPS. Plain HTTP is only allowed for localhost.")
+    if parsed.scheme == "http" and not _is_local_http_host(host):
+        raise ValueError(
+            "Remote MCP servers must use HTTPS. Plain HTTP is only allowed for loopback, "
+            "private, or link-local hosts (and *.local mDNS names)."
+        )
     return url
 
 
 def build_namespaced_tool_name(server_alias: str, tool_name: str) -> str:
     """Build a local tool name for a remote MCP tool."""
-    alias = _require_name_segment("server alias", server_alias)
+    alias = _require_alias_segment("server alias", server_alias)
     tool_segment = _normalize_name_segment("tool name", tool_name)
     return f"{alias}{_NAMESPACE_SEPARATOR}{tool_segment}"
 
@@ -179,12 +243,20 @@ class RemoteMcpServerConfig:
     headers: Mapping[str, str] = field(default_factory=dict)
     request_timeout_s: float = 10.0
     tool_timeout_s: float = 30.0
+    # Explicit opt-in to sending credential headers over plain HTTP to a non-loopback host.
+    allow_insecure_http: bool = False
 
     def __post_init__(self) -> None:
         """Validate configuration once the dataclass has been created."""
-        object.__setattr__(self, "alias", _require_name_segment("server alias", self.alias))
+        object.__setattr__(self, "alias", _require_alias_segment("server alias", self.alias))
         object.__setattr__(self, "url", validate_http_mcp_url(self.url))
         object.__setattr__(self, "headers", {str(k): str(v) for k, v in self.headers.items()})
+        has_credentials = any(k.lower() == "authorization" for k in self.headers)
+        if has_credentials and is_plaintext_remote_url(self.url) and not self.allow_insecure_http:
+            raise ValueError(
+                f"MCP server '{self.alias}' would send credentials over plain HTTP ({self.url}), "
+                "exposing them to anyone on the network. Use HTTPS or a loopback address."
+            )
         if self.request_timeout_s <= 0:
             raise ValueError("request_timeout_s must be greater than zero.")
         if self.tool_timeout_s <= 0:

--- a/src/reachy_mini_conversation_app/mcp_server_routes.py
+++ b/src/reachy_mini_conversation_app/mcp_server_routes.py
@@ -1,0 +1,290 @@
+"""JSON-RPC methods for managing custom remote MCP server tools."""
+
+import asyncio
+import logging
+from typing import Any
+from pathlib import Path
+from collections.abc import Callable
+
+from reachy_mini.apps.jsonrpc_server import JsonRpcServer
+from reachy_mini_conversation_app.config import LOCKED_PROFILE, config
+from reachy_mini_conversation_app.mcp_servers import (
+    BEARER_AUTH_TYPE,
+    McpServerAuth,
+    McpServerManifestError,
+    InstalledMcpServersManifest,
+    McpServerAliasConflictError,
+    McpServerNotConfiguredError,
+    McpServerProfileUpdateError,
+    read_mcp_servers,
+    remove_mcp_server,
+    install_mcp_server,
+    find_server_token_env,
+    list_token_requirements,
+)
+from reachy_mini_conversation_app.profile_store import canonical_profile_name
+from reachy_mini_conversation_app.tool_settings import (
+    RestartCallback,
+    apply_tool_change,
+    raise_tool_settings_error,
+)
+from reachy_mini_conversation_app.profile_toolsets import read_profile_tool_names
+
+
+logger = logging.getLogger(__name__)
+
+# Persists env values and reports whether they reached the instance `.env`:
+# "persisted", "session" (nothing to write to), or "failed".
+PersistEnvCallback = Callable[[dict[str, str]], str]
+
+
+def _server_settings_payload(
+    manifest: InstalledMcpServersManifest,
+    token_set_by_alias: dict[str, bool],
+) -> dict[str, object]:
+    return {
+        "servers": [
+            {
+                "alias": server.alias,
+                "url": server.url,
+                "tool_count": len(server.tools),
+                "token_env": server.auth.token_env if server.auth is not None else None,
+                "token_set": token_set_by_alias.get(server.alias, False),
+            }
+            for server in sorted(manifest.servers, key=lambda entry: entry.alias)
+        ],
+        "editable": LOCKED_PROFILE is None,
+    }
+
+
+def _settings_payload(instance_path: str | Path | None) -> dict[str, object]:
+    """Build the settings payload, folding in which servers currently have their token set."""
+    manifest = read_mcp_servers(instance_path)
+    token_set_by_alias = {req.alias: req.token_set for req in list_token_requirements(instance_path)}
+    return _server_settings_payload(manifest, token_set_by_alias)
+
+
+def _error_detail(error: BaseException) -> str:
+    return str(error).strip() or type(error).__name__
+
+
+def _required_string(params: dict[str, Any], key: str, reason: str, message: str) -> str:
+    value = params.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise_tool_settings_error(reason, message)
+    return value.strip()
+
+
+def _optional_float(params: dict[str, Any], key: str) -> float | None:
+    value = params.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise_tool_settings_error("invalid_mcp_timeout", "Timeouts must be a number of seconds greater than zero.")
+    return float(value)
+
+
+def _auth_from_params(params: dict[str, Any]) -> McpServerAuth | None:
+    """Build the auth descriptor from request params, or None when the server needs no token."""
+    token_env = params.get("token_env")
+    if token_env is None or (isinstance(token_env, str) and not token_env.strip()):
+        return None
+    if not isinstance(token_env, str):
+        raise_tool_settings_error("invalid_mcp_token_env", "Enter the name of the environment variable to read.")
+    allow_insecure_http = params.get("allow_insecure_http", False)
+    if not isinstance(allow_insecure_http, bool):
+        raise_tool_settings_error("invalid_mcp_auth", "The insecure-HTTP opt-in must be true or false.")
+    try:
+        return McpServerAuth(
+            type=BEARER_AUTH_TYPE,
+            token_env=token_env.strip(),
+            allow_insecure_http=allow_insecure_http,
+        )
+    except ValueError as exc:
+        raise_tool_settings_error("invalid_mcp_token_env", _error_detail(exc))
+
+
+def register_mcp_server_methods(
+    rpc: JsonRpcServer,
+    get_loop: Callable[[], asyncio.AbstractEventLoop | None],
+    restart_conversation: RestartCallback,
+    persist_env_values: PersistEnvCallback,
+    *,
+    instance_path: str | Path | None,
+) -> None:
+    """Register custom MCP server management methods."""
+
+    async def _list_mcp_servers(_params: dict[str, Any]) -> dict[str, object]:
+        try:
+            return await asyncio.to_thread(_settings_payload, instance_path)
+        except Exception as exc:
+            logger.exception("Failed to list configured MCP servers")
+            raise_tool_settings_error("mcp_servers_unavailable", _error_detail(exc))
+
+    async def _add_mcp_server(params: dict[str, Any]) -> dict[str, object]:
+        if LOCKED_PROFILE is not None:
+            raise_tool_settings_error("profile_locked", "MCP server editing is locked.")
+        alias = _required_string(params, "alias", "invalid_mcp_alias", "Enter a short alias, e.g. my_server.")
+        url = _required_string(params, "url", "invalid_mcp_url", "Enter the server's MCP endpoint URL.")
+        auth = _auth_from_params(params)
+
+        try:
+            result = await asyncio.to_thread(
+                install_mcp_server,
+                alias,
+                url,
+                instance_path,
+                auth=auth,
+                request_timeout_s=_optional_float(params, "request_timeout_s"),
+                tool_timeout_s=_optional_float(params, "tool_timeout_s"),
+                install_only=True,
+            )
+        except McpServerAliasConflictError as exc:
+            logger.warning("MCP server alias conflict: %s", exc)
+            raise_tool_settings_error("mcp_server_alias_conflict", _error_detail(exc))
+        except McpServerManifestError as exc:
+            logger.error("Refusing to rewrite a damaged MCP servers manifest: %s", exc)
+            raise_tool_settings_error("mcp_servers_manifest_damaged", _error_detail(exc))
+        except ValueError as exc:
+            logger.warning("Invalid MCP server configuration %r: %s", alias, exc)
+            raise_tool_settings_error("invalid_mcp_server", _error_detail(exc))
+        except RuntimeError as exc:
+            logger.error("Failed to configure MCP server %r: %s", alias, exc)
+            raise_tool_settings_error("mcp_server_add_failed", _error_detail(exc))
+        except Exception as exc:
+            logger.exception("Unexpected failure configuring MCP server %r", alias)
+            raise_tool_settings_error("mcp_server_add_failed", _error_detail(exc))
+
+        active_profile = canonical_profile_name(config.REACHY_MINI_CUSTOM_PROFILE)
+        try:
+            active_tools = await asyncio.to_thread(read_profile_tool_names, active_profile, instance_path)
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            logger.warning("Configured MCP server but could not inspect active profile %r: %s", active_profile, exc)
+            active_tools = []
+        apply_detail = (
+            await asyncio.to_thread(
+                apply_tool_change,
+                instance_path,
+                get_loop,
+                restart_conversation,
+                "mcp_servers_changed",
+            )
+            if any(tool_name.startswith(f"{result.resolved_server.alias}__") for tool_name in active_tools)
+            else "The server is ready to assign to personalities."
+        )
+
+        action = "Refreshed" if result.refreshed else "Added"
+        tool_count = len(result.resolved_server.tools)
+        tool_label = "tool" if tool_count == 1 else "tools"
+        message = (
+            f"{action} {result.resolved_server.alias} with {tool_count} {tool_label}. "
+            "Choose which personalities can use them in Tool access. "
+            f"{apply_detail}"
+        )
+        return {
+            **await asyncio.to_thread(_settings_payload, instance_path),
+            "message": message,
+        }
+
+    async def _remove_mcp_server(params: dict[str, Any]) -> dict[str, object]:
+        if LOCKED_PROFILE is not None:
+            raise_tool_settings_error("profile_locked", "MCP server editing is locked.")
+        alias = _required_string(params, "alias", "invalid_mcp_alias", "Enter the alias of a configured server.")
+        try:
+            result = await asyncio.to_thread(remove_mcp_server, alias, instance_path)
+            disabled_profiles = result.disabled_profiles
+        except McpServerNotConfiguredError as exc:
+            logger.warning("Cannot remove MCP server %r: %s", alias, exc)
+            raise_tool_settings_error("mcp_server_not_configured", _error_detail(exc))
+        except McpServerProfileUpdateError as exc:
+            logger.error("Failed to disable removed MCP server tools: %s", exc)
+            raise_tool_settings_error("profile_disable_failed", _error_detail(exc))
+        except McpServerManifestError as exc:
+            logger.error("Refusing to rewrite a damaged MCP servers manifest: %s", exc)
+            raise_tool_settings_error("mcp_servers_manifest_damaged", _error_detail(exc))
+        except ValueError as exc:
+            logger.warning("Invalid MCP server alias %r: %s", alias, exc)
+            raise_tool_settings_error("invalid_mcp_alias", _error_detail(exc))
+        except RuntimeError as exc:
+            logger.error("Failed to remove MCP server %r: %s", alias, exc)
+            raise_tool_settings_error("mcp_server_remove_failed", _error_detail(exc))
+        except Exception as exc:
+            logger.exception("Unexpected failure removing MCP server %r", alias)
+            raise_tool_settings_error("mcp_server_remove_failed", _error_detail(exc))
+
+        active_profile = canonical_profile_name(config.REACHY_MINI_CUSTOM_PROFILE)
+        apply_detail = (
+            await asyncio.to_thread(
+                apply_tool_change,
+                instance_path,
+                get_loop,
+                restart_conversation,
+                "mcp_servers_changed",
+            )
+            if any(profile_name == active_profile for profile_name, _ in disabled_profiles)
+            else "No active conversation restart is needed."
+        )
+
+        disabled_tool_count = sum(len(tool_ids) for _, tool_ids in disabled_profiles)
+        tool_label = "tool" if disabled_tool_count == 1 else "tools"
+        message = (
+            f"Removed {result.removed_server.alias}. "
+            f"Disabled {disabled_tool_count} {tool_label} across personalities. {apply_detail}"
+        )
+        return {
+            **await asyncio.to_thread(_settings_payload, instance_path),
+            "message": message,
+        }
+
+    async def _save_mcp_server_token(params: dict[str, Any]) -> dict[str, object]:
+        if LOCKED_PROFILE is not None:
+            raise_tool_settings_error("profile_locked", "MCP server editing is locked.")
+        alias = _required_string(params, "alias", "invalid_mcp_alias", "Enter the alias of a configured server.")
+        token = params.get("token")
+        if not isinstance(token, str) or not token.strip():
+            raise_tool_settings_error("empty_token", "Enter a token first.")
+
+        try:
+            token_env = await asyncio.to_thread(find_server_token_env, instance_path, alias)
+        except RuntimeError as exc:
+            logger.warning("Could not read the MCP servers manifest: %s", exc)
+            raise_tool_settings_error("mcp_servers_unavailable", _error_detail(exc))
+        if token_env is None:
+            raise_tool_settings_error("unknown_mcp_server", "That MCP server is no longer configured.")
+
+        try:
+            persist_state = await asyncio.to_thread(persist_env_values, {token_env: token.strip()})
+        except ValueError as exc:
+            # The value cannot round-trip through the instance `.env`.
+            raise_tool_settings_error("invalid_token", _error_detail(exc))
+        except Exception as exc:
+            logger.exception("Failed to store the token for MCP server %r", alias)
+            raise_tool_settings_error("token_save_failed", _error_detail(exc))
+
+        # The client reads the token when it is built, so tools that were skipped
+        # for a missing token only appear after the registry is rebuilt.
+        apply_detail = await asyncio.to_thread(
+            apply_tool_change,
+            instance_path,
+            get_loop,
+            restart_conversation,
+            "mcp_server_token_changed",
+        )
+        if persist_state == "failed":
+            message = (
+                f"Saved the token for {alias} for this session only: writing the instance .env failed, "
+                f"so it will not survive a restart. {apply_detail}"
+            )
+        elif persist_state == "session":
+            message = f"Saved the token for {alias} for this session. {apply_detail}"
+        else:
+            message = f"Saved the token for {alias}. {apply_detail}"
+        return {
+            **await asyncio.to_thread(_settings_payload, instance_path),
+            "message": message,
+        }
+
+    rpc.register("mcp_servers.list", _list_mcp_servers)
+    rpc.register("mcp_servers.add", _add_mcp_server)
+    rpc.register("mcp_servers.remove", _remove_mcp_server)
+    rpc.register("mcp_servers.save_token", _save_mcp_server_token)

--- a/src/reachy_mini_conversation_app/mcp_server_routes.py
+++ b/src/reachy_mini_conversation_app/mcp_server_routes.py
@@ -127,6 +127,11 @@ def register_mcp_server_methods(
         alias = _required_string(params, "alias", "invalid_mcp_alias", "Enter a short alias, e.g. my_server.")
         url = _required_string(params, "url", "invalid_mcp_url", "Enter the server's MCP endpoint URL.")
         auth = _auth_from_params(params)
+        # Validate before the try: these raise their own JsonRpcError, and the
+        # broad `except Exception` below would otherwise remap it to a generic
+        # add-failed reason and lose the specific message.
+        request_timeout_s = _optional_float(params, "request_timeout_s")
+        tool_timeout_s = _optional_float(params, "tool_timeout_s")
 
         try:
             result = await asyncio.to_thread(
@@ -135,8 +140,8 @@ def register_mcp_server_methods(
                 url,
                 instance_path,
                 auth=auth,
-                request_timeout_s=_optional_float(params, "request_timeout_s"),
-                tool_timeout_s=_optional_float(params, "tool_timeout_s"),
+                request_timeout_s=request_timeout_s,
+                tool_timeout_s=tool_timeout_s,
                 install_only=True,
             )
         except McpServerAliasConflictError as exc:

--- a/src/reachy_mini_conversation_app/mcp_servers.py
+++ b/src/reachy_mini_conversation_app/mcp_servers.py
@@ -1,0 +1,676 @@
+"""Manage generic remote MCP server tool sources for the conversation app.
+
+Unlike ``tool_spaces`` (which is specific to Hugging Face Gradio Spaces), this
+module lets the app talk to any HTTP(S) MCP server given a URL and an optional
+auth token. The token value is never persisted: only the *name* of the
+environment variable that holds it is stored in the manifest, and the value is
+read from the environment at runtime.
+
+Tools discovered at add time are cached in the manifest, so startup builds
+clients from the cache without any network discovery (matching the installed
+tool-spaces behavior). Unlike Space tools, generic server tools keep their raw
+namespaced name ``{alias}__{tool}`` with no redundant-prefix cleaning:
+arbitrary servers have no naming convention to strip.
+"""
+
+import os
+import re
+import asyncio
+import logging
+import argparse
+import threading
+from typing import Any
+from pathlib import Path
+from dataclasses import field, asdict, replace, dataclass
+from collections.abc import Sequence
+
+# Importing config loads the .env file, so an auth token placed there is
+# available when resolving servers from the standalone CLI.
+from reachy_mini_conversation_app.config import USER_PERSONALITIES_DIRNAME, config
+from reachy_mini_conversation_app.mcp_client import (
+    McpClientError,
+    RemoteToolSpec,
+    RemoteMcpToolClient,
+    RemoteMcpServerConfig,
+    _require_alias_segment,
+    validate_http_mcp_url,
+    is_plaintext_remote_url,
+)
+from reachy_mini_conversation_app.tool_spaces import read_installed_tool_spaces
+from reachy_mini_conversation_app.profile_store import DEFAULT_PROFILE_NAME, list_profile_names
+from reachy_mini_conversation_app.profile_toolsets import (
+    ProfileToolsets,
+    enable_profile_tools,
+    read_profile_toolsets,
+    write_profile_toolsets,
+    read_profile_tool_names,
+    get_profile_toolsets_path,
+    profile_toolsets_transaction,
+    disable_profile_tools_by_prefix,
+)
+from reachy_mini_conversation_app.remote_tool_sources import (
+    MCP_SERVERS_FILENAME,
+    CachedRemoteTool,
+    manifest_path,
+    parse_cached_tools,
+    read_manifest_envelope,
+    write_manifest_payload,
+    build_cached_tools_client,
+)
+
+
+logger = logging.getLogger(__name__)
+
+MCP_SERVERS_VERSION = 1
+BEARER_AUTH_TYPE = "bearer"
+# POSIX-style environment variable name: leading letter/underscore, then
+# letters/digits/underscores. Names outside this set can't round-trip through the
+# instance `.env` (e.g. a name with a space writes a line python-dotenv won't parse).
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SUPPORTED_AUTH_TYPES = {BEARER_AUTH_TYPE}
+_MANIFEST_LOCK = threading.RLock()
+
+
+@dataclass(frozen=True)
+class McpServerAuth:
+    """Auth descriptor for an MCP server. Stores the env-var name, never the secret."""
+
+    type: str
+    token_env: str
+    # Explicit opt-in to sending the token over plain HTTP to a non-loopback host.
+    allow_insecure_http: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate the auth descriptor."""
+        auth_type = self.type.strip().lower()
+        if auth_type not in _SUPPORTED_AUTH_TYPES:
+            raise ValueError(
+                f"Unsupported MCP auth type '{self.type}'. Expected one of: {sorted(_SUPPORTED_AUTH_TYPES)}."
+            )
+        object.__setattr__(self, "type", auth_type)
+        token_env = self.token_env.strip()
+        if not token_env:
+            raise ValueError("MCP auth 'token_env' (the environment variable name) cannot be empty.")
+        if not _ENV_VAR_NAME_RE.match(token_env):
+            raise ValueError(
+                f"Invalid MCP auth 'token_env' name '{token_env}'. Use a valid environment variable "
+                "name: a letter or underscore followed by letters, digits, or underscores "
+                "(e.g. MCP_SERVER_TOKEN)."
+            )
+        object.__setattr__(self, "token_env", token_env)
+
+
+@dataclass(frozen=True)
+class InstalledMcpServer:
+    """Persisted record for one configured MCP server and the tools discovered at add time."""
+
+    alias: str
+    url: str
+    auth: McpServerAuth | None = None
+    request_timeout_s: float = 10.0
+    tool_timeout_s: float = 30.0
+    tools: list[CachedRemoteTool] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validate alias, URL and timeouts once the dataclass is created."""
+        object.__setattr__(self, "alias", _require_alias_segment("server alias", self.alias))
+        object.__setattr__(self, "url", validate_http_mcp_url(self.url))
+        if self.request_timeout_s <= 0:
+            raise ValueError("request_timeout_s must be greater than zero.")
+        if self.tool_timeout_s <= 0:
+            raise ValueError("tool_timeout_s must be greater than zero.")
+
+
+@dataclass(frozen=True)
+class InstalledMcpServersManifest:
+    """Persisted manifest of configured MCP servers."""
+
+    version: int = MCP_SERVERS_VERSION
+    servers: list[InstalledMcpServer] = field(default_factory=list)
+    # Entries the reader dropped as invalid. A rewrite from this manifest would
+    # permanently delete them, so add/remove refuse while it is non-zero.
+    skipped_entries: int = 0
+
+
+class McpServerAliasConflictError(RuntimeError):
+    """Raised when a server alias is already claimed by another tool source."""
+
+
+class McpServerNotConfiguredError(RuntimeError):
+    """Raised when removing a server that is not configured."""
+
+
+class McpServerProfileUpdateError(RuntimeError):
+    """Raised when configured MCP server tools cannot be updated in profiles."""
+
+
+class McpServerManifestError(RuntimeError):
+    """Raised when the manifest holds entries a rewrite would destroy."""
+
+
+@dataclass(frozen=True)
+class McpServerInstallResult:
+    """Result of configuring or refreshing one MCP server."""
+
+    resolved_server: InstalledMcpServer
+    manifest: InstalledMcpServersManifest
+    manifest_path: Path
+    refreshed: bool
+    enabled_profile: str | None
+    added_tool_ids: list[str]
+
+
+@dataclass(frozen=True)
+class McpServerRemovalResult:
+    """Result of removing one configured MCP server."""
+
+    removed_server: InstalledMcpServer
+    manifest: InstalledMcpServersManifest
+    disabled_profiles: list[tuple[str, list[str]]]
+
+
+def get_mcp_servers_path(instance_path: str | Path | None) -> Path:
+    """Return the MCP servers manifest path for the current mode."""
+    return manifest_path(instance_path, MCP_SERVERS_FILENAME)
+
+
+def _parse_auth(raw_auth: object, alias: str, path: Path) -> McpServerAuth | None:
+    if raw_auth is None:
+        return None
+    if not isinstance(raw_auth, dict):
+        raise RuntimeError(f"Invalid 'auth' for MCP server '{alias}' in {path}: expected an object.")
+    allow_insecure_http = raw_auth.get("allow_insecure_http", False)
+    if not isinstance(allow_insecure_http, bool):
+        # Refuse truthy strings like "false": a mis-typed value must never grant the insecure opt-in.
+        raise RuntimeError(
+            f"Invalid 'auth' for MCP server '{alias}' in {path}: 'allow_insecure_http' must be true or false."
+        )
+    try:
+        return McpServerAuth(
+            type=str(raw_auth.get("type", "")),
+            token_env=str(raw_auth.get("token_env", "")),
+            allow_insecure_http=allow_insecure_http,
+        )
+    except ValueError as exc:
+        raise RuntimeError(f"Invalid 'auth' for MCP server '{alias}' in {path}: {exc}") from exc
+
+
+def _parse_server_entry(raw_server: object, path: Path) -> InstalledMcpServer:
+    if not isinstance(raw_server, dict):
+        raise RuntimeError(f"Invalid MCP servers entry in {path}: expected an object.")
+    alias = str(raw_server.get("alias", ""))
+    auth = _parse_auth(raw_server.get("auth"), alias, path)
+    try:
+        return InstalledMcpServer(
+            alias=alias,
+            url=str(raw_server.get("url", "")),
+            auth=auth,
+            request_timeout_s=float(raw_server.get("request_timeout_s", 10.0)),
+            tool_timeout_s=float(raw_server.get("tool_timeout_s", 30.0)),
+            tools=parse_cached_tools(raw_server.get("tools", [])),
+        )
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"Invalid MCP server entry in {path}: {exc}") from exc
+
+
+def read_mcp_servers(instance_path: str | Path | None) -> InstalledMcpServersManifest:
+    """Read the configured MCP servers manifest if present, skipping invalid entries so one bad server cannot disable the rest."""
+    with _MANIFEST_LOCK:
+        path = get_mcp_servers_path(instance_path)
+        envelope = read_manifest_envelope(path, "servers")
+    if envelope is None:
+        return InstalledMcpServersManifest()
+    raw_servers, version = envelope
+
+    servers: list[InstalledMcpServer] = []
+    seen_aliases: set[str] = set()
+    skipped = 0
+    for raw_server in raw_servers:
+        try:
+            server = _parse_server_entry(raw_server, path)
+            if server.alias in seen_aliases:
+                raise RuntimeError(f"Duplicate MCP server alias '{server.alias}' found in {path}.")
+        except RuntimeError as exc:
+            logger.warning("Skipping invalid MCP server entry: %s", exc)
+            skipped += 1
+            continue
+        seen_aliases.add(server.alias)
+        servers.append(server)
+
+    return InstalledMcpServersManifest(version=version, servers=servers, skipped_entries=skipped)
+
+
+def write_mcp_servers(instance_path: str | Path | None, manifest: InstalledMcpServersManifest) -> Path:
+    """Persist the MCP servers manifest. The token value is never stored, only token_env."""
+    servers_payload: list[dict[str, Any]] = []
+    for server in manifest.servers:
+        entry: dict[str, Any] = {
+            "alias": server.alias,
+            "url": server.url,
+            "request_timeout_s": server.request_timeout_s,
+            "tool_timeout_s": server.tool_timeout_s,
+            "tools": [asdict(tool) for tool in server.tools],
+        }
+        if server.auth is not None:
+            entry["auth"] = {"type": server.auth.type, "token_env": server.auth.token_env}
+            if server.auth.allow_insecure_http:
+                entry["auth"]["allow_insecure_http"] = True
+        servers_payload.append(entry)
+
+    payload = {"version": manifest.version, "servers": servers_payload}
+    with _MANIFEST_LOCK:
+        return write_manifest_payload(get_mcp_servers_path(instance_path), payload)
+
+
+def configured_aliases(instance_path: str | Path | None) -> set[str]:
+    """Aliases currently claimed by configured MCP servers."""
+    return {server.alias for server in read_mcp_servers(instance_path).servers}
+
+
+def _resolve_auth_headers(server: InstalledMcpServer) -> dict[str, str]:
+    """Build request headers for a server, reading the secret from the environment."""
+    if server.auth is None:
+        return {}
+    if server.auth.type == BEARER_AUTH_TYPE:
+        token = (os.environ.get(server.auth.token_env) or "").strip()
+        if not token:
+            raise RuntimeError(
+                f"Env var '{server.auth.token_env}' for MCP server '{server.alias}' is not set or empty."
+            )
+        if is_plaintext_remote_url(server.url):
+            if not server.auth.allow_insecure_http:
+                raise RuntimeError(
+                    f"MCP server '{server.alias}' would send its bearer token over plain HTTP ({server.url}), "
+                    "exposing it to anyone on the network. Use HTTPS, a loopback address, or opt in "
+                    "explicitly with 'mcp-servers add ... --allow-insecure-token'."
+                )
+            logger.warning(
+                "MCP server '%s' sends its bearer token over plain HTTP (%s) per --allow-insecure-token; "
+                "the token is visible to anyone on the local network.",
+                server.alias,
+                server.url,
+            )
+        return {"Authorization": f"Bearer {token}"}
+    # Unreachable: McpServerAuth validates the type, but keep this defensive.
+    raise RuntimeError(f"Unsupported MCP auth type '{server.auth.type}' for server '{server.alias}'.")
+
+
+def build_server_config(server: InstalledMcpServer) -> RemoteMcpServerConfig:
+    """Build a transport config for a server, resolving auth headers from the environment."""
+    return RemoteMcpServerConfig(
+        alias=server.alias,
+        url=server.url,
+        headers=_resolve_auth_headers(server),
+        request_timeout_s=server.request_timeout_s,
+        tool_timeout_s=server.tool_timeout_s,
+        allow_insecure_http=server.auth.allow_insecure_http if server.auth is not None else False,
+    )
+
+
+def build_generic_remote_client(server: InstalledMcpServer) -> RemoteMcpToolClient:
+    """Build an MCP client from cached tools, raising RuntimeError when auth cannot be resolved."""
+    return build_cached_tools_client(build_server_config(server), server.tools)
+
+
+@dataclass(frozen=True)
+class McpTokenRequirement:
+    """One configured MCP server's auth-token requirement, for the settings UI."""
+
+    alias: str
+    token_env: str
+    token_set: bool
+
+
+def list_token_requirements(instance_path: str | Path | None) -> list[McpTokenRequirement]:
+    """Return the configured servers' auth-token requirements for the settings UI."""
+    requirements: list[McpTokenRequirement] = []
+    for server in read_mcp_servers(instance_path).servers:
+        if server.auth is not None and server.auth.type == BEARER_AUTH_TYPE:
+            token_set = bool((os.environ.get(server.auth.token_env) or "").strip())
+            requirements.append(
+                McpTokenRequirement(alias=server.alias, token_env=server.auth.token_env, token_set=token_set)
+            )
+    return requirements
+
+
+def find_server_token_env(instance_path: str | Path | None, alias: str) -> str | None:
+    """Return the token env-var name for a configured MCP server alias, or None."""
+    return next((req.token_env for req in list_token_requirements(instance_path) if req.alias == alias), None)
+
+
+def _build_generic_server_tools(remote_specs: Sequence[RemoteToolSpec]) -> list[CachedRemoteTool]:
+    """Map discovered remote specs to app-facing tools without HF-specific name cleaning."""
+    return [
+        CachedRemoteTool(
+            local_name=spec.namespaced_name,
+            client_tool_name=spec.namespaced_name,
+            remote_name=spec.remote_name,
+            description=spec.description,
+            parameters_schema=dict(spec.parameters_schema),
+        )
+        for spec in remote_specs
+    ]
+
+
+async def resolve_mcp_server(server: InstalledMcpServer) -> InstalledMcpServer:
+    """Connect to a configured MCP server and return it with freshly discovered tools."""
+    client = RemoteMcpToolClient(build_server_config(server))
+    try:
+        remote_specs = await client.list_tool_specs()
+    except McpClientError as exc:
+        raise RuntimeError(f"Failed to discover MCP tools for '{server.alias}': {exc}") from exc
+
+    return replace(server, tools=_build_generic_server_tools(remote_specs))
+
+
+def resolve_mcp_server_sync(server: InstalledMcpServer) -> InstalledMcpServer:
+    """Resolve one configured MCP server synchronously."""
+    return asyncio.run(resolve_mcp_server(server))
+
+
+def _restore_profile_toolsets(
+    instance_path: str | Path | None,
+    toolsets: ProfileToolsets,
+    settings_existed: bool,
+) -> None:
+    settings_path = get_profile_toolsets_path(instance_path)
+    if settings_existed:
+        write_profile_toolsets(instance_path, toolsets)
+    else:
+        settings_path.unlink(missing_ok=True)
+
+
+def _require_rewritable_manifest(manifest: InstalledMcpServersManifest, instance_path: str | Path | None) -> None:
+    if manifest.skipped_entries:
+        raise McpServerManifestError(
+            f"The MCP servers manifest contains {manifest.skipped_entries} invalid entry(ies) that a rewrite "
+            f"would permanently delete. Fix or remove them in {get_mcp_servers_path(instance_path)} first."
+        )
+
+
+def _space_aliases(instance_path: str | Path | None) -> set[str]:
+    """Aliases claimed by installed Spaces. Raises so alias-collision checks fail closed."""
+    return {space.alias for space in read_installed_tool_spaces(instance_path).spaces}
+
+
+def install_mcp_server(
+    alias: str,
+    url: str,
+    instance_path: str | Path | None,
+    *,
+    auth: McpServerAuth | None = None,
+    request_timeout_s: float | None = None,
+    tool_timeout_s: float | None = None,
+    install_only: bool = False,
+    profile: str | None = None,
+) -> McpServerInstallResult:
+    """Configure or refresh one MCP server and optionally enable its tools in a profile.
+
+    Re-running an add is the documented cache-refresh flow, so options that are
+    not repeated keep their stored values instead of resetting to defaults.
+    """
+    target_profile = profile or config.REACHY_MINI_CUSTOM_PROFILE or DEFAULT_PROFILE_NAME
+    if not install_only:
+        try:
+            read_profile_tool_names(target_profile, instance_path)
+        except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
+            raise McpServerProfileUpdateError(
+                f"Cannot enable MCP server tools in profile '{target_profile}': {exc}"
+            ) from exc
+
+    with _MANIFEST_LOCK:
+        manifest = read_mcp_servers(instance_path)
+        _require_rewritable_manifest(manifest, instance_path)
+        requested_alias = _require_alias_segment("server alias", alias)
+        existing = next((entry for entry in manifest.servers if entry.alias == requested_alias), None)
+
+        server = InstalledMcpServer(
+            alias=requested_alias,
+            url=url,
+            auth=auth if auth is not None else (existing.auth if existing is not None else None),
+            request_timeout_s=(
+                request_timeout_s
+                if request_timeout_s is not None
+                else existing.request_timeout_s
+                if existing is not None
+                else 10.0
+            ),
+            tool_timeout_s=(
+                tool_timeout_s
+                if tool_timeout_s is not None
+                else existing.tool_timeout_s
+                if existing is not None
+                else 30.0
+            ),
+        )
+
+        if existing is not None and existing.url != server.url:
+            raise McpServerAliasConflictError(
+                f"MCP server alias '{server.alias}' is already configured for {existing.url}. "
+                "Remove it first to point it elsewhere."
+            )
+        if existing is None:
+            # Fail closed: an unnoticed collision crashes tool registration at boot,
+            # so refuse the add when the other manifest cannot be checked.
+            try:
+                space_aliases = _space_aliases(instance_path)
+            except RuntimeError as exc:
+                raise McpServerAliasConflictError(
+                    f"Cannot add MCP server '{server.alias}': the installed tool-spaces manifest is unreadable, "
+                    f"so the alias cannot be checked for collisions. Fix it first: {exc}"
+                ) from exc
+            if server.alias in space_aliases:
+                raise McpServerAliasConflictError(
+                    f"Cannot add MCP server '{server.alias}': its alias collides with an installed tool space. "
+                    "Choose a different alias."
+                )
+
+    # Resolve outside the manifest lock: discovery is a network round-trip, and
+    # failing before anything is persisted is the point (bad URL, unreachable
+    # server, missing token). Discovered tools are cached so startup needs no
+    # network; re-running add refreshes the cache.
+    resolved = resolve_mcp_server_sync(server)
+
+    with _MANIFEST_LOCK, profile_toolsets_transaction():
+        manifest = read_mcp_servers(instance_path)
+        _require_rewritable_manifest(manifest, instance_path)
+        refreshed = any(entry.alias == resolved.alias for entry in manifest.servers)
+        updated_manifest = InstalledMcpServersManifest(
+            version=manifest.version,
+            servers=sorted(
+                [entry for entry in manifest.servers if entry.alias != resolved.alias] + [resolved],
+                key=lambda entry: entry.alias,
+            ),
+        )
+
+        enabled_profile: str | None = None
+        added_tool_ids: list[str] = []
+        profile_toolsets = ProfileToolsets()
+        profile_settings_existed = False
+        if not install_only:
+            profile_toolsets = read_profile_toolsets(instance_path)
+            profile_settings_existed = get_profile_toolsets_path(instance_path).exists()
+            tool_ids = [tool.local_name for tool in resolved.tools]
+            try:
+                added_tool_ids = enable_profile_tools(target_profile, tool_ids, instance_path)
+            except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
+                raise McpServerProfileUpdateError(
+                    f"Could not enable '{resolved.alias}' in profile '{target_profile}': {exc}"
+                ) from exc
+            enabled_profile = target_profile
+
+        try:
+            written_path = write_mcp_servers(instance_path, updated_manifest)
+        except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
+            if not install_only:
+                try:
+                    _restore_profile_toolsets(instance_path, profile_toolsets, profile_settings_existed)
+                except (OSError, RuntimeError, UnicodeError, ValueError) as rollback_exc:
+                    raise McpServerProfileUpdateError(
+                        f"Could not persist '{resolved.alias}', and restoring the previous profile tool "
+                        f"settings also failed: {rollback_exc}"
+                    ) from rollback_exc
+            raise RuntimeError(f"Could not persist MCP server '{resolved.alias}': {exc}") from exc
+
+    return McpServerInstallResult(
+        resolved_server=resolved,
+        manifest=updated_manifest,
+        manifest_path=written_path,
+        refreshed=refreshed,
+        enabled_profile=enabled_profile,
+        added_tool_ids=added_tool_ids,
+    )
+
+
+def remove_mcp_server(alias: str, instance_path: str | Path | None) -> McpServerRemovalResult:
+    """Remove one configured MCP server and disable its tools in all profiles."""
+    validated_alias = _require_alias_segment("server alias", alias)
+    with _MANIFEST_LOCK, profile_toolsets_transaction():
+        manifest = read_mcp_servers(instance_path)
+        _require_rewritable_manifest(manifest, instance_path)
+        removed_server = next((entry for entry in manifest.servers if entry.alias == validated_alias), None)
+        if removed_server is None:
+            raise McpServerNotConfiguredError(f"MCP server not configured: {validated_alias}")
+
+        updated_manifest = InstalledMcpServersManifest(
+            version=manifest.version,
+            servers=[entry for entry in manifest.servers if entry.alias != validated_alias],
+        )
+        profile_toolsets = read_profile_toolsets(instance_path)
+        profile_settings_existed = get_profile_toolsets_path(instance_path).exists()
+        profile_names = [DEFAULT_PROFILE_NAME, *list_profile_names(config.PROFILES_DIRECTORY)]
+        profile_names.extend(
+            f"{USER_PERSONALITIES_DIRNAME}/{name}" for name in list_profile_names(config.user_personalities_root())
+        )
+        profile_names.extend(profile_toolsets.profiles)
+        try:
+            disabled_profiles = disable_profile_tools_by_prefix(
+                profile_names,
+                f"{removed_server.alias}__",
+                instance_path,
+            )
+        except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
+            raise McpServerProfileUpdateError(
+                f"Could not remove '{validated_alias}' because its profile tool access could not be updated: {exc}"
+            ) from exc
+        try:
+            write_mcp_servers(instance_path, updated_manifest)
+        except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
+            try:
+                _restore_profile_toolsets(instance_path, profile_toolsets, profile_settings_existed)
+            except (OSError, RuntimeError, UnicodeError, ValueError) as rollback_exc:
+                raise McpServerProfileUpdateError(
+                    f"Could not persist removal of '{validated_alias}', and restoring the previous profile tool "
+                    f"settings also failed: {rollback_exc}"
+                ) from rollback_exc
+            raise RuntimeError(f"Could not persist removal of MCP server '{validated_alias}': {exc}") from exc
+
+    return McpServerRemovalResult(
+        removed_server=removed_server,
+        manifest=updated_manifest,
+        disabled_profiles=disabled_profiles,
+    )
+
+
+def format_mcp_server_listing(server: InstalledMcpServer) -> str:
+    """Format one configured MCP server for terminal output (no secrets)."""
+    lines = [
+        f"{server.alias}",
+        f"  MCP endpoint: {server.url}",
+    ]
+    if server.tools:
+        lines.append("  Tools:")
+        lines.extend([f"    - {tool.local_name}" for tool in server.tools])
+    else:
+        lines.append("  Tools: none discovered")
+    return "\n".join(lines)
+
+
+def _auth_from_args(args: argparse.Namespace, existing_auth: McpServerAuth | None) -> McpServerAuth | None:
+    """Build the auth descriptor for an add, keeping stored values for flags that were not repeated."""
+    token_env = (getattr(args, "token_env", None) or "").strip()
+    stored_allow_insecure = existing_auth is not None and existing_auth.allow_insecure_http
+    requested_allow_insecure = bool(getattr(args, "allow_insecure_token", False))
+    # The insecure-HTTP opt-in sticks until 'remove', like every other stored flag.
+    allow_insecure_token = requested_allow_insecure or stored_allow_insecure
+
+    if not token_env:
+        if allow_insecure_token and not stored_allow_insecure:
+            logger.warning("--allow-insecure-token has no effect without --token-env.")
+        if existing_auth is not None:
+            logger.info("Keeping stored auth (token env '%s').", existing_auth.token_env)
+        return existing_auth
+
+    if stored_allow_insecure and not requested_allow_insecure:
+        logger.info("Keeping the stored --allow-insecure-token opt-in.")
+    return McpServerAuth(
+        type=BEARER_AUTH_TYPE,
+        token_env=token_env,
+        allow_insecure_http=allow_insecure_token,
+    )
+
+
+def handle_mcp_servers_command(args: argparse.Namespace, *, instance_path: str | Path | None = None) -> int:
+    """Handle mcp-servers subcommands from the main CLI."""
+    command = getattr(args, "mcp_servers_command", None)
+    if command == "add":
+        try:
+            existing = next(
+                (entry for entry in read_mcp_servers(instance_path).servers if entry.alias == args.alias.strip()),
+                None,
+            )
+            auth = _auth_from_args(args, existing.auth if existing is not None else None)
+            install_result = install_mcp_server(
+                args.alias,
+                args.url,
+                instance_path,
+                auth=auth,
+                request_timeout_s=getattr(args, "request_timeout", None),
+                tool_timeout_s=getattr(args, "tool_timeout", None),
+                install_only=bool(getattr(args, "install_only", False)),
+                profile=getattr(args, "profile", None),
+            )
+        except (RuntimeError, ValueError) as exc:
+            logger.error("%s", exc)
+            return 1
+
+        action = "Refreshed" if install_result.refreshed else "Configured"
+        logger.info("%s MCP server: %s", action, install_result.resolved_server.alias)
+        logger.info("Manifest: %s", install_result.manifest_path)
+        logger.info("%s", format_mcp_server_listing(install_result.resolved_server))
+
+        if install_result.enabled_profile is None:
+            logger.info("Server configured. Select its tools under Tool access to enable them.")
+            return 0
+        if install_result.added_tool_ids:
+            logger.info("Enabled in profile '%s': %s", install_result.enabled_profile, install_result.added_tool_ids)
+        else:
+            logger.info("All tool IDs already present in profile '%s'.", install_result.enabled_profile)
+        return 0
+
+    if command == "remove":
+        try:
+            removal_result = remove_mcp_server(args.alias, instance_path)
+        except McpServerNotConfiguredError as exc:
+            logger.warning("%s", exc)
+            return 1
+        except (RuntimeError, ValueError) as exc:
+            logger.error("%s", exc)
+            return 1
+
+        logger.info("Removed MCP server: %s", removal_result.removed_server.alias)
+        for profile_name, disabled_tool_ids in removal_result.disabled_profiles:
+            logger.info("Disabled in profile '%s': %s", profile_name, disabled_tool_ids)
+        return 0
+
+    if command == "list":
+        manifest = read_mcp_servers(instance_path)
+        logger.info("Manifest: %s", get_mcp_servers_path(instance_path))
+        if not manifest.servers:
+            logger.info("No configured MCP servers.")
+            return 0
+        for server in manifest.servers:
+            logger.info("%s", format_mcp_server_listing(server))
+        return 0
+
+    raise RuntimeError(f"Unknown mcp-servers command: {command}")

--- a/src/reachy_mini_conversation_app/mcp_servers.py
+++ b/src/reachy_mini_conversation_app/mcp_servers.py
@@ -32,8 +32,8 @@ from reachy_mini_conversation_app.mcp_client import (
     RemoteToolSpec,
     RemoteMcpToolClient,
     RemoteMcpServerConfig,
-    _require_alias_segment,
     validate_http_mcp_url,
+    _require_alias_segment,
     is_plaintext_remote_url,
 )
 from reachy_mini_conversation_app.tool_spaces import read_installed_tool_spaces

--- a/src/reachy_mini_conversation_app/remote_tool_sources.py
+++ b/src/reachy_mini_conversation_app/remote_tool_sources.py
@@ -10,7 +10,7 @@ on Space-specific machinery.
 import os
 import json
 import logging
-from typing import Any
+from typing import Any, Protocol
 from pathlib import Path
 from dataclasses import dataclass
 from collections.abc import Sequence
@@ -81,6 +81,35 @@ def configured_server_aliases(instance_path: str | Path | None) -> set[str]:
         return set()
     entries, _version = envelope
     return {str(entry["alias"]) for entry in entries if isinstance(entry, dict) and entry.get("alias")}
+
+
+class CachedToolRecord(Protocol):
+    """Structural type for a cached tool record from any source manifest.
+
+    Spaces and generic MCP servers keep separate record types (their manifests
+    have different shapes around them), but the registry only needs these five
+    fields to build an adapter, so it accepts either.
+    """
+
+    @property
+    def local_name(self) -> str:
+        """Tool ID as it appears in a profile's enabled tools."""
+
+    @property
+    def client_tool_name(self) -> str:
+        """Namespaced name the MCP client dispatches on."""
+
+    @property
+    def remote_name(self) -> str:
+        """Tool name on the remote server."""
+
+    @property
+    def description(self) -> str:
+        """Description handed to the model."""
+
+    @property
+    def parameters_schema(self) -> dict[str, Any]:
+        """JSON Schema for the tool's arguments."""
 
 
 @dataclass(frozen=True)

--- a/src/reachy_mini_conversation_app/remote_tool_sources.py
+++ b/src/reachy_mini_conversation_app/remote_tool_sources.py
@@ -1,0 +1,135 @@
+"""Source-agnostic building blocks shared by the remote tool-source manifests.
+
+Both installed Hugging Face Spaces (``tool_spaces``) and generic MCP servers
+(``mcp_servers``) persist the tools discovered at install time, rebuild clients
+from that cache at startup, and wire their tool IDs into profile toolsets. This
+module holds the pieces the generic MCP-server code needs so it does not depend
+on Space-specific machinery.
+"""
+
+import os
+import json
+import logging
+from typing import Any
+from pathlib import Path
+from dataclasses import dataclass
+from collections.abc import Sequence
+
+from reachy_mini_conversation_app.mcp_client import (
+    RemoteToolSpec,
+    RemoteMcpToolClient,
+    RemoteMcpServerConfig,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Where terminal mode (no managed app instance) keeps manifests and downloads.
+TERMINAL_EXTERNAL_CONTENT_DIRECTORY = Path("external_content")
+
+MCP_SERVERS_FILENAME = "mcp_servers.json"
+
+
+def manifest_path(instance_path: str | Path | None, filename: str) -> Path:
+    """Return a source manifest's path: the app instance dir, or external_content/ in terminal mode."""
+    if instance_path is not None:
+        return Path(instance_path) / filename
+    return TERMINAL_EXTERNAL_CONTENT_DIRECTORY / filename
+
+
+def read_manifest_envelope(path: Path, entries_key: str) -> tuple[list[object], int] | None:
+    """Read and validate a manifest's shared JSON envelope, returning (raw entries, version) or None when absent."""
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Failed to read {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Invalid payload in {path}: expected a JSON object.")
+    entries = payload.get(entries_key, [])
+    if not isinstance(entries, list):
+        raise RuntimeError(f"Invalid payload in {path}: '{entries_key}' must be a list.")
+    version = payload.get("version", 1)
+    if not isinstance(version, int) or isinstance(version, bool):
+        raise RuntimeError(f"Invalid payload in {path}: 'version' must be an int.")
+    return entries, version
+
+
+def write_manifest_payload(path: Path, payload: dict[str, Any]) -> Path:
+    """Persist a manifest payload, replacing the file atomically so a crash cannot truncate it."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary_path.write_text(f"{json.dumps(payload, indent=2, sort_keys=True)}\n", encoding="utf-8")
+        temporary_path.replace(path)
+    finally:
+        try:
+            temporary_path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("Failed to remove temporary manifest %s: %s", temporary_path, exc)
+    return path
+
+
+def configured_server_aliases(instance_path: str | Path | None) -> set[str]:
+    """Aliases claimed in the MCP servers manifest; raises RuntimeError so alias-collision checks fail closed."""
+    # Raw envelope read rather than mcp_servers.read_mcp_servers: this shared module
+    # must not import mcp_servers back (import cycle), and counting even invalid
+    # entries' aliases is the conservative choice for a collision check.
+    envelope = read_manifest_envelope(manifest_path(instance_path, MCP_SERVERS_FILENAME), "servers")
+    if envelope is None:
+        return set()
+    entries, _version = envelope
+    return {str(entry["alias"]) for entry in entries if isinstance(entry, dict) and entry.get("alias")}
+
+
+@dataclass(frozen=True)
+class CachedRemoteTool:
+    """App-facing metadata for one remote tool cached in a source's manifest."""
+
+    local_name: str
+    client_tool_name: str
+    remote_name: str
+    description: str
+    parameters_schema: dict[str, Any]
+
+
+def parse_cached_tools(raw_tools: object) -> list[CachedRemoteTool]:
+    """Parse a manifest entry's cached-tools list, skipping malformed items."""
+    if not isinstance(raw_tools, list):
+        return []
+    return [
+        CachedRemoteTool(
+            local_name=str(tool["local_name"]),
+            client_tool_name=str(tool["client_tool_name"]),
+            remote_name=str(tool.get("remote_name", "")),
+            description=str(tool.get("description", "")),
+            parameters_schema=dict(tool.get("parameters_schema") or {}),
+        )
+        for tool in raw_tools
+        if isinstance(tool, dict)
+        and tool.get("local_name")
+        and tool.get("client_tool_name")
+        and isinstance(tool.get("parameters_schema") or {}, dict)
+    ]
+
+
+def build_cached_tools_client(
+    server_config: RemoteMcpServerConfig,
+    cached_tools: Sequence[CachedRemoteTool],
+) -> RemoteMcpToolClient:
+    """Build an MCP client from a transport config and manifest-cached tool records."""
+    return RemoteMcpToolClient(
+        server_config,
+        known_tools=[
+            RemoteToolSpec(
+                server_alias=server_config.alias,
+                remote_name=tool.remote_name,
+                namespaced_name=tool.client_tool_name,
+                description=tool.description,
+                parameters_schema=tool.parameters_schema,
+            )
+            for tool in cached_tools
+            if tool.remote_name
+        ],
+    )

--- a/src/reachy_mini_conversation_app/static/js/api.js
+++ b/src/reachy_mini_conversation_app/static/js/api.js
@@ -149,6 +149,14 @@ export const addToolSpace = (slug) =>
 export const removeToolSpace = (slug) =>
   rpcCall("tool_spaces.remove", { slug }, { timeoutMs: TOOL_SPACE_TIMEOUT_MS });
 
+export const listMcpServers = () => rpcCall("mcp_servers.list");
+export const addMcpServer = (payload) =>
+  rpcCall("mcp_servers.add", payload, { timeoutMs: TOOL_SPACE_TIMEOUT_MS });
+export const removeMcpServer = (alias) =>
+  rpcCall("mcp_servers.remove", { alias }, { timeoutMs: TOOL_SPACE_TIMEOUT_MS });
+export const saveMcpServerToken = (alias, token) =>
+  rpcCall("mcp_servers.save_token", { alias, token });
+
 export const getProfileTools = (profile) =>
   rpcCall("profile_tools.get", profile ? { profile } : {});
 export const saveProfileTools = (profile, enabledTools) =>
@@ -177,6 +185,20 @@ const ERROR_MESSAGES = Object.freeze({
   not_deletable: "This personality can't be deleted.",
   loop_unavailable: "Reachy is still starting up. Try again in a moment.",
   tool_space_not_installed: "That Tool Space is no longer installed.",
+  invalid_mcp_alias: "Enter a short alias using letters, numbers and underscores.",
+  invalid_mcp_url: "Enter the server's MCP endpoint URL.",
+  invalid_mcp_token_env: "Enter a valid environment variable name, e.g. MY_SERVER_TOKEN.",
+  invalid_mcp_timeout: "Timeouts must be a number of seconds greater than zero.",
+  invalid_mcp_server: "That MCP server configuration isn't valid.",
+  mcp_server_alias_conflict: "That alias is already used by another tool source.",
+  mcp_server_not_configured: "That MCP server is no longer configured.",
+  mcp_servers_unavailable: "Couldn't read the MCP server list. Check mcp_servers.json for errors.",
+  mcp_servers_manifest_damaged:
+    "mcp_servers.json has entries that can't be read. Fix them before adding or removing servers.",
+  unknown_mcp_server: "That MCP server is no longer configured.",
+  empty_token: "Enter a token first.",
+  invalid_token: "Tokens can't contain line breaks or '${'.",
+  token_save_failed: "Couldn't store that token.",
 });
 
 /** Map a thrown error to user-facing copy, falling back to its raw message. */

--- a/src/reachy_mini_conversation_app/static/js/components/mcp-servers.js
+++ b/src/reachy_mini_conversation_app/static/js/components/mcp-servers.js
@@ -1,0 +1,292 @@
+/** Custom MCP servers section: add, remove, and set each server's access token. */
+
+import {
+  addMcpServer,
+  describeError,
+  listMcpServers,
+  removeMcpServer,
+  saveMcpServerToken,
+} from "../api.js";
+import { h } from "../ui.js";
+import { confirmDialog } from "./confirm-dialog.js";
+
+export function buildMcpServersSection({ signal, onBeforeChange, onChanged } = {}) {
+  const aliasInput = h("input", {
+    id: "mcp-server-alias",
+    type: "text",
+    name: "alias",
+    required: "required",
+    autocomplete: "off",
+    autocapitalize: "none",
+    spellcheck: "false",
+    placeholder: "my_server",
+    class: "settings-input",
+  });
+  const urlInput = h("input", {
+    id: "mcp-server-url",
+    type: "url",
+    name: "url",
+    required: "required",
+    autocomplete: "off",
+    autocapitalize: "none",
+    spellcheck: "false",
+    enterkeyhint: "go",
+    placeholder: "https://example.com/mcp",
+    class: "settings-input",
+  });
+  const tokenEnvInput = h("input", {
+    id: "mcp-server-token-env",
+    type: "text",
+    name: "token_env",
+    autocomplete: "off",
+    autocapitalize: "none",
+    spellcheck: "false",
+    placeholder: "MY_SERVER_TOKEN (optional)",
+    class: "settings-input",
+  });
+  const addButton = h("button", { type: "submit", class: "btn btn--primary" }, "Add server");
+  const status = h("p", { class: "settings-status", role: "status", "aria-live": "polite" });
+  const list = h(
+    "div",
+    { class: "settings-tool-spaces", role: "list", "aria-live": "polite" },
+    h("p", { class: "settings-hint" }, "Loading configured servers…")
+  );
+  const form = h(
+    "form",
+    { class: "settings-form" },
+    h("label", { class: "settings-label", for: "mcp-server-alias" }, "Alias"),
+    aliasInput,
+    h("label", { class: "settings-label", for: "mcp-server-url" }, "MCP endpoint"),
+    h("div", { class: "settings-tool-space-controls" }, urlInput, addButton),
+    h("label", { class: "settings-label", for: "mcp-server-token-env" }, "Token variable"),
+    tokenEnvInput,
+    h(
+      "p",
+      { class: "settings-hint" },
+      "Connect any MCP server over HTTPS. The alias namespaces its tools, so tools arrive as " +
+        "alias__tool. If the server needs a token, name the environment variable to read it from — " +
+        "the token itself is stored separately, never in the server list."
+    ),
+    status
+  );
+  const element = h(
+    "section",
+    { class: "settings-section" },
+    h("h2", { class: "settings-section-title" }, "MCP servers"),
+    form,
+    h("h3", { class: "settings-list-title" }, "Configured"),
+    list
+  );
+
+  let busy = false;
+  let editable = true;
+  // Tokens typed but not yet saved, carried across every re-render so a refresh
+  // does not clobber a token the user is in the middle of typing.
+  const pendingTokens = new Map();
+  // Skip a re-render when the server list is unchanged, for the same reason.
+  let renderedSignature = null;
+
+  function harvestPendingTokens() {
+    list.querySelectorAll("input[data-alias]").forEach((input) => {
+      if (input.value) pendingTokens.set(input.dataset.alias, input.value);
+      else pendingTokens.delete(input.dataset.alias);
+    });
+  }
+
+  function setBusy(nextBusy, addLabel = "Add server") {
+    busy = nextBusy;
+    form.toggleAttribute("aria-busy", nextBusy);
+    list.toggleAttribute("aria-busy", nextBusy);
+    for (const input of [aliasInput, urlInput, tokenEnvInput]) {
+      input.disabled = nextBusy || !editable;
+    }
+    addButton.disabled = nextBusy || !editable;
+    addButton.textContent = nextBusy ? addLabel : "Add server";
+    list.querySelectorAll("button").forEach((button) => {
+      button.disabled = nextBusy || !editable;
+    });
+  }
+
+  function buildTokenControls(server) {
+    if (!server.token_env) return null;
+    const input = h("input", {
+      type: "password",
+      class: "settings-input",
+      autocomplete: "off",
+      spellcheck: "false",
+      dataset: { alias: server.alias },
+      "aria-label": `Access token for ${server.alias}`,
+      placeholder: server.token_set ? "Token stored — enter a new one to replace" : `token for ${server.token_env}`,
+    });
+    input.value = pendingTokens.get(server.alias) || "";
+    const saveButton = h(
+      "button",
+      { type: "button", class: "btn btn--ghost", disabled: busy || !editable ? "disabled" : null },
+      server.token_set ? "Replace token" : "Save token"
+    );
+    saveButton.addEventListener("click", async () => {
+      const token = (input.value || "").trim();
+      if (!token) {
+        status.classList.add("is-error");
+        status.textContent = `Enter a token for ${server.alias}.`;
+        return;
+      }
+      status.classList.remove("is-error");
+      status.textContent = `Saving token for ${server.alias}…`;
+      setBusy(true, "Saving token…");
+      try {
+        const result = await saveMcpServerToken(server.alias, token);
+        if (signal?.aborted) return;
+        pendingTokens.delete(server.alias);
+        input.value = "";
+        renderedSignature = null;
+        render(result);
+        status.textContent = result?.message || `Saved the token for ${server.alias}.`;
+        await onChanged?.();
+      } catch (error) {
+        if (signal?.aborted) return;
+        status.textContent = `Could not save the token for ${server.alias}: ${describeError(error)}`;
+        status.classList.add("is-error");
+      } finally {
+        if (!signal?.aborted) setBusy(false);
+      }
+    });
+    return h("div", { class: "settings-tool-space-controls" }, input, saveButton);
+  }
+
+  function buildRemoveButton(server) {
+    const removeButton = h(
+      "button",
+      {
+        type: "button",
+        class: "btn btn--ghost",
+        "aria-label": `Remove MCP server ${server.alias}`,
+        disabled: busy || !editable ? "disabled" : null,
+      },
+      "Remove"
+    );
+    removeButton.addEventListener("click", async () => {
+      if (onBeforeChange && !(await onBeforeChange())) return;
+      const confirmed = await confirmDialog({
+        title: "Remove MCP server?",
+        message: `Removing “${server.alias}” disables its tools in every personality.`,
+        confirmLabel: "Remove",
+        danger: true,
+        signal,
+      });
+      if (!confirmed || signal?.aborted) return;
+
+      status.classList.remove("is-error");
+      status.textContent = `Removing “${server.alias}”…`;
+      setBusy(true, "Removing…");
+      try {
+        const result = await removeMcpServer(server.alias);
+        if (signal?.aborted) return;
+        pendingTokens.delete(server.alias);
+        renderedSignature = null;
+        render(result);
+        status.textContent = result?.message || `Removed “${server.alias}”.`;
+        await onChanged?.();
+      } catch (error) {
+        if (signal?.aborted) return;
+        status.textContent = `Failed to remove: ${describeError(error)}`;
+        status.classList.add("is-error");
+      } finally {
+        if (!signal?.aborted) setBusy(false);
+      }
+    });
+    return removeButton;
+  }
+
+  function render(payload) {
+    editable = payload?.editable !== false;
+    const servers = Array.isArray(payload?.servers) ? payload.servers : [];
+    const nextSignature = JSON.stringify(
+      servers.map((server) => [server.alias, server.url, server.tool_count, server.token_env, !!server.token_set])
+    );
+    if (nextSignature === renderedSignature) {
+      setBusy(busy);
+      return;
+    }
+    harvestPendingTokens();
+    renderedSignature = nextSignature;
+
+    list.replaceChildren();
+    if (!servers.length) {
+      list.appendChild(h("p", { class: "settings-hint" }, "No MCP servers configured."));
+      setBusy(busy);
+      if (!editable) status.textContent = "MCP server editing is locked by the administrator.";
+      return;
+    }
+
+    for (const server of servers) {
+      const toolCount = Number(server.tool_count) || 0;
+      const details = [server.url, `${toolCount} ${toolCount === 1 ? "tool" : "tools"}`];
+      if (server.token_env) details.push(server.token_set ? "Token set" : "Token needed");
+      list.appendChild(
+        h(
+          "div",
+          { class: "settings-tool-space", role: "listitem" },
+          h(
+            "div",
+            { class: "settings-tool-space-summary" },
+            h("strong", { class: "settings-tool-space-name" }, server.alias),
+            h("span", { class: "settings-tool-space-meta" }, details.join(" · ")),
+            buildTokenControls(server)
+          ),
+          buildRemoveButton(server)
+        )
+      );
+    }
+    setBusy(busy);
+    if (!editable) status.textContent = "MCP server editing is locked by the administrator.";
+  }
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (addButton.disabled) return;
+    const alias = aliasInput.value.trim();
+    const url = urlInput.value.trim();
+    if (!alias || !url) return;
+    if (onBeforeChange && !(await onBeforeChange())) return;
+
+    status.classList.remove("is-error");
+    status.textContent = `Connecting to “${alias}”…`;
+    setBusy(true, "Connecting…");
+    try {
+      const tokenEnv = tokenEnvInput.value.trim();
+      const result = await addMcpServer(tokenEnv ? { alias, url, token_env: tokenEnv } : { alias, url });
+      if (signal?.aborted) return;
+      aliasInput.value = "";
+      urlInput.value = "";
+      tokenEnvInput.value = "";
+      renderedSignature = null;
+      render(result);
+      status.textContent = result?.message || `Added “${alias}”.`;
+      await onChanged?.();
+    } catch (error) {
+      if (signal?.aborted) return;
+      status.textContent = `Failed to add: ${describeError(error)}`;
+      status.classList.add("is-error");
+    } finally {
+      if (!signal?.aborted) setBusy(false);
+    }
+  });
+
+  return {
+    element,
+    async refresh() {
+      try {
+        const payload = await listMcpServers();
+        if (signal?.aborted) return;
+        render(payload);
+      } catch (error) {
+        if (signal?.aborted) return;
+        renderedSignature = null;
+        list.replaceChildren(
+          h("p", { class: "settings-status is-error" }, `Could not load MCP servers: ${describeError(error)}`)
+        );
+      }
+    },
+  };
+}

--- a/src/reachy_mini_conversation_app/static/js/views/tools.js
+++ b/src/reachy_mini_conversation_app/static/js/views/tools.js
@@ -9,6 +9,7 @@ import {
 import { ROUTES } from "../constants.js";
 import { h } from "../ui.js";
 import { confirmDialog } from "../components/confirm-dialog.js";
+import { buildMcpServersSection } from "../components/mcp-servers.js";
 import { buildProfileToolsSection } from "../components/profile-tools.js";
 
 export async function mountToolsView({ outlet, signal, searchParams, setLeaveGuard, replaceRoute }) {
@@ -31,6 +32,11 @@ export async function mountToolsView({ outlet, signal, searchParams, setLeaveGua
     onBeforeChange: profileToolsSection.confirmDiscard,
     onChanged: profileToolsSection.refresh,
   });
+  const mcpServersSection = buildMcpServersSection({
+    signal,
+    onBeforeChange: profileToolsSection.confirmDiscard,
+    onChanged: profileToolsSection.refresh,
+  });
   const view = h(
     "section",
     { class: "view view--tools" },
@@ -41,15 +47,20 @@ export async function mountToolsView({ outlet, signal, searchParams, setLeaveGua
       h(
         "p",
         { class: "view-subtitle" },
-        "Choose tool access by personality and manage Tool Spaces."
+        "Choose tool access by personality and manage Tool Spaces and MCP servers."
       )
     ),
     profileToolsSection.element,
-    toolSpacesSection.element
+    toolSpacesSection.element,
+    mcpServersSection.element
   );
   outlet.replaceChildren(view);
 
-  await Promise.all([profileToolsSection.refresh(), toolSpacesSection.refresh()]);
+  await Promise.all([
+    profileToolsSection.refresh(),
+    toolSpacesSection.refresh(),
+    mcpServersSection.refresh(),
+  ]);
 }
 
 function buildToolSpacesSection({ signal, onBeforeChange, onChanged } = {}) {

--- a/src/reachy_mini_conversation_app/tool_spaces.py
+++ b/src/reachy_mini_conversation_app/tool_spaces.py
@@ -27,6 +27,7 @@ from reachy_mini_conversation_app.mcp_client import (
     build_namespaced_tool_name,
 )
 from reachy_mini_conversation_app.profile_store import DEFAULT_PROFILE_NAME, list_profile_names
+from reachy_mini_conversation_app.remote_tool_sources import configured_server_aliases
 from reachy_mini_conversation_app.profile_toolsets import (
     ProfileToolsets,
     enable_profile_tools,
@@ -611,6 +612,22 @@ def install_tool_space(
             raise ToolSpaceAliasConflictError(
                 f"Cannot install '{resolved_space.slug}': its local alias '{resolved_space.alias}' conflicts with "
                 f"already-installed '{alias_conflict.slug}'. Rename one Space on Hugging Face to get a distinct alias."
+            )
+
+        # Fail closed against the other manifest too: aliases namespace tool IDs
+        # across both sources, so a collision would make one source's tools
+        # shadow the other's at registration time.
+        try:
+            server_aliases = configured_server_aliases(instance_path)
+        except RuntimeError as exc:
+            raise ToolSpaceAliasConflictError(
+                f"Cannot install '{resolved_space.slug}': the MCP servers manifest is unreadable, so the alias "
+                f"cannot be checked for collisions. Fix it first: {exc}"
+            ) from exc
+        if resolved_space.alias in server_aliases:
+            raise ToolSpaceAliasConflictError(
+                f"Cannot install '{resolved_space.slug}': its local alias '{resolved_space.alias}' collides with a "
+                "configured MCP server. Remove that server, or rename the Space on Hugging Face."
             )
 
         refreshed = any(installed_space.slug == resolved_space.slug for installed_space in manifest.spaces)

--- a/src/reachy_mini_conversation_app/tool_spaces.py
+++ b/src/reachy_mini_conversation_app/tool_spaces.py
@@ -27,7 +27,6 @@ from reachy_mini_conversation_app.mcp_client import (
     build_namespaced_tool_name,
 )
 from reachy_mini_conversation_app.profile_store import DEFAULT_PROFILE_NAME, list_profile_names
-from reachy_mini_conversation_app.remote_tool_sources import configured_server_aliases
 from reachy_mini_conversation_app.profile_toolsets import (
     ProfileToolsets,
     enable_profile_tools,
@@ -38,6 +37,7 @@ from reachy_mini_conversation_app.profile_toolsets import (
     profile_toolsets_transaction,
     disable_profile_tools_by_prefix,
 )
+from reachy_mini_conversation_app.remote_tool_sources import configured_server_aliases
 
 
 logger = logging.getLogger(__name__)

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -10,11 +10,13 @@ import importlib.util
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Callable, ClassVar, Sequence, TypedDict
 from pathlib import Path
+from functools import partial
 from dataclasses import dataclass
 
 from reachy_mini import ReachyMini
 from reachy_mini_conversation_app.config import config, list_tool_module_names
 from reachy_mini_conversation_app.mcp_client import McpToolTimeoutError, McpToolInvocationError
+from reachy_mini_conversation_app.mcp_servers import read_mcp_servers, build_generic_remote_client
 from reachy_mini_conversation_app.tool_spaces import build_remote_client, read_installed_tool_spaces
 from reachy_mini_conversation_app.profile_toolsets import read_profile_tool_names
 from reachy_mini_conversation_app.tools.tool_constants import SystemTool
@@ -22,6 +24,7 @@ from reachy_mini_conversation_app.tools.tool_constants import SystemTool
 
 if TYPE_CHECKING:
     from reachy_mini_conversation_app.mcp_client import RemoteMcpToolClient
+    from reachy_mini_conversation_app.remote_tool_sources import CachedRemoteTool
     from reachy_mini_conversation_app.tools.background_tool_manager import BackgroundToolManager
 
 
@@ -97,29 +100,37 @@ _TOOLS_LOCK = threading.RLock()
 _EXTERNAL_TOOL_MODULE_NAMESPACE = "reachy_mini_conversation_app._external_tools"
 
 
+# A remote tool's origin: an installed Space (id = slug) or a generic MCP server (id = alias).
+RemoteToolSourceKind = Literal["space", "mcp"]
+# Result-payload key naming the source, per kind ("tool_space_slug" predates generic servers).
+_SOURCE_PAYLOAD_KEYS: Dict[str, str] = {"space": "tool_space_slug", "mcp": "mcp_server_alias"}
+
+
 class RemoteMcpTool(Tool):
-    """Adapter exposing one remote MCP tool through the local Tool interface."""
+    """Adapter exposing one cached remote MCP tool through the local Tool interface."""
 
     _auto_register: ClassVar[bool] = False
 
     def __init__(
         self,
         *,
-        slug: str,
+        source_kind: RemoteToolSourceKind,
+        source_id: str,
         name: str,
         description: str,
         parameters_schema: Dict[str, Any],
         client_tool_name: str,
         client: "RemoteMcpToolClient",
     ) -> None:
-        """Store the resolved local/remote names and the shared MCP client."""
+        """Store the resolved local/remote names, the source descriptor, and the shared MCP client."""
         self.name = name
         self.description = description
         self.parameters_schema = parameters_schema
-        self._space_slug = slug
+        self._source_id = source_id
+        self._source_payload_key = _SOURCE_PAYLOAD_KEYS[source_kind]
         self._client_tool_name = client_tool_name
         self._client = client
-        self._registry_source = f"space:{slug}:{client_tool_name}"
+        self._registry_source = f"{source_kind}:{source_id}:{client_tool_name}"
 
     async def __call__(self, deps: ToolDependencies, **kwargs: Any) -> Dict[str, Any]:
         """Invoke the underlying remote MCP tool."""
@@ -129,13 +140,13 @@ class RemoteMcpTool(Tool):
             # Timeout subclasses the retryable error, but retrying it would just double the wait.
             raise
         except McpToolInvocationError as exc:
-            logger.warning("Remote MCP tool failed once; retrying %s from %s: %s", self.name, self._space_slug, exc)
+            logger.warning("Remote MCP tool failed once; retrying %s from %s: %s", self.name, self._source_id, exc)
             await asyncio.sleep(_REMOTE_TOOL_RETRY_DELAY_S)
             result = await self._client.call_tool(self._client_tool_name, kwargs)
         payload = dict(result)
         if payload.get("namespaced_tool_name") == self._client_tool_name:
             payload["namespaced_tool_name"] = self.name
-        payload.setdefault("tool_space_slug", self._space_slug)
+        payload.setdefault(self._source_payload_key, self._source_id)
         return payload
 
 
@@ -319,47 +330,123 @@ def _read_profile_tool_names(instance_path: str | Path | None) -> list[str]:
     return tool_names
 
 
+def _resolve_cached_manifest_tools(
+    tool_names: list[str],
+    *,
+    alias: str,
+    source_kind: RemoteToolSourceKind,
+    source_id: str,
+    source_label: str,
+    refresh_command: str,
+    cached_tools: Sequence["CachedRemoteTool"],
+    make_client: Callable[[], "RemoteMcpToolClient"],
+) -> list[RemoteMcpTool]:
+    """Build the RemoteMcpTool adapters one manifest source contributes to the profile, without network calls."""
+    enabled_tool_names = {name for name in tool_names if name.startswith(f"{alias}__")}
+    if not enabled_tool_names:
+        return []
+
+    discovered_tool_names = {tool.local_name for tool in cached_tools}
+    missing_tool_names = sorted(enabled_tool_names - discovered_tool_names)
+    if missing_tool_names:
+        logger.warning(
+            "Tools enabled from %s are missing from the cached manifest and will be skipped: %s. "
+            "Re-run '%s' to refresh.",
+            source_label,
+            ", ".join(missing_tool_names),
+            refresh_command,
+        )
+
+    try:
+        client = make_client()
+    except Exception as exc:
+        # Registering tools whose every call would fail (e.g. a missing token, or a
+        # bearer token refused over plain HTTP) only hides the problem; skip them
+        # and they load on the next rebuild once the configuration is fixed.
+        logger.warning(
+            "Skipping %d enabled tool(s) from %s: %s",
+            len(enabled_tool_names),
+            source_label,
+            exc,
+        )
+        return []
+
+    remote_tools: list[RemoteMcpTool] = []
+    for remote_tool in cached_tools:
+        if remote_tool.local_name not in enabled_tool_names:
+            continue
+        cache_key = ("remote", f"{source_kind}:{source_id}:{remote_tool.local_name}:{remote_tool.client_tool_name}")
+        cached_tool = _LOADED_REMOTE_TOOL_CACHE.get(cache_key)
+        if cached_tool is None:
+            cached_tool = RemoteMcpTool(
+                source_kind=source_kind,
+                source_id=source_id,
+                name=remote_tool.local_name,
+                description=remote_tool.description,
+                parameters_schema=remote_tool.parameters_schema,
+                client_tool_name=remote_tool.client_tool_name,
+                client=client,
+            )
+            _LOADED_REMOTE_TOOL_CACHE[cache_key] = cached_tool
+        remote_tools.append(cached_tool)
+    return remote_tools
+
+
 def _resolve_remote_tools(tool_names: list[str], instance_path: str | Path | None) -> list[RemoteMcpTool]:
     """Build Space tools enabled by the active profile from the cached install manifest, without any network calls."""
+    try:
+        manifest = read_installed_tool_spaces(instance_path)
+    except RuntimeError as exc:
+        # A corrupt manifest must not take down the whole tool registry at boot.
+        logger.error("Skipping installed tool Spaces: %s", exc)
+        return []
+
     remote_tools: list[RemoteMcpTool] = []
-    for installed_space in read_installed_tool_spaces(instance_path).spaces:
-        enabled_tool_names = {name for name in tool_names if name.startswith(f"{installed_space.alias}__")}
-        if not enabled_tool_names:
-            continue
-
-        discovered_tool_names = {tool.local_name for tool in installed_space.tools}
-        missing_tool_names = sorted(enabled_tool_names - discovered_tool_names)
-        if missing_tool_names:
-            logger.warning(
-                "Tools enabled from '%s' are missing from the install manifest and will be skipped: %s. "
-                "Re-run 'tool-spaces add %s' to refresh.",
-                installed_space.slug,
-                ", ".join(missing_tool_names),
-                installed_space.slug,
+    for installed_space in manifest.spaces:
+        remote_tools.extend(
+            _resolve_cached_manifest_tools(
+                tool_names,
+                alias=installed_space.alias,
+                source_kind="space",
+                source_id=installed_space.slug,
+                source_label=f"Space '{installed_space.slug}'",
+                refresh_command=f"tool-spaces add {installed_space.slug}",
+                cached_tools=installed_space.tools,
+                make_client=partial(
+                    build_remote_client,
+                    installed_space.alias,
+                    installed_space.mcp_url,
+                    private=installed_space.private,
+                    cached_tools=installed_space.tools,
+                ),
             )
-
-        client = build_remote_client(
-            installed_space.alias,
-            installed_space.mcp_url,
-            private=installed_space.private,
-            cached_tools=installed_space.tools,
         )
-        for remote_tool in installed_space.tools:
-            if remote_tool.local_name not in enabled_tool_names:
-                continue
-            cache_key = ("remote", f"{installed_space.slug}:{remote_tool.local_name}:{remote_tool.client_tool_name}")
-            cached_tool = _LOADED_REMOTE_TOOL_CACHE.get(cache_key)
-            if cached_tool is None:
-                cached_tool = RemoteMcpTool(
-                    slug=installed_space.slug,
-                    name=remote_tool.local_name,
-                    description=remote_tool.description,
-                    parameters_schema=remote_tool.parameters_schema,
-                    client_tool_name=remote_tool.client_tool_name,
-                    client=client,
-                )
-                _LOADED_REMOTE_TOOL_CACHE[cache_key] = cached_tool
-            remote_tools.append(cached_tool)
+    return remote_tools
+
+
+def _resolve_generic_mcp_tools(tool_names: list[str], instance_path: str | Path | None) -> list[RemoteMcpTool]:
+    """Build custom MCP server tools enabled by the active profile from the cached manifest, without network calls."""
+    try:
+        manifest = read_mcp_servers(instance_path)
+    except RuntimeError as exc:
+        # A corrupt manifest must not take down the whole tool registry at boot.
+        logger.error("Skipping custom MCP servers: %s", exc)
+        return []
+
+    remote_tools: list[RemoteMcpTool] = []
+    for server in manifest.servers:
+        remote_tools.extend(
+            _resolve_cached_manifest_tools(
+                tool_names,
+                alias=server.alias,
+                source_kind="mcp",
+                source_id=server.alias,
+                source_label=f"MCP server '{server.alias}'",
+                refresh_command=f"mcp-servers add {server.alias} {server.url}",
+                cached_tools=server.tools,
+                make_client=partial(build_generic_remote_client, server),
+            )
+        )
 
     return remote_tools
 
@@ -421,7 +508,10 @@ def initialize_tools(instance_path: str | Path | None = None, *, force: bool = F
             logger.info("Reloading tool registry for active profile/configuration change.")
 
         tool_names = _read_profile_tool_names(effective_instance_path)
-        remote_tools = _resolve_remote_tools(tool_names, effective_instance_path)
+        remote_tools = [
+            *_resolve_remote_tools(tool_names, effective_instance_path),
+            *_resolve_generic_mcp_tools(tool_names, effective_instance_path),
+        ]
         remote_tool_names = {tool.name for tool in remote_tools}
         loaded_tool_classes = _load_enabled_tools(tool_names, remote_tool_names)
         tools = _build_tool_registry(

--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -24,7 +24,7 @@ from reachy_mini_conversation_app.tools.tool_constants import SystemTool
 
 if TYPE_CHECKING:
     from reachy_mini_conversation_app.mcp_client import RemoteMcpToolClient
-    from reachy_mini_conversation_app.remote_tool_sources import CachedRemoteTool
+    from reachy_mini_conversation_app.remote_tool_sources import CachedToolRecord
     from reachy_mini_conversation_app.tools.background_tool_manager import BackgroundToolManager
 
 
@@ -338,7 +338,7 @@ def _resolve_cached_manifest_tools(
     source_id: str,
     source_label: str,
     refresh_command: str,
-    cached_tools: Sequence["CachedRemoteTool"],
+    cached_tools: Sequence["CachedToolRecord"],
     make_client: Callable[[], "RemoteMcpToolClient"],
 ) -> list[RemoteMcpTool]:
     """Build the RemoteMcpTool adapters one manifest source contributes to the profile, without network calls."""
@@ -396,8 +396,9 @@ def _resolve_remote_tools(tool_names: list[str], instance_path: str | Path | Non
     """Build Space tools enabled by the active profile from the cached install manifest, without any network calls."""
     try:
         manifest = read_installed_tool_spaces(instance_path)
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         # A corrupt manifest must not take down the whole tool registry at boot.
+        # ValueError too: the manifest's slug and URL validators raise it directly.
         logger.error("Skipping installed tool Spaces: %s", exc)
         return []
 
@@ -428,7 +429,7 @@ def _resolve_generic_mcp_tools(tool_names: list[str], instance_path: str | Path 
     """Build custom MCP server tools enabled by the active profile from the cached manifest, without network calls."""
     try:
         manifest = read_mcp_servers(instance_path)
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         # A corrupt manifest must not take down the whole tool registry at boot.
         logger.error("Skipping custom MCP servers: %s", exc)
         return []

--- a/src/reachy_mini_conversation_app/utils.py
+++ b/src/reachy_mini_conversation_app/utils.py
@@ -46,6 +46,66 @@ def parse_args() -> tuple[argparse.Namespace, list]:  # type: ignore
     remove_parser.add_argument("space_slug", help="Installed Hugging Face Space slug in the form owner/space-name")
 
     tool_spaces_subparsers.add_parser("list", help="List installed Space tool sources")
+
+    mcp_servers_parser = subparsers.add_parser("mcp-servers", help="Manage custom remote MCP server tool sources")
+    mcp_servers_subparsers = mcp_servers_parser.add_subparsers(dest="mcp_servers_command", required=True)
+
+    mcp_add_parser = mcp_servers_subparsers.add_parser("add", help="Configure one MCP server, or refresh its tools")
+    mcp_add_parser.add_argument("alias", help="Local alias namespacing this server's tools, e.g. my_server")
+    mcp_add_parser.add_argument("url", help="MCP endpoint URL. HTTPS, except on the local network.")
+    mcp_add_parser.add_argument(
+        "--token-env",
+        dest="token_env",
+        default=None,
+        metavar="ENV_VAR",
+        help=(
+            "Name of the environment variable holding this server's bearer token. "
+            "The token value itself is never written to the manifest."
+        ),
+    )
+    mcp_add_parser.add_argument(
+        "--allow-insecure-token",
+        action="store_true",
+        default=False,
+        help=(
+            "Permit sending the bearer token over plain HTTP to a non-loopback host. "
+            "The token is then visible to anyone on the network."
+        ),
+    )
+    mcp_add_parser.add_argument(
+        "--request-timeout",
+        dest="request_timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Timeout for discovery requests (default: 10).",
+    )
+    mcp_add_parser.add_argument(
+        "--tool-timeout",
+        dest="tool_timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="Timeout for tool calls (default: 30).",
+    )
+    mcp_add_parser.add_argument(
+        "--install-only",
+        action="store_true",
+        default=False,
+        help="Configure the server without enabling its tools in any profile.",
+    )
+    mcp_add_parser.add_argument(
+        "--profile",
+        dest="profile",
+        default=None,
+        metavar="PROFILE",
+        help="Enable tools in this profile instead of the active profile.",
+    )
+
+    mcp_remove_parser = mcp_servers_subparsers.add_parser("remove", help="Remove one configured MCP server")
+    mcp_remove_parser.add_argument("alias", help="Alias of the configured MCP server")
+
+    mcp_servers_subparsers.add_parser("list", help="List configured MCP servers")
     return parser.parse_known_args()
 
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -852,3 +852,53 @@ def test_rpc_settings_methods() -> None:
     assert isinstance(r2["result"], list)
     assert "spaces" in r3["result"]
     assert "enabled_tools" in r4["result"]
+
+
+def test_persist_env_values_round_trips_special_characters_through_dotenv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Values with `#`, quotes, or spaces must survive a python-dotenv reload of the .env."""
+    import os
+
+    from dotenv import dotenv_values
+
+    token_env = "MCP_CONSOLE_QUOTED_TOKEN"
+    monkeypatch.setenv(token_env, "")
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    stream = LocalStream(MagicMock(), robot, settings_app=FastAPI(), instance_path=str(tmp_path))
+
+    token = 'abc #123 it\'s "fine"'
+    assert stream._persist_env_values({token_env: token}) == "persisted"
+    assert os.environ[token_env] == token
+    assert dotenv_values(tmp_path / ".env")[token_env] == token
+
+    # python-dotenv interpolates ${VAR} in every quoting style, with no escape syntax.
+    with pytest.raises(ValueError):
+        stream._persist_env_values({token_env: "abc${HOME}def"})
+
+
+def test_backend_config_rejects_hf_host_with_line_break(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host carrying a line break would inject extra assignments into the instance .env."""
+    monkeypatch.setattr(config, "HF_REALTIME_CONNECTION_MODE", "deployed")
+    monkeypatch.setattr(config, "HF_REALTIME_SESSION_URL", None)
+    monkeypatch.setattr(config, "HF_REALTIME_WS_URL", None)
+
+    app = FastAPI()
+    robot = SimpleNamespace(media=SimpleNamespace(audio=None, backend=None))
+    stream = LocalStream(MagicMock(), robot, settings_app=app, instance_path=str(tmp_path))
+    stream._init_settings_ui_if_needed()
+
+    resp = _rpc_call(
+        app,
+        "backend.config",
+        {"backend": "huggingface", "hf_mode": "local", "hf_host": "host\nSOME_OTHER_VAR=1", "hf_port": 8765},
+    )
+
+    assert resp["error"]["data"]["reason"] == "invalid_hf_host"
+    env_path = tmp_path / ".env"
+    written = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    assert "SOME_OTHER_VAR" not in written

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -3,16 +3,68 @@ from __future__ import annotations
 import pytest
 
 
-pytest.importorskip("mcp.types")
+pytest.importorskip("mcp_types")
 
-from mcp.types import Tool, TextContent, CallToolResult
+from mcp_types import Tool, TextContent, CallToolResult
 
 from reachy_mini_conversation_app.mcp_client import (
     RemoteToolSpec,
+    RemoteMcpServerConfig,
     RemoteToolCallResponse,
     validate_http_mcp_url,
     build_namespaced_tool_name,
 )
+
+
+def test_server_config_refuses_credentials_over_plain_http_to_lan_host() -> None:
+    """The config is the last line of defense: no credential header may ride plain HTTP off-machine without an explicit opt-in."""
+    with pytest.raises(ValueError, match="credentials over plain HTTP"):
+        RemoteMcpServerConfig(
+            alias="example",
+            url="http://192.168.1.50:8000/mcp",
+            headers={"Authorization": "Bearer secret"},
+        )
+
+
+def test_server_config_allows_credentials_over_plain_http_with_opt_in_or_loopback() -> None:
+    """The explicit opt-in and loopback hosts keep credentialed plain-HTTP configs buildable."""
+    RemoteMcpServerConfig(
+        alias="example",
+        url="http://192.168.1.50:8000/mcp",
+        headers={"Authorization": "Bearer secret"},
+        allow_insecure_http=True,
+    )
+    RemoteMcpServerConfig(
+        alias="example",
+        url="http://127.0.0.1:8000/mcp",
+        headers={"Authorization": "Bearer secret"},
+    )
+    RemoteMcpServerConfig(alias="example", url="http://192.168.1.50:8000/mcp")
+
+
+def test_server_config_requires_opt_in_for_credentials_on_localhost_subdomains() -> None:
+    """RFC 6761 loopback-pinning of '*.localhost' is only a SHOULD, so credentials over plain HTTP to a subdomain need the explicit opt-in."""
+    with pytest.raises(ValueError, match="credentials over plain HTTP"):
+        RemoteMcpServerConfig(
+            alias="example",
+            url="http://dev.localhost:8000/mcp",
+            headers={"Authorization": "Bearer secret"},
+        )
+    RemoteMcpServerConfig(
+        alias="example",
+        url="http://dev.localhost:8000/mcp",
+        headers={"Authorization": "Bearer secret"},
+        allow_insecure_http=True,
+    )
+
+
+def test_alias_rejects_namespace_ambiguous_forms() -> None:
+    """An alias containing '__' or ending in '_' blurs the namespace separator, letting one server's removal strip a sibling's tools."""
+    for bad_alias in ("ha_", "h__a"):
+        with pytest.raises(ValueError, match="Aliases cannot"):
+            build_namespaced_tool_name(bad_alias, "light")
+        with pytest.raises(ValueError, match="Aliases cannot"):
+            RemoteMcpServerConfig(alias=bad_alias, url="http://127.0.0.1:8000/mcp")
 
 
 def test_validate_http_mcp_url_rejects_non_http_scheme() -> None:
@@ -27,6 +79,45 @@ def test_validate_http_mcp_url_rejects_non_local_plain_http() -> None:
         validate_http_mcp_url("http://example.com/mcp")
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8000/mcp",
+        "http://localhost:8000/mcp",
+        "http://dev.localhost:8000/mcp",
+        "http://[::1]:8000/mcp",
+        "http://192.168.1.50:8000/mcp",
+        "http://169.254.10.10/mcp",
+        "http://my-mcp-server.local:8000/mcp",
+        "https://example.com/mcp",
+    ],
+)
+def test_validate_http_mcp_url_accepts_local_network_endpoints(url: str) -> None:
+    """Plain HTTP is fine on the local network (loopback, private, link-local, mDNS); HTTPS always is."""
+    assert validate_http_mcp_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://8.8.8.8/mcp",
+        "http://my-server.example.org:8000/mcp",
+        "http://intranet-host:8000/mcp",
+    ],
+)
+def test_validate_http_mcp_url_rejects_public_plain_http(url: str) -> None:
+    """Plain HTTP to public IPs or unresolvable-name hosts is rejected (the plain public-name case is covered above)."""
+    with pytest.raises(ValueError, match="must use HTTPS"):
+        validate_http_mcp_url(url)
+
+
+def test_validate_http_mcp_url_classifies_ipv4_mapped_ipv6_by_embedded_address() -> None:
+    """A mapped public address must not slip through is_private (CVE-2024-4032, is_private true for all of ::ffff:0:0/96 before 3.11.10/3.12.4)."""
+    with pytest.raises(ValueError, match="must use HTTPS"):
+        validate_http_mcp_url("http://[::ffff:8.8.8.8]/mcp")
+    assert validate_http_mcp_url("http://[::ffff:192.168.1.50]/mcp")
+
+
 def test_build_namespaced_tool_name_normalizes_tool_segment() -> None:
     """Remote tool names are normalized into app-safe tool IDs."""
     assert build_namespaced_tool_name("gradio_docs", "search-docs") == "gradio_docs__search_docs"
@@ -37,7 +128,7 @@ def test_remote_tool_spec_translates_to_function_spec() -> None:
     tool = Tool(
         name="search-docs",
         description="Search the docs",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"query": {"type": "string"}},
             "required": ["query"],
@@ -64,8 +155,8 @@ def test_remote_tool_error_result_maps_to_app_payload() -> None:
     """Remote tool errors should remain visible after response mapping."""
     result = CallToolResult(
         content=[TextContent(type="text", text="Search backend unavailable")],
-        structuredContent=None,
-        isError=True,
+        structured_content=None,
+        is_error=True,
     )
 
     payload = RemoteToolCallResponse.from_call_tool_result(

--- a/tests/test_mcp_client_integration.py
+++ b/tests/test_mcp_client_integration.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 import asyncio
-from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 
 import pytest
 import uvicorn
 import pytest_asyncio
-from starlette.routing import Mount
 from starlette.responses import PlainTextResponse
-from starlette.applications import Starlette
 
 
-pytest.importorskip("mcp.server.fastmcp")
+pytest.importorskip("mcp.server")
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from reachy_mini_conversation_app.mcp_client import (
     RemoteToolSpec,
@@ -41,7 +38,7 @@ class _BearerAuthMiddleware:
 
 
 def _build_local_mcp_app(required_token: str) -> object:
-    mcp_server = FastMCP("Reachy Test MCP", stateless_http=True, json_response=True)
+    mcp_server = MCPServer("Reachy Test MCP")
 
     @mcp_server.tool()
     def echo_text(message: str) -> dict[str, str]:
@@ -54,14 +51,7 @@ def _build_local_mcp_app(required_token: str) -> object:
         await asyncio.sleep(delay_s)
         return {"echo": message}
 
-    mcp_app = mcp_server.streamable_http_app()
-
-    @asynccontextmanager
-    async def lifespan(_: Starlette) -> AsyncIterator[None]:
-        async with mcp_server.session_manager.run():
-            yield
-
-    app = Starlette(routes=[Mount("/", app=mcp_app)], lifespan=lifespan)
+    app = mcp_server.streamable_http_app(json_response=True, stateless_http=True)
     return _BearerAuthMiddleware(app, required_token)
 
 
@@ -201,3 +191,53 @@ async def test_remote_mcp_tool_client_discovers_calls_and_handles_timeout(
     )
     with pytest.raises(McpTransportError, match="Failed to discover MCP tools"):
         await unauthorized_client.list_tool_specs()
+
+
+@pytest.mark.asyncio
+async def test_mcp_servers_add_caches_tools_then_calls_without_discovery(
+    local_mcp_server: tuple[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: object,
+) -> None:
+    """Full generic-server flow: add discovers and caches tools, later calls run from the cache."""
+    from argparse import Namespace
+
+    from reachy_mini_conversation_app.mcp_servers import (
+        read_mcp_servers,
+        handle_mcp_servers_command,
+        build_generic_remote_client,
+    )
+
+    server_url, token = local_mcp_server
+    token_env = "MCP_INTEGRATION_TEST_TOKEN"
+    monkeypatch.setenv(token_env, token)
+
+    args = Namespace(
+        mcp_servers_command="add",
+        alias="local_test",
+        url=server_url,
+        token_env=token_env,
+        request_timeout=2.0,
+        tool_timeout=2.0,
+        install_only=True,
+        profile=None,
+    )
+    # handle_mcp_servers_command drives its own event loop; keep it off this test's loop.
+    exit_code = await asyncio.to_thread(handle_mcp_servers_command, args, instance_path=tmp_path)
+    assert exit_code == 0
+
+    manifest = read_mcp_servers(tmp_path)
+    assert [server.alias for server in manifest.servers] == ["local_test"]
+    cached_names = sorted(tool.local_name for tool in manifest.servers[0].tools)
+    assert cached_names == ["local_test__echo_text", "local_test__slow_echo"]
+
+    client = build_generic_remote_client(manifest.servers[0])
+
+    async def _fail_list_tool_specs() -> list[RemoteToolSpec]:
+        raise AssertionError("calls must run from the cached specs, not re-discovery")
+
+    monkeypatch.setattr(client, "list_tool_specs", _fail_list_tool_specs)
+
+    result = await client.call_tool("local_test__echo_text", {"message": "hello"})
+    assert result["status"] == "ok"
+    assert result["structured_content"] == {"echo": "hello"}

--- a/tests/test_mcp_server_routes.py
+++ b/tests/test_mcp_server_routes.py
@@ -1,0 +1,351 @@
+"""Tests for the custom MCP server management methods."""
+
+import dataclasses
+from typing import Any
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from reachy_mini.apps.jsonrpc_server import JsonRpcServer
+from reachy_mini_conversation_app.config import config
+from reachy_mini_conversation_app.mcp_servers import (
+    McpServerAuth,
+    InstalledMcpServer,
+    InstalledMcpServersManifest,
+    read_mcp_servers,
+    write_mcp_servers,
+)
+from reachy_mini_conversation_app.tool_spaces import InstalledToolSpacesManifest, write_installed_tool_spaces
+from reachy_mini_conversation_app.profile_store import write_profile
+from reachy_mini_conversation_app.profile_toolsets import read_profile_tool_names
+from reachy_mini_conversation_app.mcp_server_routes import register_mcp_server_methods
+from reachy_mini_conversation_app.remote_tool_sources import CachedRemoteTool
+
+
+SERVER_ALIAS = "acme"
+SERVER_URL = "https://mcp.example.com/mcp"
+TOOL_NAME = f"{SERVER_ALIAS}__ping"
+TOKEN_ENV = "ACME_MCP_TOKEN"
+
+
+def _resolved_server(auth: McpServerAuth | None = None) -> InstalledMcpServer:
+    return InstalledMcpServer(
+        alias=SERVER_ALIAS,
+        url=SERVER_URL,
+        auth=auth,
+        tools=[
+            CachedRemoteTool(
+                local_name=TOOL_NAME,
+                client_tool_name=TOOL_NAME,
+                remote_name="ping",
+                description="Ping the server",
+                parameters_schema={"type": "object", "properties": {}, "required": []},
+            )
+        ],
+    )
+
+
+def _configure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    instance_path = tmp_path / "instance"
+    profiles_root = tmp_path / "profiles"
+    write_profile("default", profiles_root / "default", "Default profile.", ["dance"])
+    write_installed_tool_spaces(instance_path, InstalledToolSpacesManifest(spaces=[]))
+    monkeypatch.setattr(config, "PROFILES_DIRECTORY", profiles_root)
+    monkeypatch.setattr("reachy_mini_conversation_app.profile_store.DEFAULT_PROFILES_DIRECTORY", profiles_root)
+    monkeypatch.setattr(config, "REACHY_MINI_CUSTOM_PROFILE", None)
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.mcp_servers.resolve_mcp_server_sync",
+        lambda server: dataclasses.replace(server, tools=_resolved_server().tools),
+    )
+    return instance_path
+
+
+def _rpc_call(client: TestClient, method: str, params: dict[str, object] | None = None) -> dict[str, Any]:
+    with client.websocket_connect("/rpc") as websocket:
+        websocket.send_json({"jsonrpc": "2.0", "id": "1", "method": method, "params": params or {}})
+        response: dict[str, Any] = websocket.receive_json()
+        return response
+
+
+def _mount_rpc(
+    instance_path: Path | None,
+    persist_env_values: Any = None,
+    get_loop: MagicMock | None = None,
+    restart_conversation: AsyncMock | None = None,
+) -> TestClient:
+    app = FastAPI()
+    rpc = JsonRpcServer()
+    register_mcp_server_methods(
+        rpc,
+        get_loop or MagicMock(return_value=None),
+        restart_conversation or AsyncMock(),
+        persist_env_values or (lambda updates: "persisted"),
+        instance_path=instance_path,
+    )
+    rpc.mount(app)
+    return TestClient(app)
+
+
+def test_add_list_remove_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adding a server publishes it to the inventory without enabling its tools anywhere."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    client = _mount_rpc(instance_path)
+
+    added = _rpc_call(client, "mcp_servers.add", {"alias": SERVER_ALIAS, "url": SERVER_URL})["result"]
+    assert added["servers"] == [
+        {
+            "alias": SERVER_ALIAS,
+            "url": SERVER_URL,
+            "tool_count": 1,
+            "token_env": None,
+            "token_set": False,
+        }
+    ]
+    assert "ready to assign to personalities" in added["message"]
+    # install_only: the tool exists in the inventory but no profile enables it yet.
+    assert TOOL_NAME not in read_profile_tool_names("default", instance_path)
+    assert _rpc_call(client, "mcp_servers.list")["result"]["servers"] == added["servers"]
+
+    removed = _rpc_call(client, "mcp_servers.remove", {"alias": SERVER_ALIAS})["result"]
+    assert removed["servers"] == []
+    assert read_mcp_servers(instance_path).servers == []
+
+
+def test_add_reports_token_requirement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A server configured with a token variable reports whether that variable is set."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    client = _mount_rpc(instance_path)
+
+    added = _rpc_call(
+        client,
+        "mcp_servers.add",
+        {"alias": SERVER_ALIAS, "url": SERVER_URL, "token_env": TOKEN_ENV},
+    )["result"]
+    assert added["servers"][0]["token_env"] == TOKEN_ENV
+    assert added["servers"][0]["token_set"] is False
+
+    monkeypatch.setenv(TOKEN_ENV, "a-real-token")
+    assert _rpc_call(client, "mcp_servers.list")["result"]["servers"][0]["token_set"] is True
+
+
+def test_save_token_persists_and_rebuilds_the_registry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Saving a token writes the named variable and reloads tools, since a client reads its token when built."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    saved: dict[str, str] = {}
+
+    def _persist(updates: dict[str, str]) -> str:
+        saved.update(updates)
+        monkeypatch.setenv(TOKEN_ENV, updates[TOKEN_ENV])
+        return "persisted"
+
+    initialized: list[bool] = []
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_settings.initialize_tools",
+        lambda instance_path=None, force=False: initialized.append(force),
+    )
+    client = _mount_rpc(instance_path, persist_env_values=_persist)
+    write_mcp_servers(
+        instance_path,
+        InstalledMcpServersManifest(
+            servers=[_resolved_server(auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV))]
+        ),
+    )
+
+    response = _rpc_call(client, "mcp_servers.save_token", {"alias": SERVER_ALIAS, "token": "s3cr#t"})["result"]
+    assert saved == {TOKEN_ENV: "s3cr#t"}
+    assert response["servers"][0]["token_set"] is True
+    assert initialized == [True]
+
+
+@pytest.mark.parametrize(
+    ("params", "reason"),
+    [
+        pytest.param({"alias": SERVER_ALIAS, "token": "   "}, "empty_token", id="blank-token"),
+        pytest.param({"alias": SERVER_ALIAS}, "empty_token", id="missing-token"),
+        pytest.param({"alias": "", "token": "x"}, "invalid_mcp_alias", id="blank-alias"),
+        pytest.param({"alias": "nope", "token": "x"}, "unknown_mcp_server", id="unconfigured-server"),
+    ],
+)
+def test_save_token_rejects_bad_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, object],
+    reason: str,
+) -> None:
+    """Bad token saves fail with a stable reason instead of writing anything."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    saved: dict[str, str] = {}
+    client = _mount_rpc(instance_path, persist_env_values=lambda updates: saved.update(updates) or "persisted")
+    write_mcp_servers(
+        instance_path,
+        InstalledMcpServersManifest(
+            servers=[_resolved_server(auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV))]
+        ),
+    )
+
+    assert _rpc_call(client, "mcp_servers.save_token", params)["error"]["data"]["reason"] == reason
+    assert saved == {}
+
+
+def test_save_token_reports_a_value_that_cannot_round_trip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token the instance `.env` cannot represent is refused with actionable copy."""
+    instance_path = _configure(tmp_path, monkeypatch)
+
+    def _refuse(updates: dict[str, str]) -> str:
+        raise ValueError("Values must not contain line breaks or '${'.")
+
+    client = _mount_rpc(instance_path, persist_env_values=_refuse)
+    write_mcp_servers(
+        instance_path,
+        InstalledMcpServersManifest(
+            servers=[_resolved_server(auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV))]
+        ),
+    )
+
+    error = _rpc_call(client, "mcp_servers.save_token", {"alias": SERVER_ALIAS, "token": "a\nb"})["error"]
+    assert error["data"]["reason"] == "invalid_token"
+
+
+def test_save_token_warns_when_it_could_not_be_persisted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token applied to the process but not written to disk must say it will not survive a restart."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    client = _mount_rpc(instance_path, persist_env_values=lambda updates: "failed")
+    write_mcp_servers(
+        instance_path,
+        InstalledMcpServersManifest(
+            servers=[_resolved_server(auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV))]
+        ),
+    )
+
+    message = _rpc_call(client, "mcp_servers.save_token", {"alias": SERVER_ALIAS, "token": "x"})["result"]["message"]
+    assert "will not survive a restart" in message
+
+
+def test_save_token_reports_session_only_in_terminal_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no managed instance there is no `.env` to write, so the token lasts for the session only."""
+    _configure(tmp_path, monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    client = _mount_rpc(None, persist_env_values=lambda updates: "session")
+    write_mcp_servers(
+        None,
+        InstalledMcpServersManifest(
+            servers=[_resolved_server(auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV))]
+        ),
+    )
+
+    message = _rpc_call(client, "mcp_servers.save_token", {"alias": SERVER_ALIAS, "token": "x"})["result"]["message"]
+    assert "for this session" in message
+
+
+def test_list_reports_an_unreadable_manifest_instead_of_an_empty_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A damaged manifest must surface as an error, not as 'no servers configured'."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    instance_path.mkdir(parents=True, exist_ok=True)
+    (instance_path / "mcp_servers.json").write_text("{not valid json", encoding="utf-8")
+    client = _mount_rpc(instance_path)
+
+    error = _rpc_call(client, "mcp_servers.list")["error"]
+    assert error["data"]["reason"] == "mcp_servers_unavailable"
+
+
+@pytest.mark.parametrize(
+    ("params", "reason"),
+    [
+        pytest.param({"url": SERVER_URL}, "invalid_mcp_alias", id="missing-alias"),
+        pytest.param({"alias": SERVER_ALIAS}, "invalid_mcp_url", id="missing-url"),
+        pytest.param({"alias": "bad__alias", "url": SERVER_URL}, "invalid_mcp_server", id="ambiguous-alias"),
+        pytest.param(
+            {"alias": SERVER_ALIAS, "url": "http://example.com/mcp"},
+            "invalid_mcp_server",
+            id="public-plain-http",
+        ),
+        pytest.param(
+            {"alias": SERVER_ALIAS, "url": SERVER_URL, "token_env": "BAD NAME"},
+            "invalid_mcp_token_env",
+            id="invalid-token-env",
+        ),
+        pytest.param(
+            {"alias": SERVER_ALIAS, "url": SERVER_URL, "request_timeout_s": 0},
+            "invalid_mcp_timeout",
+            id="non-positive-timeout",
+        ),
+    ],
+)
+def test_add_rejects_invalid_input_without_persisting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    params: dict[str, object],
+    reason: str,
+) -> None:
+    """Invalid configuration is refused with a stable reason and nothing is written."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    client = _mount_rpc(instance_path)
+
+    assert _rpc_call(client, "mcp_servers.add", params)["error"]["data"]["reason"] == reason
+    assert read_mcp_servers(instance_path).servers == []
+
+
+def test_add_rejects_an_alias_already_claimed_by_a_space(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aliases namespace tool IDs across both sources, so a cross-source collision is refused."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.mcp_servers._space_aliases",
+        lambda path: {SERVER_ALIAS},
+    )
+    client = _mount_rpc(instance_path)
+
+    error = _rpc_call(client, "mcp_servers.add", {"alias": SERVER_ALIAS, "url": SERVER_URL})["error"]
+    assert error["data"]["reason"] == "mcp_server_alias_conflict"
+    assert read_mcp_servers(instance_path).servers == []
+
+
+def test_remove_rejects_a_server_that_is_not_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removing an unknown alias reports it rather than silently succeeding."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    client = _mount_rpc(instance_path)
+
+    error = _rpc_call(client, "mcp_servers.remove", {"alias": "ghost"})["error"]
+    assert error["data"]["reason"] == "mcp_server_not_configured"
+
+
+def test_locked_mode_exposes_the_inventory_but_rejects_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A locked profile may read the server list but may not change it."""
+    instance_path = _configure(tmp_path, monkeypatch)
+    monkeypatch.setattr("reachy_mini_conversation_app.mcp_server_routes.LOCKED_PROFILE", "kiosk")
+    client = _mount_rpc(instance_path)
+
+    assert _rpc_call(client, "mcp_servers.list")["result"]["editable"] is False
+    for method, params in (
+        ("mcp_servers.add", {"alias": SERVER_ALIAS, "url": SERVER_URL}),
+        ("mcp_servers.remove", {"alias": SERVER_ALIAS}),
+        ("mcp_servers.save_token", {"alias": SERVER_ALIAS, "token": "x"}),
+    ):
+        assert _rpc_call(client, method, params)["error"]["data"]["reason"] == "profile_locked"

--- a/tests/test_mcp_server_runtime.py
+++ b/tests/test_mcp_server_runtime.py
@@ -1,0 +1,309 @@
+import sys
+import json
+import importlib
+from types import ModuleType
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+import reachy_mini_conversation_app.config as config_mod
+import reachy_mini_conversation_app.mcp_servers as mcp_servers_mod
+from reachy_mini_conversation_app.mcp_servers import (
+    McpServerAuth,
+    InstalledMcpServer,
+    InstalledMcpServersManifest,
+    write_mcp_servers,
+)
+from reachy_mini_conversation_app.tool_spaces import (
+    InstalledToolSpace,
+    InstalledToolSpacesManifest,
+    write_installed_tool_spaces,
+)
+from reachy_mini_conversation_app.profile_store import write_profile
+from reachy_mini_conversation_app.remote_tool_sources import CachedRemoteTool
+
+
+SERVER_ALIAS = "example"
+SERVER_URL = "http://192.168.1.50:8000/mcp"
+TOOL_ID = f"{SERVER_ALIAS}__do_thing"
+TOKEN_ENV = "MCP_SERVER_RUNTIME_TOKEN"
+
+
+def _reload_core_tools() -> ModuleType:
+    for module_name in list(sys.modules):
+        if module_name.startswith("reachy_mini_conversation_app.tools."):
+            sys.modules.pop(module_name, None)
+
+    sys.modules.pop("reachy_mini_conversation_app.tools.core_tools", None)
+    return importlib.import_module("reachy_mini_conversation_app.tools.core_tools")
+
+
+def _installed_server(auth: McpServerAuth | None = None) -> InstalledMcpServer:
+    return InstalledMcpServer(
+        alias=SERVER_ALIAS,
+        url=SERVER_URL,
+        auth=auth,
+        tools=[
+            CachedRemoteTool(
+                local_name=TOOL_ID,
+                client_tool_name=TOOL_ID,
+                remote_name="do_thing",
+                description="Remote tool do_thing",
+                parameters_schema={
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                },
+            )
+        ],
+    )
+
+
+def _profile_enabling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile_name: str,
+    tool_ids: list[str],
+) -> None:
+    """Point config at an external profile whose authored defaults enable tool_ids."""
+    external_profiles_root = tmp_path / "external_profiles"
+    write_profile(profile_name, external_profiles_root / profile_name, "hello", tool_ids)
+    monkeypatch.setattr(config_mod.config, "REACHY_MINI_CUSTOM_PROFILE", profile_name)
+    monkeypatch.setattr(config_mod.config, "PROFILES_DIRECTORY", external_profiles_root)
+    monkeypatch.setattr(config_mod.config, "TOOLS_DIRECTORY", None)
+    monkeypatch.setattr(config_mod.config, "AUTOLOAD_EXTERNAL_TOOLS", False)
+
+
+def _mcp_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _profile_enabling(tmp_path, monkeypatch, "mcp_profile", [TOOL_ID])
+
+
+@pytest.mark.asyncio
+async def test_initialize_tools_loads_enabled_generic_mcp_tools_and_dispatches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enabled generic MCP server tools should register from the cached manifest and dispatch."""
+    monkeypatch.chdir(tmp_path)
+    _mcp_profile(tmp_path, monkeypatch)
+
+    client = AsyncMock()
+    client.call_tool.return_value = {
+        "status": "ok",
+        "server_alias": SERVER_ALIAS,
+        "remote_tool_name": "do_thing",
+        "namespaced_tool_name": TOOL_ID,
+        "content_blocks": [],
+        "text": "hello",
+    }
+    captured_servers: list[InstalledMcpServer] = []
+
+    def _build_generic_remote_client(server: InstalledMcpServer) -> AsyncMock:
+        captured_servers.append(server)
+        return client
+
+    monkeypatch.setattr(mcp_servers_mod, "build_generic_remote_client", _build_generic_remote_client)
+
+    write_mcp_servers(None, InstalledMcpServersManifest(servers=[_installed_server()]))
+
+    core_tools_mod = _reload_core_tools()
+    core_tools_mod.initialize_tools()
+
+    assert TOOL_ID in core_tools_mod.ALL_TOOLS
+    assert [server.alias for server in captured_servers] == [SERVER_ALIAS]
+    assert captured_servers[0].tools == _installed_server().tools
+    assert any(spec["name"] == TOOL_ID for spec in core_tools_mod.get_tool_specs())
+
+    result = await core_tools_mod.dispatch_tool_call(
+        TOOL_ID,
+        json.dumps({"message": "hello"}),
+        core_tools_mod.ToolDependencies(
+            reachy_mini=object(),
+            movement_manager=object(),
+        ),
+    )
+
+    assert result["namespaced_tool_name"] == TOOL_ID
+    assert result["mcp_server_alias"] == SERVER_ALIAS
+    assert "tool_space_slug" not in result
+    client.call_tool.assert_awaited_once_with(TOOL_ID, {"message": "hello"})
+
+
+def test_initialize_tools_skips_generic_tools_with_missing_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A missing bearer token skips the server's tools with a warning: registering tools whose every call would fail unauthenticated only hides the problem."""
+    monkeypatch.chdir(tmp_path)
+    _mcp_profile(tmp_path, monkeypatch)
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+
+    write_mcp_servers(
+        None,
+        InstalledMcpServersManifest(
+            servers=[_installed_server(auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV))]
+        ),
+    )
+
+    core_tools_mod = _reload_core_tools()
+    with caplog.at_level("WARNING"):
+        core_tools_mod.initialize_tools()
+
+    assert TOOL_ID not in core_tools_mod.ALL_TOOLS
+    assert any(TOKEN_ENV in record.getMessage() for record in caplog.records)
+
+
+def test_initialize_tools_warns_when_enabled_generic_tool_missing_from_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A tool enabled in the profile but absent from the cached manifest is skipped with a refresh hint."""
+    monkeypatch.chdir(tmp_path)
+    _mcp_profile(tmp_path, monkeypatch)
+
+    write_mcp_servers(
+        None,
+        InstalledMcpServersManifest(servers=[InstalledMcpServer(alias=SERVER_ALIAS, url=SERVER_URL)]),
+    )
+
+    core_tools_mod = _reload_core_tools()
+    with caplog.at_level("WARNING"):
+        core_tools_mod.initialize_tools()
+
+    assert TOOL_ID not in core_tools_mod.ALL_TOOLS
+    assert any("mcp-servers add" in record.message for record in caplog.records)
+
+
+def test_initialize_tools_skips_generic_servers_on_corrupt_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A corrupt mcp_servers.json must not take down the whole tool registry at boot."""
+    monkeypatch.chdir(tmp_path)
+    _mcp_profile(tmp_path, monkeypatch)
+
+    manifest_path = tmp_path / "external_content" / "mcp_servers.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text("{not valid json", encoding="utf-8")
+
+    core_tools_mod = _reload_core_tools()
+    with caplog.at_level("ERROR"):
+        core_tools_mod.initialize_tools()
+
+    assert TOOL_ID not in core_tools_mod.ALL_TOOLS
+    assert any("mcp_servers.json" in record.getMessage() for record in caplog.records)
+
+
+def test_initialize_tools_skips_spaces_on_corrupt_manifest_but_keeps_generic_servers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A corrupt installed_tool_spaces.json must not take down the registry: generic MCP tools still load."""
+    monkeypatch.chdir(tmp_path)
+    _mcp_profile(tmp_path, monkeypatch)
+
+    spaces_path = tmp_path / "external_content" / "installed_tool_spaces.json"
+    spaces_path.parent.mkdir(parents=True, exist_ok=True)
+    spaces_path.write_text("{not valid json", encoding="utf-8")
+    write_mcp_servers(None, InstalledMcpServersManifest(servers=[_installed_server()]))
+
+    core_tools_mod = _reload_core_tools()
+    with caplog.at_level("ERROR"):
+        core_tools_mod.initialize_tools()
+
+    assert TOOL_ID in core_tools_mod.ALL_TOOLS
+    assert any("installed_tool_spaces.json" in record.getMessage() for record in caplog.records)
+
+
+def test_initialize_tools_fails_on_name_collision_between_space_and_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Space tool and a generic server tool claiming the same local name must hard-fail.
+
+    The add-time guards prevent this alias overlap, but manifests edited by hand can
+    still collide; the registry is the backstop.
+    """
+    monkeypatch.chdir(tmp_path)
+    # Both sources claim the alias "owner_example" (the Space's alias derives from its slug),
+    # so the same enabled tool ID resolves through both.
+    colliding_alias = "owner_example"
+    colliding_tool_id = f"{colliding_alias}__do_thing"
+
+    _profile_enabling(tmp_path, monkeypatch, "collision_profile", [colliding_tool_id])
+
+    colliding_tool = CachedRemoteTool(
+        local_name=colliding_tool_id,
+        client_tool_name=colliding_tool_id,
+        remote_name="do_thing",
+        description="Colliding tool",
+        parameters_schema={},
+    )
+    write_installed_tool_spaces(
+        None,
+        InstalledToolSpacesManifest(
+            spaces=[
+                InstalledToolSpace(
+                    slug="owner/example",
+                    alias=colliding_alias,
+                    mcp_url="https://owner-example.hf.space/gradio_api/mcp/",
+                    private=False,
+                    tools=[colliding_tool],
+                )
+            ]
+        ),
+    )
+    write_mcp_servers(
+        None,
+        InstalledMcpServersManifest(
+            servers=[InstalledMcpServer(alias=colliding_alias, url=SERVER_URL, tools=[colliding_tool])]
+        ),
+    )
+
+    core_tools_mod = _reload_core_tools()
+    with pytest.raises(RuntimeError, match="Duplicate Tool.name"):
+        core_tools_mod.initialize_tools()
+
+
+def test_initialize_tools_survives_a_spaces_manifest_with_an_invalid_slug(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The Space manifest validators raise ValueError, not RuntimeError, so the registry must tolerate both."""
+    monkeypatch.chdir(tmp_path)
+    _mcp_profile(tmp_path, monkeypatch)
+
+    spaces_path = tmp_path / "external_content" / "installed_tool_spaces.json"
+    spaces_path.parent.mkdir(parents=True, exist_ok=True)
+    spaces_path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "spaces": [
+                    {
+                        "slug": "not a valid slug!",
+                        "alias": "x",
+                        "mcp_url": "https://x-y.hf.space/gradio_api/mcp/",
+                        "private": False,
+                        "tools": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    write_mcp_servers(None, InstalledMcpServersManifest(servers=[_installed_server()]))
+
+    core_tools_mod = _reload_core_tools()
+    with caplog.at_level("ERROR"):
+        core_tools_mod.initialize_tools()
+
+    # The bad Space is skipped, and the unrelated MCP server still registers.
+    assert any("Skipping installed tool Spaces" in record.getMessage() for record in caplog.records)
+    assert TOOL_ID in core_tools_mod.ALL_TOOLS

--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -1,0 +1,719 @@
+import sys
+import json
+from types import SimpleNamespace
+from pathlib import Path
+from argparse import Namespace
+
+import pytest
+
+import reachy_mini_conversation_app.config as config_mod
+from reachy_mini_conversation_app.main import main
+from reachy_mini_conversation_app.mcp_client import RemoteToolSpec
+from reachy_mini_conversation_app.mcp_servers import (
+    McpServerAuth,
+    InstalledMcpServer,
+    InstalledMcpServersManifest,
+    read_mcp_servers,
+    write_mcp_servers,
+    _resolve_auth_headers,
+    find_server_token_env,
+    list_token_requirements,
+    handle_mcp_servers_command,
+    build_generic_remote_client,
+)
+from reachy_mini_conversation_app.tool_spaces import (
+    InstalledToolSpace,
+    InstalledToolSpacesManifest,
+    write_installed_tool_spaces,
+)
+from reachy_mini_conversation_app.profile_store import write_profile
+from reachy_mini_conversation_app.profile_toolsets import read_profile_tool_names
+from reachy_mini_conversation_app.remote_tool_sources import CachedRemoteTool
+
+
+SERVER_ALIAS = "example"
+SERVER_URL = "http://192.168.1.50:8000/mcp"
+OTHER_SERVER_URL = "http://192.168.1.51:8000/mcp"
+# Bearer tokens are only allowed over plain HTTP when the host is loopback.
+LOOPBACK_SERVER_URL = "http://127.0.0.1:8000/mcp"
+TOOL_ID = f"{SERVER_ALIAS}__do_thing"
+TOKEN_ENV = "MCP_SERVER_TOKEN_EXAMPLE"
+
+# Alias derived from this slug collides with the MCP server alias used in cross-source tests.
+SPACE_SLUG = "example/search-tool"
+SPACE_ALIAS = "example_search_tool"
+
+
+def _remote_spec(alias: str, remote_name: str = "do_thing") -> RemoteToolSpec:
+    return RemoteToolSpec(
+        server_alias=alias,
+        remote_name=remote_name,
+        namespaced_name=f"{alias}__{remote_name}",
+        description=f"Remote tool {remote_name}",
+        parameters_schema={
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        },
+    )
+
+
+def _mock_discovery(monkeypatch: pytest.MonkeyPatch, remote_names: list[str] | None = None) -> None:
+    names = remote_names or ["do_thing"]
+
+    async def _mock_list_tool_specs(self: object) -> list[RemoteToolSpec]:
+        alias = self.server.alias  # type: ignore[attr-defined]
+        return [_remote_spec(alias, remote_name) for remote_name in names]
+
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.mcp_client.RemoteMcpToolClient.list_tool_specs",
+        _mock_list_tool_specs,
+    )
+
+
+def _run_cli(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> int:
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit) as exc:
+        main()
+    return int(exc.value.code)
+
+
+def test_mcp_servers_add_list_remove_round_trip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI should configure, list, and remove a generic MCP server cleanly."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch)
+
+    assert (
+        _run_cli(
+            monkeypatch,
+            ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--install-only"],
+        )
+        == 0
+    )
+
+    manifest_path = tmp_path / "external_content" / "mcp_servers.json"
+    assert manifest_path.is_file()
+    written = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert written["version"] == 1
+    assert written["servers"] == [
+        {
+            "alias": SERVER_ALIAS,
+            "url": SERVER_URL,
+            "request_timeout_s": 10.0,
+            "tool_timeout_s": 30.0,
+            "tools": [
+                {
+                    "local_name": TOOL_ID,
+                    "client_tool_name": TOOL_ID,
+                    "remote_name": "do_thing",
+                    "description": "Remote tool do_thing",
+                    "parameters_schema": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}},
+                        "required": ["message"],
+                    },
+                }
+            ],
+        }
+    ]
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "list"]) == 0
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "remove", SERVER_ALIAS]) == 0
+    assert read_mcp_servers(None).servers == []
+
+
+def test_mcp_servers_list_reads_from_cache_without_network(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Listing must not reconnect to the configured servers."""
+    monkeypatch.chdir(tmp_path)
+
+    async def _fail_discovery(self: object) -> list[RemoteToolSpec]:
+        raise AssertionError("list must not trigger network discovery")
+
+    write_mcp_servers(
+        None,
+        InstalledMcpServersManifest(
+            servers=[
+                InstalledMcpServer(
+                    alias=SERVER_ALIAS,
+                    url=SERVER_URL,
+                    tools=[
+                        CachedRemoteTool(
+                            local_name=TOOL_ID,
+                            client_tool_name=TOOL_ID,
+                            remote_name="do_thing",
+                            description="Remote tool do_thing",
+                            parameters_schema={},
+                        )
+                    ],
+                )
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.mcp_client.RemoteMcpToolClient.list_tool_specs",
+        _fail_discovery,
+    )
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "list"]) == 0
+
+
+def test_mcp_servers_add_never_persists_token_value(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the env-var name may reach the manifest, never the secret."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(TOKEN_ENV, "super-secret-value")
+    _mock_discovery(monkeypatch)
+
+    assert (
+        _run_cli(
+            monkeypatch,
+            [
+                "app",
+                "mcp-servers",
+                "add",
+                SERVER_ALIAS,
+                LOOPBACK_SERVER_URL,
+                "--token-env",
+                TOKEN_ENV,
+                "--install-only",
+            ],
+        )
+        == 0
+    )
+
+    manifest_text = (tmp_path / "external_content" / "mcp_servers.json").read_text(encoding="utf-8")
+    assert "super-secret-value" not in manifest_text
+    entry = json.loads(manifest_text)["servers"][0]
+    assert entry["auth"] == {"type": "bearer", "token_env": TOKEN_ENV}
+
+
+@pytest.mark.parametrize(
+    "add_args",
+    [
+        pytest.param([SERVER_ALIAS, SERVER_URL, "--token-env", TOKEN_ENV], id="token-env-unset"),
+        pytest.param([SERVER_ALIAS, "http://example.com/mcp"], id="public-plain-http"),
+        pytest.param([SERVER_ALIAS, SERVER_URL, "--token-env", "BAD NAME"], id="invalid-token-env-name"),
+    ],
+)
+def test_mcp_servers_add_rejects_invalid_config_before_persisting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    add_args: list[str],
+) -> None:
+    """A bad add (unset token env, public plain HTTP, unroundtrippable env name) fails before anything is persisted."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    _mock_discovery(monkeypatch)
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", *add_args, "--install-only"]) == 1
+    assert not (tmp_path / "external_content" / "mcp_servers.json").exists()
+
+
+def test_mcp_servers_add_refreshes_cached_tools_for_same_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-running add for the same alias and URL re-discovers and rewrites the cache."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch, ["do_thing"])
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--install-only"]) == 0
+    assert [tool.local_name for tool in read_mcp_servers(None).servers[0].tools] == [TOOL_ID]
+
+    _mock_discovery(monkeypatch, ["do_thing", "do_other_thing"])
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--install-only"]) == 0
+
+    manifest = read_mcp_servers(None)
+    assert len(manifest.servers) == 1
+    assert [tool.local_name for tool in manifest.servers[0].tools] == [
+        TOOL_ID,
+        f"{SERVER_ALIAS}__do_other_thing",
+    ]
+
+
+def test_mcp_servers_add_refresh_keeps_stored_auth_and_timeouts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The no-flag cache-refresh flow must not silently drop auth, timeouts, or the insecure-HTTP opt-in."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(TOKEN_ENV, "secret")
+    _mock_discovery(monkeypatch, ["do_thing"])
+    assert (
+        _run_cli(
+            monkeypatch,
+            [
+                "app",
+                "mcp-servers",
+                "add",
+                SERVER_ALIAS,
+                SERVER_URL,
+                "--token-env",
+                TOKEN_ENV,
+                "--allow-insecure-token",
+                "--request-timeout",
+                "5",
+                "--tool-timeout",
+                "60",
+                "--install-only",
+            ],
+        )
+        == 0
+    )
+
+    _mock_discovery(monkeypatch, ["do_thing", "do_other_thing"])
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--install-only"]) == 0
+
+    server = read_mcp_servers(None).servers[0]
+    assert server.auth is not None
+    assert server.auth.token_env == TOKEN_ENV
+    # Dropping the opt-in on refresh would also have blocked resolving this LAN server.
+    assert server.auth.allow_insecure_http is True
+    assert server.request_timeout_s == 5.0
+    assert server.tool_timeout_s == 60.0
+    assert [tool.local_name for tool in server.tools] == [TOOL_ID, f"{SERVER_ALIAS}__do_other_thing"]
+
+
+def test_mcp_servers_add_token_rotation_keeps_insecure_token_opt_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing --token-env on a re-add (e.g. rotating the token) must not silently drop the stored insecure-HTTP opt-in."""
+    other_token_env = f"{TOKEN_ENV}_V2"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(TOKEN_ENV, "secret")
+    monkeypatch.setenv(other_token_env, "secret-v2")
+    _mock_discovery(monkeypatch)
+    assert (
+        _run_cli(
+            monkeypatch,
+            [
+                "app",
+                "mcp-servers",
+                "add",
+                SERVER_ALIAS,
+                SERVER_URL,
+                "--token-env",
+                TOKEN_ENV,
+                "--allow-insecure-token",
+                "--install-only",
+            ],
+        )
+        == 0
+    )
+
+    assert (
+        _run_cli(
+            monkeypatch,
+            ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--token-env", other_token_env, "--install-only"],
+        )
+        == 0
+    )
+    server = read_mcp_servers(None).servers[0]
+    assert server.auth is not None
+    assert server.auth.token_env == other_token_env
+    assert server.auth.allow_insecure_http is True
+
+
+def test_read_mcp_servers_rejects_non_bool_allow_insecure_http(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A hand-edited truthy string like "false" must never grant the insecure-HTTP opt-in."""
+    payload = {
+        "version": 1,
+        "servers": [
+            {
+                "alias": SERVER_ALIAS,
+                "url": SERVER_URL,
+                "auth": {"type": "bearer", "token_env": TOKEN_ENV, "allow_insecure_http": "false"},
+            }
+        ],
+    }
+    (tmp_path / "mcp_servers.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        manifest = read_mcp_servers(tmp_path)
+
+    assert manifest.servers == []
+    assert "allow_insecure_http" in caplog.text
+
+
+def test_mcp_servers_add_fails_closed_when_spaces_manifest_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable tool-spaces manifest must block the add: an unchecked alias collision crashes the app at boot."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch)
+    (tmp_path / "external_content").mkdir()
+    (tmp_path / "external_content" / "installed_tool_spaces.json").write_text("{not json", encoding="utf-8")
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--install-only"]) == 1
+    assert read_mcp_servers(None).servers == []
+
+
+def test_build_generic_remote_client_raises_on_unresolvable_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A server whose token cannot be resolved must not produce a client that silently calls unauthenticated."""
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    server = InstalledMcpServer(
+        alias=SERVER_ALIAS,
+        url=LOOPBACK_SERVER_URL,
+        auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV),
+    )
+
+    with pytest.raises(RuntimeError, match=TOKEN_ENV):
+        build_generic_remote_client(server)
+
+
+def test_mcp_servers_add_rejects_same_alias_different_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An alias can't silently switch to another endpoint."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch)
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--install-only"]) == 0
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SERVER_ALIAS, OTHER_SERVER_URL, "--install-only"]) == 1
+    assert read_mcp_servers(None).servers[0].url == SERVER_URL
+
+
+def test_mcp_servers_add_rejects_installed_space_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server alias that collides with an installed Space alias is rejected."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch)
+    write_installed_tool_spaces(
+        None,
+        InstalledToolSpacesManifest(
+            spaces=[
+                InstalledToolSpace(
+                    slug=SPACE_SLUG,
+                    alias=SPACE_ALIAS,
+                    mcp_url="https://example-search-tool.hf.space/gradio_api/mcp/",
+                    private=False,
+                )
+            ]
+        ),
+    )
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SPACE_ALIAS, SERVER_URL, "--install-only"]) == 1
+    assert not (tmp_path / "external_content" / "mcp_servers.json").exists()
+
+
+def test_tool_spaces_add_rejects_configured_server_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Installing a Space whose alias collides with a configured MCP server is rejected."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch)
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SPACE_ALIAS, SERVER_URL, "--install-only"]) == 0
+
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.tool_spaces.HfApi.space_info",
+        lambda self, slug, **kwargs: SimpleNamespace(
+            id=slug,
+            private=False,
+            disabled=False,
+            sdk="gradio",
+            host=None,
+            subdomain=slug.replace("/", "-"),
+            tags=[],
+        ),
+    )
+
+    assert _run_cli(monkeypatch, ["app", "tool-spaces", "add", SPACE_SLUG, "--install-only"]) == 1
+
+
+def test_read_mcp_servers_skips_duplicate_alias(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A duplicate alias keeps the first entry and skips the later one, so one bad entry can't disable the rest."""
+    payload = {
+        "version": 1,
+        "servers": [
+            {"alias": SERVER_ALIAS, "url": SERVER_URL, "request_timeout_s": 10.0, "tool_timeout_s": 30.0},
+            {"alias": SERVER_ALIAS, "url": OTHER_SERVER_URL, "request_timeout_s": 10.0, "tool_timeout_s": 30.0},
+        ],
+    }
+    (tmp_path / "mcp_servers.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        manifest = read_mcp_servers(tmp_path)
+
+    assert [server.url for server in manifest.servers] == [SERVER_URL]
+    assert "Duplicate MCP server alias" in caplog.text
+
+
+def test_mcp_servers_manifest_uses_instance_path_when_provided(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Managed instance paths should store the manifest beside other instance-local state."""
+    _mock_discovery(monkeypatch)
+
+    args = Namespace(
+        mcp_servers_command="add",
+        alias=SERVER_ALIAS,
+        url=SERVER_URL,
+        token_env=None,
+        request_timeout=10.0,
+        tool_timeout=30.0,
+        install_only=True,
+        profile=None,
+    )
+    assert handle_mcp_servers_command(args, instance_path=tmp_path) == 0
+    assert (tmp_path / "mcp_servers.json").is_file()
+    assert not (tmp_path / "external_content" / "mcp_servers.json").exists()
+
+
+def test_mcp_servers_add_and_remove_wire_tools_into_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Add without flags enables the discovered tools in the active profile; remove strips them again."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch)
+    write_profile("default", tmp_path / "default", "hello", [])
+    monkeypatch.setattr(config_mod.config, "PROFILES_DIRECTORY", tmp_path)
+    monkeypatch.setattr(config_mod.config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL]) == 0
+    assert TOOL_ID in read_profile_tool_names("default", None)
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "remove", SERVER_ALIAS]) == 0
+    assert TOOL_ID not in read_profile_tool_names("default", None)
+    assert read_mcp_servers(None).servers == []
+
+
+def test_list_token_requirements_reflects_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """token_set must track whether the named env var currently holds a value."""
+    write_mcp_servers(
+        tmp_path,
+        InstalledMcpServersManifest(
+            servers=[
+                InstalledMcpServer(
+                    alias=SERVER_ALIAS,
+                    url=SERVER_URL,
+                    auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV),
+                ),
+                InstalledMcpServer(alias="no_auth", url=OTHER_SERVER_URL),
+            ]
+        ),
+    )
+
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+    requirements = list_token_requirements(tmp_path)
+    assert [(req.alias, req.token_env, req.token_set) for req in requirements] == [(SERVER_ALIAS, TOKEN_ENV, False)]
+
+    monkeypatch.setenv(TOKEN_ENV, "some-token")
+    assert list_token_requirements(tmp_path)[0].token_set is True
+
+    assert find_server_token_env(tmp_path, SERVER_ALIAS) == TOKEN_ENV
+    assert find_server_token_env(tmp_path, "no_auth") is None
+    assert find_server_token_env(tmp_path, "missing") is None
+
+
+def test_resolve_auth_headers_plain_http_bearer_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Bearer over plain HTTP: rejected on LAN, allowed on loopback, allowed with a warning when opted in."""
+    monkeypatch.setenv(TOKEN_ENV, "some-token")
+
+    def _server(url: str, allow_insecure_http: bool = False) -> InstalledMcpServer:
+        return InstalledMcpServer(
+            alias=SERVER_ALIAS,
+            url=url,
+            auth=McpServerAuth(type="bearer", token_env=TOKEN_ENV, allow_insecure_http=allow_insecure_http),
+        )
+
+    with pytest.raises(RuntimeError, match="plain HTTP"):
+        _resolve_auth_headers(_server(SERVER_URL))
+
+    # Loopback endpoints never put the token on the wire, so plain HTTP is fine there.
+    assert _resolve_auth_headers(_server(LOOPBACK_SERVER_URL)) == {"Authorization": "Bearer some-token"}
+
+    # An opted-in server resolves, but still warns on every resolve.
+    with caplog.at_level("WARNING"):
+        assert _resolve_auth_headers(_server(SERVER_URL, allow_insecure_http=True)) == {
+            "Authorization": "Bearer some-token"
+        }
+    assert any("plain HTTP" in record.message for record in caplog.records)
+
+
+def test_mcp_servers_add_rejects_token_over_lan_plain_http(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configuring a bearer token for a plain-HTTP LAN endpoint must fail before persisting."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(TOKEN_ENV, "some-token")
+    _mock_discovery(monkeypatch)
+
+    assert (
+        _run_cli(
+            monkeypatch,
+            ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--token-env", TOKEN_ENV, "--install-only"],
+        )
+        == 1
+    )
+    assert not (tmp_path / "external_content" / "mcp_servers.json").exists()
+
+
+def test_mcp_servers_add_allows_token_over_lan_plain_http_with_opt_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--allow-insecure-token opts one server into sending its token over plain LAN HTTP and persists the opt-in."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(TOKEN_ENV, "some-token")
+    _mock_discovery(monkeypatch)
+
+    assert (
+        _run_cli(
+            monkeypatch,
+            [
+                "app",
+                "mcp-servers",
+                "add",
+                SERVER_ALIAS,
+                SERVER_URL,
+                "--token-env",
+                TOKEN_ENV,
+                "--allow-insecure-token",
+                "--install-only",
+            ],
+        )
+        == 0
+    )
+
+    manifest_text = (tmp_path / "external_content" / "mcp_servers.json").read_text(encoding="utf-8")
+    assert "some-token" not in manifest_text
+    entry = json.loads(manifest_text)["servers"][0]
+    assert entry["auth"] == {"type": "bearer", "token_env": TOKEN_ENV, "allow_insecure_http": True}
+    assert read_mcp_servers(None).servers[0].auth == McpServerAuth(
+        type="bearer", token_env=TOKEN_ENV, allow_insecure_http=True
+    )
+
+
+def test_read_mcp_servers_skips_corrupt_entries_and_keeps_the_rest(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One corrupt entry is skipped with a warning; valid servers in the same manifest still load."""
+    corrupt_entries = [
+        {"alias": "corrupt", "url": SERVER_URL, "request_timeout_s": None},
+        "not-an-object",
+    ]
+    for corrupt_entry in corrupt_entries:
+        payload = {
+            "version": 1,
+            "servers": [
+                corrupt_entry,
+                {"alias": SERVER_ALIAS, "url": SERVER_URL, "request_timeout_s": 10.0, "tool_timeout_s": 30.0},
+            ],
+        }
+        (tmp_path / "mcp_servers.json").write_text(json.dumps(payload), encoding="utf-8")
+
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            manifest = read_mcp_servers(tmp_path)
+
+        assert [server.alias for server in manifest.servers] == [SERVER_ALIAS]
+        assert "Skipping invalid MCP server entry" in caplog.text
+
+
+def test_mcp_servers_add_and_remove_refuse_rewrite_when_entries_were_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrelated add/remove must not rewrite a manifest whose skipped invalid entries the rewrite would permanently delete."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch)
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--install-only"]) == 0
+
+    manifest_path = tmp_path / "external_content" / "mcp_servers.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["servers"].append(
+        {"alias": "broken", "url": SERVER_URL, "auth": {"type": "bearer", "token_env": "BAD NAME"}}
+    )
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    before = manifest_path.read_text(encoding="utf-8")
+
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "add", "other", OTHER_SERVER_URL, "--install-only"]) == 1
+    assert _run_cli(monkeypatch, ["app", "mcp-servers", "remove", SERVER_ALIAS]) == 1
+    assert manifest_path.read_text(encoding="utf-8") == before
+
+
+def test_handle_mcp_servers_command_accepts_minimal_namespace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The documented programmatic call works with only the required fields, defaulting every optional flag."""
+    _mock_discovery(monkeypatch)
+    profiles_dir = tmp_path / "profiles"
+    write_profile("default", profiles_dir / "default", "hello", [])
+    monkeypatch.setattr(config_mod.config, "PROFILES_DIRECTORY", profiles_dir)
+    monkeypatch.setattr(config_mod.config, "REACHY_MINI_CUSTOM_PROFILE", None)
+
+    args = Namespace(mcp_servers_command="add", alias=SERVER_ALIAS, url=SERVER_URL)
+    assert handle_mcp_servers_command(args, instance_path=tmp_path) == 0
+
+    server = read_mcp_servers(tmp_path).servers[0]
+    assert server.auth is None
+    assert server.request_timeout_s == 10.0
+    assert server.tool_timeout_s == 30.0
+    assert TOOL_ID in read_profile_tool_names("default", tmp_path)
+
+
+def test_cli_rejects_unrecognized_mcp_servers_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo in a security-sensitive flag must fail the command instead of being silently dropped by parse_known_args."""
+    monkeypatch.chdir(tmp_path)
+    _mock_discovery(monkeypatch)
+
+    assert (
+        _run_cli(
+            monkeypatch,
+            ["app", "mcp-servers", "add", SERVER_ALIAS, SERVER_URL, "--token_env", TOKEN_ENV, "--install-only"],
+        )
+        == 2
+    )
+    assert not (tmp_path / "external_content" / "mcp_servers.json").exists()
+
+
+def test_read_mcp_servers_drops_tools_with_non_mapping_schema(tmp_path: Path) -> None:
+    """A cached tool whose parameters_schema is not an object is dropped; the server and its other tools load."""
+    payload = {
+        "version": 1,
+        "servers": [
+            {
+                "alias": SERVER_ALIAS,
+                "url": SERVER_URL,
+                "tools": [
+                    {"local_name": "bad", "client_tool_name": "bad", "parameters_schema": ["oops"]},
+                    {"local_name": "good", "client_tool_name": "good", "parameters_schema": {"type": "object"}},
+                ],
+            }
+        ],
+    }
+    (tmp_path / "mcp_servers.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    manifest = read_mcp_servers(tmp_path)
+
+    assert [server.alias for server in manifest.servers] == [SERVER_ALIAS]
+    assert [tool.local_name for tool in manifest.servers[0].tools] == ["good"]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-13T14:36:32.296430344Z"
+exclude-newer = "2026-08-03T01:25:26.4860129Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1037,6 +1037,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1095,12 +1108,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -1483,15 +1503,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1501,9 +1521,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1902,6 +1935,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2283,20 +2328,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2561,8 +2592,10 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "huggingface-hub" },
     { name = "mcp" },
+    { name = "mcp-types" },
     { name = "openai" },
     { name = "python-dotenv" },
     { name = "reachy-mini" },
@@ -2583,8 +2616,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", specifier = ">=2.5.0" },
     { name = "huggingface-hub", specifier = ">=1.17.0" },
-    { name = "mcp", specifier = ">=1.27.1" },
+    { name = "mcp", specifier = "==2.0.0" },
+    { name = "mcp-types", specifier = "==2.0.0" },
     { name = "openai", specifier = "==2.28.0" },
     { name = "python-dotenv" },
     { name = "reachy-mini", specifier = ">=1.10.0rc2" },
@@ -3226,6 +3261,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #434. Lets users wire any HTTP(S) MCP server into the conversation app, alongside the existing Hugging Face Space tool sources:

- New `mcp-servers` CLI (`add` / `remove` / `list`): discovers tools at add time, caches them in an `mcp_servers.json` manifest, and wires tool IDs into a profile. Startup builds clients from the cache with **zero network discovery**, matching the installed-tool-spaces behavior.
- Auth via bearer token: only the **env-var name** is persisted, never the secret. The settings web UI gets a token section that stores the value in the instance `.env`.
- Security model: public plain-HTTP endpoints are rejected (HTTPS required); loopback is always fine; private/LAN plain HTTP is allowed but sending a token over it requires an explicit sticky `--allow-insecure-token` opt-in.
- Shared `remote_tool_sources` module absorbs the cache/profile plumbing common to Spaces and generic servers; cross-source alias collisions fail closed at add time.
- Built on the **mcp v2 beta SDK** (`mcp==2.0.0b2`): the client auto-negotiates `server/discover` (2026-07-28 spec) and falls back to the `initialize` handshake, so every protocol revision back to 2024-11-05 works — verified in tests against an in-process v2 server and live against an `mcp 1.28.1` server.

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [x] Console mode (default)
- [x] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [x] Profiles or custom tools
</details>

## Notes

**Draft until the MCP v2 SDK and the 2026-07-28 spec are final (expected within about a week).** The `mcp==2.0.0b2` / `mcp-types==2.0.0b2` exact pins follow the SDK beta guidance and will be flipped to the stable release before this leaves draft. The beta packages are opted out of the repo's 7-day uv quarantine window for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)