### PR TITLE
feat(personalities): bulk list + avatars over JSON-RPC

### DIFF
--- a/src/reachy_mini_conversation_app/avatars.py
+++ b/src/reachy_mini_conversation_app/avatars.py
@@ -1,18 +1,8 @@
 """Avatar (SVG) resolution for personality profiles.
 
-Built-in personas ship a hand-drawn SVG under ``static/avatars/``. The map
-below mirrors ``AVATAR_BY_PROFILE`` in ``static/js/constants.js`` (the local
-web UI resolves avatars the same way over HTTP); both lists are tiny and are
-kept in sync by hand when a built-in persona is added or renamed.
-
-Resolution order for a selection:
-  1. ``<profile_dir>/avatar.svg`` - lets a (future) user persona carry its own
-     avatar, so an author flow that writes the SVG alongside the profile works
-     without touching this map;
-  2. the built-in ``AVATAR_BY_PROFILE`` mapping;
-  3. the default avatar.
-
-No HTTP or framework dependencies - importable anywhere, like ``personality``.
+Mirrors the front-end ``AVATAR_BY_PROFILE`` map (``static/js/constants.js``);
+kept in sync by hand. Resolution order: a profile-local ``avatar.svg``, then
+the built-in map, then the default.
 """
 
 from __future__ import annotations

--- a/src/reachy_mini_conversation_app/avatars.py
+++ b/src/reachy_mini_conversation_app/avatars.py
@@ -1,0 +1,95 @@
+"""Avatar (SVG) resolution for personality profiles.
+
+Built-in personas ship a hand-drawn SVG under ``static/avatars/``. The map
+below mirrors ``AVATAR_BY_PROFILE`` in ``static/js/constants.js`` (the local
+web UI resolves avatars the same way over HTTP); both lists are tiny and are
+kept in sync by hand when a built-in persona is added or renamed.
+
+Resolution order for a selection:
+  1. ``<profile_dir>/avatar.svg`` - lets a (future) user persona carry its own
+     avatar, so an author flow that writes the SVG alongside the profile works
+     without touching this map;
+  2. the built-in ``AVATAR_BY_PROFILE`` mapping;
+  3. the default avatar.
+
+No HTTP or framework dependencies - importable anywhere, like ``personality``.
+"""
+
+from __future__ import annotations
+from typing import Optional
+from pathlib import Path
+
+from .personality import DEFAULT_OPTION, resolve_profile_dir
+
+
+DEFAULT_AVATAR_FILE = "default.svg"
+
+# Built-in profile dir name -> avatar file under static/avatars/.
+# Mirror of AVATAR_BY_PROFILE in static/js/constants.js.
+AVATAR_BY_PROFILE: dict[str, str] = {
+    "bored_teenager": "bored-teenager.svg",
+    "captain_circuit": "captain-circuit.svg",
+    "chess_coach": "chess-coach.svg",
+    "cosmic_kitchen": "cosmic-kitchen.svg",
+    "default": "default.svg",
+    "hype_bot": "hype-bot.svg",
+    "mad_scientist_assistant": "mad-scientist.svg",
+    "mars_rover": "mars-rover.svg",
+    "nature_documentarian": "nature-doc.svg",
+    "noir_detective": "noir-detective.svg",
+    "sorry_bro": "sorry-bro.svg",
+    "time_traveler": "time-traveler.svg",
+    "victorian_butler": "victorian-butler.svg",
+}
+
+
+def _avatars_dir() -> Path:
+    return Path(__file__).parent / "static" / "avatars"
+
+
+def _own_avatar_path(name: str) -> Optional[Path]:
+    """Return a profile-local ``avatar.svg`` path when it exists, else None."""
+    if name == DEFAULT_OPTION:
+        return None
+    try:
+        candidate = resolve_profile_dir(name) / "avatar.svg"
+        return candidate if candidate.is_file() else None
+    except Exception:
+        return None
+
+
+def avatar_id_for(name: str) -> str:
+    """Return a stable id for a selection's avatar, for client-side caching.
+
+    Two selections that resolve to the same file share an id, so a client can
+    fetch each distinct avatar once. User personas that carry their own
+    ``avatar.svg`` get their (unique) selection as id.
+    """
+    if _own_avatar_path(name) is not None:
+        return name
+    key = "default" if name == DEFAULT_OPTION else name
+    file = AVATAR_BY_PROFILE.get(key, DEFAULT_AVATAR_FILE)
+    return file[:-4] if file.endswith(".svg") else file
+
+
+def read_avatar_svg(name: str) -> Optional[str]:
+    """Return the SVG markup for a selection, falling back to the default.
+
+    Returns None only if even the default avatar is missing from disk.
+    """
+    own = _own_avatar_path(name)
+    if own is not None:
+        try:
+            return own.read_text(encoding="utf-8")
+        except Exception:
+            pass
+
+    key = "default" if name == DEFAULT_OPTION else name
+    file = AVATAR_BY_PROFILE.get(key, DEFAULT_AVATAR_FILE)
+    for candidate in (_avatars_dir() / file, _avatars_dir() / DEFAULT_AVATAR_FILE):
+        if candidate.is_file():
+            try:
+                return candidate.read_text(encoding="utf-8")
+            except Exception:
+                continue
+    return None

--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -20,6 +20,7 @@ from .config import (
     get_default_voice,
     get_available_voices,
 )
+from .avatars import avatar_id_for, read_avatar_svg
 from .personality import (
     DEFAULT_OPTION,
     _sanitize_name,
@@ -168,6 +169,37 @@ class PersonalityOps:
             "enabled_tools": enabled,
         }
 
+    def get_all(self) -> dict[str, Any]:
+        """Return every personality with its full config in a single call.
+
+        Batches ``get_choices`` + ``load`` for each entry so a remote client
+        (e.g. the phone) can render the whole picker without an N+1 round-trip
+        and without bundling the defaults itself. Avatars are intentionally
+        *not* inlined here - an SVG can be hundreds of KB, which would bloat one
+        message on the data channel - so each entry carries an ``avatar_id``
+        and the SVG is fetched lazily (and cached) via ``personalities.avatar``.
+        """
+        items: list[dict[str, Any]] = []
+        for selection in [DEFAULT_OPTION, *list_personalities()]:
+            entry = self.load(selection)
+            entry["name"] = selection
+            entry["avatar_id"] = avatar_id_for(selection)
+            items.append(entry)
+        return {
+            "personalities": items,
+            "current": self._current_choice(),
+            "startup": self._startup_choice_value(),
+            "locked": LOCKED_PROFILE is not None,
+            "locked_to": LOCKED_PROFILE,
+        }
+
+    def avatar(self, name: str) -> dict[str, Any]:
+        """Return the SVG markup for a personality (falls back to the default)."""
+        svg = read_avatar_svg(name)
+        if svg is None:
+            raise RouteError("avatar_unavailable")
+        return {"name": name, "avatar_id": avatar_id_for(name), "svg": svg}
+
     def save(self, raw: dict[str, Any]) -> dict[str, Any]:
         """Create or update a user personality from a raw payload dict."""
         name = str(raw.get("name", ""))
@@ -305,7 +337,9 @@ def register_personality_methods(rpc: JsonRpcServer, ops: PersonalityOps) -> Non
         return _method
 
     rpc.register("personalities.list", _wrap(lambda p: ops.get_choices()))
+    rpc.register("personalities.all", _wrap(lambda p: ops.get_all()))
     rpc.register("personalities.load", _wrap(lambda p: ops.load(str(p["name"]))))
+    rpc.register("personalities.avatar", _wrap(lambda p: ops.avatar(str(p["name"]))))
     rpc.register("personalities.save", _wrap(lambda p: ops.save(p)))
     rpc.register("personalities.delete", _wrap(lambda p: ops.delete(str(p["name"]))))
     rpc.register(

--- a/src/reachy_mini_conversation_app/personality_routes.py
+++ b/src/reachy_mini_conversation_app/personality_routes.py
@@ -170,15 +170,9 @@ class PersonalityOps:
         }
 
     def get_all(self) -> dict[str, Any]:
-        """Return every personality with its full config in a single call.
-
-        Batches ``get_choices`` + ``load`` for each entry so a remote client
-        (e.g. the phone) can render the whole picker without an N+1 round-trip
-        and without bundling the defaults itself. Avatars are intentionally
-        *not* inlined here - an SVG can be hundreds of KB, which would bloat one
-        message on the data channel - so each entry carries an ``avatar_id``
-        and the SVG is fetched lazily (and cached) via ``personalities.avatar``.
-        """
+        """Return every personality with its full config in a single call."""
+        # No inline SVG: an avatar can be 100+ KB; clients fetch them lazily via
+        # personalities.avatar and cache by avatar_id.
         items: list[dict[str, Any]] = []
         for selection in [DEFAULT_OPTION, *list_personalities()]:
             entry = self.load(selection)

--- a/tests/test_personality_avatars.py
+++ b/tests/test_personality_avatars.py
@@ -1,0 +1,106 @@
+"""Coverage for avatar resolution and the bulk personality listing.
+
+These back the phone's "load everything from the daemon instead of bundling
+the defaults" path: ``personalities.all`` returns every persona in one call
+(no inline SVG), and ``personalities.avatar`` serves one SVG on demand with a
+default fallback.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import reachy_mini_conversation_app.personality as personality_mod
+from reachy_mini_conversation_app.config import config
+from reachy_mini_conversation_app.avatars import (
+    DEFAULT_AVATAR_FILE,
+    avatar_id_for,
+    read_avatar_svg,
+)
+from reachy_mini_conversation_app.personality import DEFAULT_OPTION
+from reachy_mini_conversation_app.personality_routes import (
+    RouteError,
+    PersonalityOps,
+    build_personality_ops,
+)
+
+
+def _ops() -> PersonalityOps:
+    """Build ops with stub callbacks; get_all/avatar touch neither loop nor handler."""
+    return build_personality_ops(object(), lambda: None)  # type: ignore[arg-type]
+
+
+def test_avatar_id_maps_builtin_to_slug() -> None:
+    """A built-in profile resolves to its shared avatar slug (no .svg suffix)."""
+    assert avatar_id_for("mad_scientist_assistant") == "mad-scientist"
+    assert avatar_id_for(DEFAULT_OPTION) == "default"
+
+
+def test_avatar_id_falls_back_to_default_for_unknown() -> None:
+    """An unmapped selection (e.g. a user persona) falls back to the default id."""
+    assert avatar_id_for("user_personalities/whatever") == "default"
+
+
+def test_read_avatar_svg_returns_builtin_markup() -> None:
+    """A built-in persona yields real SVG markup from static/avatars/."""
+    svg = read_avatar_svg("mad_scientist_assistant")
+    assert svg is not None
+    assert "<svg" in svg
+
+
+def test_read_avatar_svg_defaults_for_unknown() -> None:
+    """An unknown selection falls back to the default avatar, not None."""
+    default_svg = (Path(personality_mod.__file__).parent / "static" / "avatars" / DEFAULT_AVATAR_FILE).read_text(
+        encoding="utf-8"
+    )
+    assert read_avatar_svg("user_personalities/nope") == default_svg
+
+
+def test_profile_local_avatar_takes_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A persona that ships its own avatar.svg wins over the mapping/default."""
+    monkeypatch.setattr(config, "INSTANCE_PATH", tmp_path)
+    personality_mod._write_profile("selfie", "Be brief.", "")
+    own = tmp_path / "user_personalities" / "selfie" / "avatar.svg"
+    own.write_text("<svg id='own'></svg>", encoding="utf-8")
+
+    assert read_avatar_svg("user_personalities/selfie") == "<svg id='own'></svg>"
+    assert avatar_id_for("user_personalities/selfie") == "user_personalities/selfie"
+
+
+def test_get_all_lists_every_persona_without_inline_svg() -> None:
+    """get_all returns the built-in default first plus each persona, avatar_id only."""
+    result = _ops().get_all()
+    personalities = result["personalities"]
+
+    assert personalities[0]["name"] == DEFAULT_OPTION
+    names = {p["name"] for p in personalities}
+    assert "mad_scientist_assistant" in names
+    for entry in personalities:
+        assert "avatar_id" in entry
+        assert "instructions" in entry
+        assert "svg" not in entry  # avatars are fetched lazily, never inlined here
+
+
+def test_avatar_method_returns_svg_and_id() -> None:
+    """personalities.avatar returns the markup plus a cache id."""
+    payload = _ops().avatar("mad_scientist_assistant")
+    assert payload["avatar_id"] == "mad-scientist"
+    assert "<svg" in payload["svg"]
+
+
+def test_avatar_method_falls_back_for_unknown() -> None:
+    """An unknown selection still yields the default SVG rather than erroring."""
+    payload = _ops().avatar("user_personalities/nope")
+    assert "<svg" in payload["svg"]
+    assert payload["avatar_id"] == "default"
+
+
+def test_avatar_unavailable_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If even the default avatar cannot be read, avatar() surfaces a RouteError."""
+    monkeypatch.setattr(
+        "reachy_mini_conversation_app.personality_routes.read_avatar_svg",
+        lambda name: None,
+    )
+    with pytest.raises(RouteError) as ei:
+        _ops().avatar("mad_scientist_assistant")
+    assert ei.value.reason == "avatar_unavailable"


### PR DESCRIPTION
Stacked on top of #455 (`1252-rpc-over-webrtc`). Lets a remote client (the phone) drive the whole personality picker from the daemon over JSON-RPC, instead of bundling the default personas + avatars in the app.

## What
- **`personalities.all`**: batches `list` + `load` for every persona in a single call. Each entry carries the usual config (instructions, greeting, tools, voice, tools state) plus an `avatar_id`. Avatars are **not** inlined here - a single SVG can be 100+ KB (mad-scientist is ~150 KB), so inlining all of them would bloat one data-channel message.
- **`personalities.avatar { name }`**: returns one SVG on demand (cacheable client-side by `avatar_id`), falling back to the default avatar; raises `avatar_unavailable` only if even the default is missing.
- New **`avatars`** module: transport-agnostic avatar resolution mirroring the front-end `AVATAR_BY_PROFILE` map (`static/js/constants.js`). Resolution order: profile-local `avatar.svg` -> built-in map -> default. The profile-local step is forward-compat: a future author flow can write a persona's `avatar.svg` next to its files and it just works.

## Why
The phone currently duplicates ~1.1 MB of default persona SVGs. With these two methods it can load the persona list cheaply and lazy-load each avatar from the daemon (the single source of truth), then cache by `avatar_id`.

## Verification
- `ruff check` + `ruff format` clean on the touched files.
- New `tests/test_personality_avatars.py` covers id mapping, SVG resolution + default fallback, profile-local precedence, `get_all` shape (default first, no inline SVG), and the `avatar` method.
- Note: full `pytest` needs the companion SDK (`reachy_mini.io.jsonrpc` / `apps.jsonrpc_server`) from the daemon PR, not installed in the local venv; logic verified standalone + via an SDK-stub e2e check. CI on the stacked base has the SDK.

Made with [Cursor](https://cursor.com)