### PR TITLE
Drop the wake phrase tail so the backend never hears "hey jarvis"

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ Greet me warmly in one sentence, in character, and vary the wording each time.
 ```
 If `greeting.txt` is missing, the app uses the built-in default greeting prompt.
 
+**Wake word:**
+
+After the startup greeting, the app listens for the on-device wake word "hey jarvis" (via [openWakeWord](https://github.com/dscripka/openWakeWord)) before forwarding any microphone audio to the backend. Once woken, it converses normally; after 60 seconds of conversation inactivity the wake word gate re-arms.
+
 **Enabling tools:**
 
 List enabled tools in `tools.txt`, one per line. Prefix with `#` to comment out:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ After the startup greeting, the app listens for the on-device wake word "hey jar
 How it works:
 
 - While the gate is armed, no audio leaves the robot. Mic frames are scored locally by the bundled `hey_jarvis` model; frames are only streamed to the realtime backend after a detection. Detection is fully on-device, so nothing is sent anywhere until you speak the wake word.
-- The "hey jarvis" utterance itself is not forwarded — streaming starts with the audio that follows it, so the backend never hears (or answers) the wake phrase.
+- The "hey jarvis" utterance itself is not forwarded. Detection can fire while the phrase is still sounding, so the gate also drops a short (0.5 s) tail window after it before streaming starts — the backend never hears (or answers) the wake phrase.
 - Once awake, the detector stops running entirely, so conversation latency is unaffected.
 - The gate re-arms after 60 seconds without conversation activity, but never while the robot is still speaking or moving. Saying the wake word always grants a full 60-second window, even if you pause before speaking.
 - On re-arm, the detector model is rebuilt from scratch: openWakeWord's `reset()` retains ~10 s of audio feature history, which could otherwise cause a stale trigger.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ reachy-mini-conversation-app --no-camera
 reachy-mini-conversation-app --ui
 ```
 
+### Deploying to the robot
+
+To install a local checkout on a wireless Reachy Mini over the local network:
+
+```bash
+scripts/deploy_to_robot.sh              # defaults to pollen@reachy-mini.local
+scripts/deploy_to_robot.sh 192.168.1.42 # or pass a host/IP
+```
+
+The script builds the wheel with `uv build`, copies it over `scp`, and installs it into the robot's shared app venv (`/venvs/apps_venv`). The default SSH password is `root`; run `ssh-copy-id pollen@reachy-mini.local` once to skip password prompts. Afterwards, restart the app from the dashboard (`http://reachy-mini.local:8000`) for the new code to take effect — the script prints the exact commands.
+
 ## LLM tools exposed to the assistant
 
 The default profile exposes these tools. Custom profiles can enable a different set in their own `tools.txt`.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,17 @@ If `greeting.txt` is missing, the app uses the built-in default greeting prompt.
 
 After the startup greeting, the app listens for the on-device wake word "hey jarvis" (via [openWakeWord](https://github.com/dscripka/openWakeWord)) before forwarding any microphone audio to the backend. Once woken, it converses normally; after 60 seconds of conversation inactivity the wake word gate re-arms.
 
+How it works:
+
+- While the gate is armed, no audio leaves the robot. Mic frames are scored locally by the bundled `hey_jarvis` model; frames are only streamed to the realtime backend after a detection. Detection is fully on-device, so nothing is sent anywhere until you speak the wake word.
+- The "hey jarvis" utterance itself is not forwarded — streaming starts with the audio that follows it, so the backend never hears (or answers) the wake phrase.
+- Once awake, the detector stops running entirely, so conversation latency is unaffected.
+- The gate re-arms after 60 seconds without conversation activity, but never while the robot is still speaking or moving. Saying the wake word always grants a full 60-second window, even if you pause before speaking.
+- On re-arm, the detector model is rebuilt from scratch: openWakeWord's `reset()` retains ~10 s of audio feature history, which could otherwise cause a stale trigger.
+- The mic must run at 16 kHz (openWakeWord's required rate); the app logs a warning at startup if it does not, since detection would silently fail.
+
+Implementation lives in `src/reachy_mini_conversation_app/wake_word.py` (`WakeWordGate`), hooked into the mic loop in `console.py`. The dependency is pinned to `openwakeword>=0.4.0,<0.5` because 0.4.x bundles the `hey_jarvis` ONNX model, while 0.5+ requires `tflite-runtime`.
+
 **Enabling tools:**
 
 List enabled tools in `tools.txt`, one per line. Prefix with `#` to comment out:

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ How it works:
 - Once awake, the detector stops running entirely, so conversation latency is unaffected.
 - The gate re-arms after 60 seconds without conversation activity, but never while the robot is still speaking or moving. Saying the wake word always grants a full 60-second window, even if you pause before speaking.
 - On re-arm, the detector model is rebuilt from scratch: openWakeWord's `reset()` retains ~10 s of audio feature history, which could otherwise cause a stale trigger.
-- The mic must run at 16 kHz (openWakeWord's required rate); the app logs a warning at startup if it does not, since detection would silently fail.
+- The mic must run at 16 kHz (openWakeWord's required rate); the app refuses to start if it does not, since detection would otherwise silently fail and the robot would never wake.
 
 Implementation lives in `src/reachy_mini_conversation_app/wake_word.py` (`WakeWordGate`), hooked into the mic loop in `console.py`. The dependency is pinned to `openwakeword>=0.4.0,<0.5` because 0.4.x bundles the `hey_jarvis` ONNX model, while 0.5+ requires `tflite-runtime`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
     "reachy_mini_dances_library",
     "reachy-mini>=1.10.0rc2",
     "mcp>=1.27.1",
+
+    #Wake word detection (0.4.x bundles the hey_jarvis ONNX model; 0.5+ requires tflite-runtime)
+    "openwakeword>=0.4.0,<0.5",
 ]
 
 [dependency-groups]

--- a/scripts/deploy_to_robot.sh
+++ b/scripts/deploy_to_robot.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Build the app wheel and install it on a Reachy Mini over the local network.
+#
+# Usage: scripts/deploy_to_robot.sh [robot-host]
+#
+# The default SSH password on a stock wireless Reachy Mini is "root".
+# Run `ssh-copy-id pollen@reachy-mini.local` once to skip password prompts.
+set -euo pipefail
+
+ROBOT_HOST="${1:-${ROBOT_HOST:-reachy-mini.local}}"
+ROBOT_USER="${ROBOT_USER:-pollen}"
+APPS_VENV="/venvs/apps_venv"
+
+cd "$(dirname "$0")/.."
+
+VERSION="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml)"
+if [[ -z "$VERSION" ]]; then
+    echo "error: could not read version from pyproject.toml" >&2
+    exit 1
+fi
+WHEEL="dist/reachy_mini_conversation_app-${VERSION}-py3-none-any.whl"
+
+echo "==> Building wheel (version ${VERSION})"
+uv build --wheel
+if [[ ! -f "$WHEEL" ]]; then
+    echo "error: expected wheel not found: $WHEEL" >&2
+    exit 1
+fi
+
+WHEEL_NAME="$(basename "$WHEEL")"
+echo "==> Copying ${WHEEL_NAME} to ${ROBOT_USER}@${ROBOT_HOST}:/tmp/"
+scp "$WHEEL" "${ROBOT_USER}@${ROBOT_HOST}:/tmp/"
+
+echo "==> Installing into ${APPS_VENV} on the robot"
+# First install resolves any new dependencies; the forced no-deps reinstall
+# guarantees the app code is replaced even when the version number is unchanged.
+ssh "${ROBOT_USER}@${ROBOT_HOST}" "
+    set -euo pipefail
+    ${APPS_VENV}/bin/python -m pip install /tmp/${WHEEL_NAME}
+    ${APPS_VENV}/bin/python -m pip install --force-reinstall --no-deps /tmp/${WHEEL_NAME}
+    rm -f /tmp/${WHEEL_NAME}
+"
+
+cat <<EOF
+==> Installed ${WHEEL_NAME} on ${ROBOT_HOST}.
+
+Restart the app for the new code to take effect:
+  - from the dashboard: http://${ROBOT_HOST}:8000
+  - or via the REST API:
+      curl -X POST http://${ROBOT_HOST}:8000/api/apps/stop-current-app
+      curl -X POST http://${ROBOT_HOST}:8000/api/apps/start-app/reachy_mini_conversation_app
+
+Follow logs with:
+  ssh ${ROBOT_USER}@${ROBOT_HOST} sudo journalctl -u reachy-mini-daemon -f
+EOF

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -867,7 +867,9 @@ class LocalStream:
         input_sample_rate = self._robot.media.get_input_audio_samplerate()
         logger.debug(f"Audio recording started at {input_sample_rate} Hz")
         if input_sample_rate != 16000:
-            logger.warning("Wake word model expects 16 kHz mic input, got %s Hz", input_sample_rate)
+            # A wrong rate would leave the gate permanently closed: detection scores
+            # never cross the threshold, so no audio would ever reach the backend.
+            raise RuntimeError(f"Wake word model requires 16 kHz mic input, got {input_sample_rate} Hz")
         self._wake_gate = WakeWordGate()
         logger.info("Say 'hey jarvis' to start the conversation")
 

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -37,6 +37,7 @@ from reachy_mini_conversation_app.config import (
     refresh_runtime_config_from_env,
 )
 from reachy_mini_conversation_app.streaming import AdditionalOutputs, audio_to_float32
+from reachy_mini_conversation_app.wake_word import WakeWordGate
 from reachy_mini_conversation_app.startup_settings import read_startup_settings, write_startup_settings
 from reachy_mini_conversation_app.tools.core_tools import initialize_tools
 from reachy_mini_conversation_app.personality_routes import (
@@ -124,6 +125,7 @@ class LocalStream:
         self._settings_initialized = False
         self._asyncio_loop = None
         self._mic_muted = False  # mic starts live; the UI toggles it via the settings API
+        self._wake_gate: WakeWordGate | None = None  # built in record_loop to keep construction cheap
         self._backend_connection_state = "not_started"
         self._backend_error: str | None = None
         self._backend_retry_delay = BACKEND_RETRY_DELAY_SECONDS
@@ -861,15 +863,21 @@ class LocalStream:
                 break
 
     async def record_loop(self) -> None:
-        """Read mic frames from the recorder and forward them to the handler."""
+        """Read mic frames and forward them to the handler once the wake word gate is open."""
         input_sample_rate = self._robot.media.get_input_audio_samplerate()
         logger.debug(f"Audio recording started at {input_sample_rate} Hz")
+        if input_sample_rate != 16000:
+            logger.warning("Wake word model expects 16 kHz mic input, got %s Hz", input_sample_rate)
+        self._wake_gate = WakeWordGate()
+        logger.info("Say 'hey jarvis' to start the conversation")
 
         while not self._stop_event.is_set():
             audio_frame = self._robot.media.get_audio_sample()
             if audio_frame is not None and not self._mic_muted:
-                await self.handler.receive((input_sample_rate, audio_frame))
-                self._emit_level("user", audio_frame)
+                movement_manager = self.handler.deps.movement_manager
+                if self._wake_gate.allows(audio_frame, self.seconds_since_activity(), movement_manager.is_idle()):
+                    await self.handler.receive((input_sample_rate, audio_frame))
+                    self._emit_level("user", audio_frame)
             await asyncio.sleep(0)  # avoid busy loop
 
     async def play_loop(self) -> None:

--- a/src/reachy_mini_conversation_app/wake_word.py
+++ b/src/reachy_mini_conversation_app/wake_word.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 CHUNK_SAMPLES = 1280  # 80 ms at openwakeword's required 16 kHz rate
 DETECTION_THRESHOLD = 0.5
+PHRASE_TAIL_SECONDS = 0.5  # the score crosses the threshold while "jarvis" is still sounding
 REARM_SECONDS = 60.0
 
 
@@ -34,7 +35,10 @@ class WakeWordGate:
     def allows(self, audio_frame: NDArray[np.float32], idle_seconds: float, conversation_idle: bool) -> bool:
         """Return True when mic audio may reach the backend; run detection while gated."""
         if self._awake_at is not None:
-            if min(idle_seconds, time.monotonic() - self._awake_at) <= REARM_SECONDS or not conversation_idle:
+            awake_seconds = time.monotonic() - self._awake_at
+            if awake_seconds < PHRASE_TAIL_SECONDS:
+                return False  # drop the rest of the wake phrase so the backend never hears it
+            if min(idle_seconds, awake_seconds) <= REARM_SECONDS or not conversation_idle:
                 return True
             self._awake_at = None
             # Model.reset() keeps ~10 s of feature history, so rebuild for a clean armed state.

--- a/src/reachy_mini_conversation_app/wake_word.py
+++ b/src/reachy_mini_conversation_app/wake_word.py
@@ -1,0 +1,54 @@
+"""On-device "hey jarvis" wake word gate for the microphone stream."""
+
+import time
+import logging
+
+import numpy as np
+import openwakeword
+from numpy.typing import NDArray
+from openwakeword.model import Model
+
+from reachy_mini_conversation_app.streaming import audio_to_int16
+
+
+logger = logging.getLogger(__name__)
+
+CHUNK_SAMPLES = 1280  # 80 ms at openwakeword's required 16 kHz rate
+DETECTION_THRESHOLD = 0.5
+REARM_SECONDS = 60.0
+
+
+class WakeWordGate:
+    """Blocks mic audio until "hey jarvis" is heard; re-arms after conversation inactivity."""
+
+    def __init__(self) -> None:
+        """Load the bundled hey_jarvis model and start in the armed state."""
+        self._model = self._new_model()
+        self._pending = np.empty(0, dtype=np.int16)
+        self._awake_at: float | None = None
+
+    @staticmethod
+    def _new_model() -> Model:
+        return Model(wakeword_model_paths=[openwakeword.models["hey_jarvis"]["model_path"]])
+
+    def allows(self, audio_frame: NDArray[np.float32], idle_seconds: float, conversation_idle: bool) -> bool:
+        """Return True when mic audio may reach the backend; run detection while gated."""
+        if self._awake_at is not None:
+            if min(idle_seconds, time.monotonic() - self._awake_at) <= REARM_SECONDS or not conversation_idle:
+                return True
+            self._awake_at = None
+            # Model.reset() keeps ~10 s of feature history, so rebuild for a clean armed state.
+            self._model = self._new_model()
+            self._pending = np.empty(0, dtype=np.int16)
+            logger.info("Wake word gate re-armed after %.0f s of inactivity", REARM_SECONDS)
+        first_channel = audio_frame[:, 0] if audio_frame.ndim == 2 else audio_frame
+        self._pending = np.concatenate([self._pending, audio_to_int16(first_channel)])
+        detected = False
+        while self._pending.size >= CHUNK_SAMPLES:
+            chunk, self._pending = self._pending[:CHUNK_SAMPLES], self._pending[CHUNK_SAMPLES:]
+            if max(self._model.predict(chunk).values()) >= DETECTION_THRESHOLD:
+                detected = True
+        if detected:
+            self._awake_at = time.monotonic()
+            logger.info("Wake word detected; forwarding mic audio")
+        return False

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -845,6 +845,19 @@ def _record_loop_stream(monkeypatch: pytest.MonkeyPatch) -> tuple[LocalStream, _
 
 
 @pytest.mark.asyncio
+async def test_record_loop_rejects_non_16khz_mic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mic rate other than 16 kHz must abort startup, not silently break detection."""
+    stream, fake_gate, handler = _record_loop_stream(monkeypatch)
+    stream._robot.media.get_input_audio_samplerate = lambda: 44100
+
+    with pytest.raises(RuntimeError, match="16 kHz"):
+        await stream.record_loop()
+
+    assert fake_gate.calls == 0
+    handler.receive.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_record_loop_withholds_frames_while_gated(monkeypatch: pytest.MonkeyPatch) -> None:
     """Mic frames must not reach the backend before the wake word is heard."""
     stream, fake_gate, handler = _record_loop_stream(monkeypatch)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -817,3 +817,74 @@ def test_rpc_personalities_and_voices_methods() -> None:
         r2 = ws.receive_json()
     assert "choices" in r1["result"] and "current" in r1["result"]
     assert isinstance(r2["result"], list)
+
+
+class _FakeWakeGate:
+    """Stands in for WakeWordGate with a switchable open/closed state."""
+
+    def __init__(self) -> None:
+        self.open = False
+        self.calls = 0
+
+    def allows(self, audio_frame: Any, idle_seconds: float, conversation_idle: bool) -> bool:
+        self.calls += 1
+        return self.open
+
+
+def _record_loop_stream(monkeypatch: pytest.MonkeyPatch) -> tuple[LocalStream, _FakeWakeGate, MagicMock]:
+    fake_gate = _FakeWakeGate()
+    monkeypatch.setattr("reachy_mini_conversation_app.console.WakeWordGate", lambda: fake_gate)
+    handler = MagicMock()
+    handler.receive = AsyncMock()
+    media = SimpleNamespace(
+        get_input_audio_samplerate=lambda: 16000,
+        get_audio_sample=MagicMock(return_value=np.zeros(1280, dtype=np.float32)),
+    )
+    stream = LocalStream(handler, SimpleNamespace(media=media))
+    return stream, fake_gate, handler
+
+
+@pytest.mark.asyncio
+async def test_record_loop_withholds_frames_while_gated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mic frames must not reach the backend before the wake word is heard."""
+    stream, fake_gate, handler = _record_loop_stream(monkeypatch)
+
+    loop_task = asyncio.create_task(stream.record_loop())
+    await _wait_until(lambda: fake_gate.calls >= 3)
+    stream._stop_event.set()
+    await loop_task
+
+    handler.receive.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_record_loop_forwards_frames_once_gate_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Once the gate reports open, frames flow to the handler unchanged."""
+    stream, fake_gate, handler = _record_loop_stream(monkeypatch)
+    fake_gate.open = True
+
+    loop_task = asyncio.create_task(stream.record_loop())
+    await _wait_until(lambda: handler.receive.await_count >= 1)
+    stream._stop_event.set()
+    await loop_task
+
+    sample_rate, audio_frame = handler.receive.await_args.args[0]
+    assert sample_rate == 16000
+    assert audio_frame.dtype == np.float32
+
+
+@pytest.mark.asyncio
+async def test_record_loop_mute_wins_over_wake_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A muted mic neither forwards audio nor feeds the wake word detector."""
+    stream, fake_gate, handler = _record_loop_stream(monkeypatch)
+    fake_gate.open = True
+    stream._mic_muted = True
+    media_mock = stream._robot.media.get_audio_sample
+
+    loop_task = asyncio.create_task(stream.record_loop())
+    await _wait_until(lambda: media_mock.call_count >= 3)
+    stream._stop_event.set()
+    await loop_task
+
+    assert fake_gate.calls == 0
+    handler.receive.assert_not_awaited()

--- a/tests/test_wake_word.py
+++ b/tests/test_wake_word.py
@@ -1,0 +1,128 @@
+"""Tests for the wake word gate."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from reachy_mini_conversation_app import wake_word
+from reachy_mini_conversation_app.wake_word import CHUNK_SAMPLES, REARM_SECONDS, WakeWordGate
+
+
+class _StubModel:
+    """Stands in for openwakeword.Model with a controllable score."""
+
+    instances: list["_StubModel"] = []
+    score = 0.0
+
+    def __init__(self, wakeword_model_paths: list[str] | None = None) -> None:
+        self.predict_calls: list[np.ndarray] = []
+        _StubModel.instances.append(self)
+
+    def predict(self, chunk: np.ndarray) -> dict[str, float]:
+        self.predict_calls.append(chunk)
+        return {"hey_jarvis_v0.1": _StubModel.score}
+
+
+@pytest.fixture
+def stub_model(monkeypatch: pytest.MonkeyPatch) -> type[_StubModel]:
+    """Replace the openwakeword model with a controllable stub."""
+    _StubModel.instances = []
+    _StubModel.score = 0.0
+    monkeypatch.setattr(wake_word, "Model", _StubModel)
+    return _StubModel
+
+
+@pytest.fixture
+def fake_clock(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Give the wake word module a controllable monotonic clock."""
+    clock = SimpleNamespace(now=1000.0)
+    monkeypatch.setattr(wake_word, "time", SimpleNamespace(monotonic=lambda: clock.now))
+    return clock
+
+
+def _frame(samples: int, value: float = 0.0) -> np.ndarray:
+    return np.full(samples, value, dtype=np.float32)
+
+
+def test_frames_accumulate_into_full_chunks(stub_model: type[_StubModel]) -> None:
+    """Predict runs once per full 1280-sample chunk, not per mic frame."""
+    gate = WakeWordGate()
+    model = stub_model.instances[0]
+
+    assert gate.allows(_frame(CHUNK_SAMPLES // 2), 0.0, True) is False
+    assert model.predict_calls == []
+
+    assert gate.allows(_frame(CHUNK_SAMPLES // 2), 0.0, True) is False
+    assert len(model.predict_calls) == 1
+    assert model.predict_calls[0].size == CHUNK_SAMPLES
+
+
+def test_stereo_frames_use_first_channel_as_int16(stub_model: type[_StubModel]) -> None:
+    """Stereo input is reduced to the first channel and converted to int16."""
+    gate = WakeWordGate()
+    stereo = np.stack([_frame(CHUNK_SAMPLES, 0.5), _frame(CHUNK_SAMPLES, -0.5)], axis=1)
+
+    gate.allows(stereo, 0.0, True)
+
+    chunk = stub_model.instances[0].predict_calls[0]
+    assert chunk.dtype == np.int16
+    assert np.all(chunk == np.int16(0.5 * 32767))
+
+
+def test_detection_opens_gate_from_next_frame(stub_model: type[_StubModel], fake_clock: SimpleNamespace) -> None:
+    """The detecting frame is withheld; subsequent frames flow without detection."""
+    gate = WakeWordGate()
+    stub_model.score = 0.9
+
+    assert gate.allows(_frame(CHUNK_SAMPLES), 0.0, True) is False
+
+    stub_model.score = 0.0
+    assert gate.allows(_frame(CHUNK_SAMPLES), 0.0, True) is True
+    assert len(stub_model.instances[0].predict_calls) == 1  # no detection while awake
+
+
+def test_awake_window_survives_stale_handler_clock(stub_model: type[_StubModel], fake_clock: SimpleNamespace) -> None:
+    """Right after wake, a large handler idle time must not re-arm the gate."""
+    gate = WakeWordGate()
+    stub_model.score = 0.9
+    gate.allows(_frame(CHUNK_SAMPLES), 0.0, True)
+
+    assert gate.allows(_frame(CHUNK_SAMPLES), 999.0, True) is True
+
+
+def test_rearm_after_inactivity_rebuilds_model(stub_model: type[_StubModel], fake_clock: SimpleNamespace) -> None:
+    """After the inactivity window the gate closes and gets a fresh model."""
+    gate = WakeWordGate()
+    stub_model.score = 0.9
+    gate.allows(_frame(CHUNK_SAMPLES), 0.0, True)
+    stub_model.score = 0.0
+
+    fake_clock.now += REARM_SECONDS + 1
+    assert gate.allows(_frame(CHUNK_SAMPLES), REARM_SECONDS + 1, True) is False
+    assert len(stub_model.instances) == 2  # fresh model: reset() keeps stale feature history
+
+    stub_model.score = 0.9
+    gate.allows(_frame(CHUNK_SAMPLES), REARM_SECONDS + 2, True)
+    stub_model.score = 0.0
+    assert gate.allows(_frame(CHUNK_SAMPLES), 0.0, True) is True
+
+
+def test_no_rearm_while_conversation_active(stub_model: type[_StubModel], fake_clock: SimpleNamespace) -> None:
+    """An active conversation (listening/moving) blocks re-arm past the deadline."""
+    gate = WakeWordGate()
+    stub_model.score = 0.9
+    gate.allows(_frame(CHUNK_SAMPLES), 0.0, True)
+    stub_model.score = 0.0
+
+    fake_clock.now += REARM_SECONDS + 1
+    assert gate.allows(_frame(CHUNK_SAMPLES), REARM_SECONDS + 1, False) is True
+    assert len(stub_model.instances) == 1
+
+
+def test_real_model_scores_silence_below_threshold() -> None:
+    """Smoke test against the real bundled model: silence must not wake the gate."""
+    gate = WakeWordGate()
+
+    assert gate.allows(_frame(CHUNK_SAMPLES), 0.0, True) is False
+    assert gate._awake_at is None

--- a/tests/test_wake_word.py
+++ b/tests/test_wake_word.py
@@ -6,7 +6,12 @@ import numpy as np
 import pytest
 
 from reachy_mini_conversation_app import wake_word
-from reachy_mini_conversation_app.wake_word import CHUNK_SAMPLES, REARM_SECONDS, WakeWordGate
+from reachy_mini_conversation_app.wake_word import (
+    CHUNK_SAMPLES,
+    REARM_SECONDS,
+    PHRASE_TAIL_SECONDS,
+    WakeWordGate,
+)
 
 
 class _StubModel:
@@ -70,16 +75,19 @@ def test_stereo_frames_use_first_channel_as_int16(stub_model: type[_StubModel]) 
     assert np.all(chunk == np.int16(0.5 * 32767))
 
 
-def test_detection_opens_gate_from_next_frame(stub_model: type[_StubModel], fake_clock: SimpleNamespace) -> None:
-    """The detecting frame is withheld; subsequent frames flow without detection."""
+def test_detection_withholds_phrase_tail_then_opens(stub_model: type[_StubModel], fake_clock: SimpleNamespace) -> None:
+    """The detecting frame and the wake phrase tail are withheld; later frames flow without detection."""
     gate = WakeWordGate()
     stub_model.score = 0.9
 
     assert gate.allows(_frame(CHUNK_SAMPLES), 0.0, True) is False
 
     stub_model.score = 0.0
+    assert gate.allows(_frame(CHUNK_SAMPLES), 0.0, True) is False  # tail of "hey jarvis" still sounding
+
+    fake_clock.now += PHRASE_TAIL_SECONDS
     assert gate.allows(_frame(CHUNK_SAMPLES), 0.0, True) is True
-    assert len(stub_model.instances[0].predict_calls) == 1  # no detection while awake
+    assert len(stub_model.instances[0].predict_calls) == 1  # no detection on the tail or while awake
 
 
 def test_awake_window_survives_stale_handler_clock(stub_model: type[_StubModel], fake_clock: SimpleNamespace) -> None:
@@ -88,6 +96,7 @@ def test_awake_window_survives_stale_handler_clock(stub_model: type[_StubModel],
     stub_model.score = 0.9
     gate.allows(_frame(CHUNK_SAMPLES), 0.0, True)
 
+    fake_clock.now += PHRASE_TAIL_SECONDS
     assert gate.allows(_frame(CHUNK_SAMPLES), 999.0, True) is True
 
 
@@ -105,6 +114,7 @@ def test_rearm_after_inactivity_rebuilds_model(stub_model: type[_StubModel], fak
     stub_model.score = 0.9
     gate.allows(_frame(CHUNK_SAMPLES), REARM_SECONDS + 2, True)
     stub_model.score = 0.0
+    fake_clock.now += PHRASE_TAIL_SECONDS
     assert gate.allows(_frame(CHUNK_SAMPLES), 0.0, True) is True
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-13T14:36:32.296430344Z"
+exclude-newer = "2026-07-17T04:00:09.411177396Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1267,6 +1267,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1694,6 +1703,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1899,6 +1917,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/87/eb0abb4ef88ddb95b3c13149384c4c288f584f3be17d6a4f63f8c3e3c226/openai-2.28.0.tar.gz", hash = "sha256:bb7fdff384d2a787fa82e8822d1dd3c02e8cf901d60f1df523b7da03cbb6d48d", size = 670334, upload-time = "2026-03-13T19:56:27.306Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/df122348638885526e53140e9c6b0d844af7312682b3bde9587eebc28b47/openai-2.28.0-py3-none-any.whl", hash = "sha256:79aa5c45dba7fef84085701c235cf13ba88485e1ef4f8dfcedc44fc2a698fc1d", size = 1141218, upload-time = "2026-03-13T19:56:25.46Z" },
+]
+
+[[package]]
+name = "openwakeword"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "onnxruntime" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/40/2afdab3146f08fa51ca74eba6f44ce4f26bd2bd88e255f34b42b0f495ef0/openwakeword-0.4.0.tar.gz", hash = "sha256:58714db20d9fdc6a089e4ef714c98807519ba00822bd32e156ad4f2a00ec9d23", size = 9289877, upload-time = "2023-04-22T22:07:31.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/0f/6b22ebf0808363d0c71f7e5d0880b1c13c6a2cdcae2dc2cb8adfbdbcc278/openwakeword-0.4.0-py3-none-any.whl", hash = "sha256:2c353f49a35d384507403efde3db439353d8281a52d08a0e42a5b493e5145075", size = 9285483, upload-time = "2023-04-22T22:07:28.766Z" },
 ]
 
 [[package]]
@@ -2564,6 +2598,7 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "mcp" },
     { name = "openai" },
+    { name = "openwakeword" },
     { name = "python-dotenv" },
     { name = "reachy-mini" },
     { name = "reachy-mini-dances-library" },
@@ -2586,6 +2621,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.17.0" },
     { name = "mcp", specifier = ">=1.27.1" },
     { name = "openai", specifier = "==2.28.0" },
+    { name = "openwakeword", specifier = ">=0.4.0,<0.5" },
     { name = "python-dotenv" },
     { name = "reachy-mini", specifier = ">=1.10.0rc2" },
     { name = "reachy-mini-dances-library" },
@@ -2976,6 +3012,53 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/e844fd9586e66540a15b71924d17a6cbc1bb749e81ddd0a796bcdba4c055/scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b", size = 8789686, upload-time = "2026-06-02T11:53:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/ff880f62677a17d035817d543cb0fc8727d01eccbee81c5f7fc733a9d856/scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c", size = 8256782, upload-time = "2026-06-02T11:53:08.904Z" },
+    { url = "https://files.pythonhosted.org/packages/25/64/eb40435e1a508ab1b4e284ce43ae80f6a162e5be5e38ed5a6fab467a9ea4/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa", size = 8992419, upload-time = "2026-06-02T11:53:11.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/4810a28e473185429e45a57eebcc91fc991b33d889cc0676063e671db03d/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8", size = 9281411, upload-time = "2026-06-02T11:53:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/be3d369f40d8178ba3bd86635d132e08cb5329b023e4669d9426d84bc007/scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759", size = 8272736, upload-time = "2026-06-02T11:53:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/a733f02dc2118da7e77a134b34f39f40201a353311b011d20859d2db3556/scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28", size = 7919564, upload-time = "2026-06-02T11:53:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3151,6 +3234,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
Saying "hey jarvis" made the robot respond to the wake phrase itself (e.g. "that's not my name"). openWakeWord's score crosses the detection threshold while the phrase is still sounding, so the freshly opened gate forwarded the phrase tail; the backend's server VAD picked it up as a user turn and the model answered it.

The gate now stays closed for a 0.5 s tail window (`PHRASE_TAIL_SECONDS`) after detection, dropping the remainder of the phrase on-device before streaming starts. Detection still doesn't run during the window or while awake, so conversation latency is unchanged. Regression test added; README wake-word section updated to describe the tail window.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>

## Notes
Trade-off: a command said in the same breath as the wake phrase loses its first 0.5 s after detection. Since detection fires near the end of the phrase this mostly swallows the phrase tail; if it clips fast follow-on speech in practice, the constant can be shrunk or replaced with an energy-based phrase-end check. Not yet verified on the robot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)