### PR TITLE
Reduce conversation startup latency

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -779,8 +779,10 @@ class LocalStream:
             # Connect the backend first so it overlaps the warmup and audio config below.
             handler_task = asyncio.create_task(self._run_handler_startup_loop(), name="realtime-handler")
             self._tasks = [handler_task]
-            await asyncio.sleep(1)  # give the pipelines time to start
-            await asyncio.to_thread(apply_audio_startup_config, self._robot, logger=logger)
+            await asyncio.gather(
+                asyncio.sleep(1),  # give the pipelines time to start
+                asyncio.to_thread(apply_audio_startup_config, self._robot, logger=logger),
+            )
             self._tasks += [
                 asyncio.create_task(self.record_loop(), name="stream-record-loop"),
                 asyncio.create_task(self.play_loop(), name="stream-play-loop"),

--- a/src/reachy_mini_conversation_app/huggingface_realtime.py
+++ b/src/reachy_mini_conversation_app/huggingface_realtime.py
@@ -5,7 +5,7 @@ import base64
 import random
 import asyncio
 import logging
-from typing import Any, Final, Tuple, Optional
+from typing import TYPE_CHECKING, Any, Final, Tuple, Optional
 
 import httpx
 import numpy as np
@@ -23,7 +23,6 @@ from openai.types.realtime import (
     RealtimeSessionCreateRequestParam,
 )
 from websockets.exceptions import ConnectionClosedError
-from openai.resources.realtime.realtime import AsyncRealtimeConnection
 from openai.types.realtime.realtime_audio_input_turn_detection_param import ServerVad
 
 from reachy_mini_conversation_app.tools import core_tools
@@ -53,6 +52,10 @@ from reachy_mini_conversation_app.tools.background_tool_manager import (
     ToolNotification,
     BackgroundToolManager,
 )
+
+
+if TYPE_CHECKING:
+    from openai.resources.realtime.realtime import AsyncRealtimeConnection
 
 
 logger = logging.getLogger(__name__)
@@ -126,7 +129,7 @@ class HuggingFaceRealtimeHandler(ConversationHandler):
         self.deps = deps
 
         self.client: AsyncOpenAI
-        self.connection: AsyncRealtimeConnection | None = None
+        self.connection: "AsyncRealtimeConnection | None" = None
         self.output_queue: "asyncio.Queue[Tuple[int, NDArray[np.int16]] | AdditionalOutputs]" = asyncio.Queue()
 
         self.instance_path = instance_path

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -469,6 +469,44 @@ def test_backend_startup_failure_is_recorded_without_raising(
     assert data["backend_error"] == "RuntimeError: local server unavailable"
 
 
+def test_media_warmup_overlaps_audio_startup_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Audio configuration should run while the media pipelines warm up."""
+    monkeypatch.setattr("reachy_mini_conversation_app.console.has_hf_realtime_target", lambda: True)
+
+    handler = MagicMock()
+    handler.shutdown = AsyncMock()
+    media = SimpleNamespace(
+        audio=None,
+        backend=None,
+        start_recording=MagicMock(),
+        start_playing=MagicMock(),
+    )
+    stream = LocalStream(handler, SimpleNamespace(media=media))
+    stream.record_loop = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    stream.play_loop = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    startup_barrier = threading.Barrier(2)
+
+    async def wait_for_audio_config(_delay: float) -> None:
+        await asyncio.to_thread(startup_barrier.wait, 0.5)
+
+    def apply_audio_config(*_args: Any, **_kwargs: Any) -> bool:
+        startup_barrier.wait(0.5)
+        return True
+
+    async def start_and_stop() -> None:
+        stream._stop_event.set()
+
+    handler.start_up = AsyncMock(side_effect=start_and_stop)
+    monkeypatch.setattr("reachy_mini_conversation_app.console.asyncio.sleep", wait_for_audio_config)
+    monkeypatch.setattr("reachy_mini_conversation_app.console.apply_audio_startup_config", apply_audio_config)
+
+    try:
+        stream.launch()
+    finally:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+
 @pytest.mark.asyncio
 async def test_startup_loop_rebuilds_handler_on_restart_request(monkeypatch: pytest.MonkeyPatch) -> None:
     """LocalStream should shut down and rebuild the handler when a restart is requested."""

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,6 +1,7 @@
 """Tests for the headless console stream."""
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from typing import Any
 from pathlib import Path

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -442,10 +442,10 @@ def test_media_warmup_overlaps_audio_startup_config(monkeypatch: pytest.MonkeyPa
     startup_barrier = threading.Barrier(2)
 
     async def wait_for_audio_config(_delay: float) -> None:
-        await asyncio.to_thread(startup_barrier.wait, 0.5)
+        await asyncio.to_thread(startup_barrier.wait, 5.0)
 
     def apply_audio_config(*_args: Any, **_kwargs: Any) -> bool:
-        startup_barrier.wait(0.5)
+        startup_barrier.wait(5.0)
         return True
 
     async def start_and_stop() -> None:


### PR DESCRIPTION
## Summary
Overlap media warmup with audio configuration and make the realtime connection import type-check-only. Add a regression test for the concurrent startup path.

## Category
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [ ] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>
