### PR TITLE
Standby mode: local wake word instead of app exit on go_to_sleep (opt-in)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
     "mcp>=1.27.1",
 ]
 
+[project.optional-dependencies]
+# Local wake word for standby mode (STANDBY_ON_SLEEP=1)
+wakeword = ["openwakeword>=0.6.0"]
+
 [dependency-groups]
 dev = [
   "allure-pytest==2.16.0",

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -120,8 +120,26 @@ def _env_flag(name: str, default: bool = False) -> bool:
     return default
 
 
+def _env_float(name: str, default: float) -> float:
+    """Parse a float environment value, falling back to ``default`` on errors."""
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid float value for %s=%r, using default=%s", name, raw, default)
+        return default
+
+
 APP_TIMEOUT_MINUTES_ENV = "REACHY_MINI_APP_TIMEOUT_MINUTES"
 DEFAULT_APP_TIMEOUT_MINUTES = 1440.0
+
+STANDBY_ON_SLEEP_ENV = "STANDBY_ON_SLEEP"
+WAKE_WORD_MODEL_ENV = "WAKE_WORD_MODEL"
+WAKE_WORD_THRESHOLD_ENV = "WAKE_WORD_THRESHOLD"
+DEFAULT_WAKE_WORD_MODEL = "hey_jarvis_v0.1"
+DEFAULT_WAKE_WORD_THRESHOLD = 0.5
 
 
 def resolve_app_timeout_minutes() -> float | None:
@@ -322,6 +340,12 @@ class Config:
     AUTOLOAD_EXTERNAL_TOOLS = _env_flag("AUTOLOAD_EXTERNAL_TOOLS", default=False)
     REACHY_MINI_CUSTOM_PROFILE = LOCKED_PROFILE or os.getenv("REACHY_MINI_CUSTOM_PROFILE")
 
+    # Standby mode: "go to sleep" closes the realtime connection but keeps the
+    # app alive, listening for a local wake word instead of exiting.
+    STANDBY_ON_SLEEP = _env_flag(STANDBY_ON_SLEEP_ENV, default=False)
+    WAKE_WORD_MODEL = (os.getenv(WAKE_WORD_MODEL_ENV) or DEFAULT_WAKE_WORD_MODEL).strip()
+    WAKE_WORD_THRESHOLD = _env_float(WAKE_WORD_THRESHOLD_ENV, DEFAULT_WAKE_WORD_THRESHOLD)
+
     logger.debug(f"Custom Profile: {REACHY_MINI_CUSTOM_PROFILE}")
 
     def __init__(self) -> None:
@@ -413,6 +437,9 @@ def refresh_runtime_config_from_env() -> None:
     )
     config.HF_TOKEN = os.getenv("HF_TOKEN")
     config.REACHY_MINI_CUSTOM_PROFILE = LOCKED_PROFILE or os.getenv("REACHY_MINI_CUSTOM_PROFILE")
+    config.STANDBY_ON_SLEEP = _env_flag(STANDBY_ON_SLEEP_ENV, default=False)
+    config.WAKE_WORD_MODEL = (os.getenv(WAKE_WORD_MODEL_ENV) or DEFAULT_WAKE_WORD_MODEL).strip()
+    config.WAKE_WORD_THRESHOLD = _env_float(WAKE_WORD_THRESHOLD_ENV, DEFAULT_WAKE_WORD_THRESHOLD)
 
 
 def get_available_voices() -> list[str]:

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -141,6 +141,9 @@ class LocalStream:
         # Set the instant standby is requested, before the (possibly slow)
         # detector build: from that moment mic frames stop reaching the backend.
         self._standby_pending = False
+        # True while the physical wake-up move runs; keeps the backend gated
+        # and the detector quiet until the head is back in the open pose.
+        self._waking = False
         self._wake_detector: Any = None
         self._wake_detector_lock = threading.Lock()
         self._on_wake: Callable[[], None] | None = None
@@ -314,18 +317,30 @@ class LocalStream:
         return True
 
     async def _exit_standby(self, reason: str) -> None:
-        """Loop-side standby exit: wake the robot and reconnect the backend."""
-        if not self._standby:
+        """Loop-side standby exit: wake the robot, THEN reconnect the backend.
+
+        ``_standby`` stays True while the wake move runs so the startup loop
+        cannot reconnect (and the model cannot speak) until the head is back
+        in the open pose — muffled in-shell speech feeds the robot's own mic.
+        """
+        if not self._standby or self._waking:
             return
+        self._waking = True
         logger.info("Waking from standby (%s).", reason)
-        self._standby = False
-        self._standby_pending = False
         self._emit_phase("waking", reason)
-        if self._on_wake is not None:
-            try:
-                await asyncio.to_thread(self._on_wake)
-            except Exception:
-                logger.exception("Physical wake-up failed; reconnecting backend anyway.")
+        try:
+            if self._on_wake is not None:
+                try:
+                    await asyncio.to_thread(self._on_wake)
+                except Exception:
+                    logger.exception("Physical wake-up failed; reconnecting backend anyway.")
+        finally:
+            # No awaits between clearing the gate and requesting the restart:
+            # the startup loop must observe both together.
+            self._standby = False
+            self._standby_pending = False
+            self._waking = False
+        logger.info("Wake-up move complete; reconnecting backend.")
         self._set_backend_connection_state("connecting")
         self._restart_requested.set()
 
@@ -1002,8 +1017,13 @@ class LocalStream:
                 if self._standby:
                     # Local wake-word scoring only — the backend is down and
                     # this frame goes no further than the detector's window.
+                    # Quiet during the wake move (its chime must not re-fire).
                     detector = self._wake_detector
-                    if detector is not None and detector.process(input_sample_rate, audio_frame):
+                    if (
+                        not self._waking
+                        and detector is not None
+                        and detector.process(input_sample_rate, audio_frame)
+                    ):
                         await self._exit_standby("wake_word")
                 elif self._standby_pending:
                     # Sleep requested but standby not armed yet: drop the

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -8,6 +8,7 @@ import os
 import time
 import asyncio
 import logging
+import threading
 from typing import Any, List, Optional
 from pathlib import Path
 from collections.abc import Callable
@@ -137,7 +138,11 @@ class LocalStream:
         # Standby: backend disconnected, mic routed to the local wake-word
         # detector only. _on_wake runs the physical wake-up (motors, wobbling).
         self._standby = False
+        # Set the instant standby is requested, before the (possibly slow)
+        # detector build: from that moment mic frames stop reaching the backend.
+        self._standby_pending = False
         self._wake_detector: Any = None
+        self._wake_detector_lock = threading.Lock()
         self._on_wake: Callable[[], None] | None = None
         self._install_handler(handler)
 
@@ -231,6 +236,29 @@ class LocalStream:
         """Set the callback that physically wakes the robot on standby exit."""
         self._on_wake = on_wake
 
+    def _build_wake_detector_if_needed(self) -> Any:
+        """Build (or return) the wake-word detector; safe from any thread."""
+        with self._wake_detector_lock:
+            if self._wake_detector is None:
+                from reachy_mini_conversation_app.standby import build_wake_word_detector
+
+                self._wake_detector = build_wake_word_detector(
+                    config.WAKE_WORD_MODEL, config.WAKE_WORD_THRESHOLD
+                )
+            return self._wake_detector
+
+    def warm_up_wake_word_detector(self) -> None:
+        """Pre-build the wake-word detector in the background at startup.
+
+        Loading the model cold can take >10 s on-robot; doing it here keeps
+        the sleep-to-standby transition (and its mic cutoff) near-instant.
+        """
+        threading.Thread(
+            target=self._build_wake_detector_if_needed,
+            daemon=True,
+            name="wake-word-warmup",
+        ).start()
+
     def enter_standby(self) -> bool:
         """Enter standby from any thread. Returns False if standby is unavailable.
 
@@ -243,18 +271,19 @@ class LocalStream:
         if not self._can_rebuild_handler():
             logger.error("Standby unavailable: no handler factory to reconnect with later.")
             return False
-        if self._wake_detector is None:
-            from reachy_mini_conversation_app.standby import build_wake_word_detector
 
-            self._wake_detector = build_wake_word_detector(
-                config.WAKE_WORD_MODEL, config.WAKE_WORD_THRESHOLD
-            )
-        if self._wake_detector is None:
+        # Cut the mic off from the backend immediately; the detector build
+        # below may take seconds on a cold start and the robot is already
+        # visibly asleep when this is called.
+        self._standby_pending = True
+        if self._build_wake_detector_if_needed() is None:
+            self._standby_pending = False
             logger.error("Standby unavailable: wake word detector could not be initialized.")
             return False
 
         loop = self._asyncio_loop
         if loop is None or not loop.is_running():
+            self._standby_pending = False
             logger.error("Standby unavailable: stream loop is not running.")
             return False
         asyncio.run_coroutine_threadsafe(self._enter_standby(), loop)
@@ -263,9 +292,14 @@ class LocalStream:
     async def _enter_standby(self) -> None:
         """Loop-side standby entry: close the backend and arm the wake word."""
         if self._standby:
+            self._standby_pending = False
             return
         self._wake_detector.reset()
         self._standby = True
+        self._standby_pending = False
+        # Flush any in-flight assistant speech: the robot is asleep and must
+        # not keep talking (its own muffled audio can read as a barge-in).
+        self.clear_audio_queue()
         self._set_backend_connection_state("standby")
         self._emit_phase("standby", "go_to_sleep")
         await self._shutdown_active_handler()
@@ -285,6 +319,7 @@ class LocalStream:
             return
         logger.info("Waking from standby (%s).", reason)
         self._standby = False
+        self._standby_pending = False
         self._emit_phase("waking", reason)
         if self._on_wake is not None:
             try:
@@ -860,6 +895,10 @@ class LocalStream:
                 return
             self._set_backend_connection_state("not_started")
 
+        # Pre-load the wake-word model so entering standby later is instant.
+        if bool(getattr(config, "STANDBY_ON_SLEEP", False)):
+            self.warm_up_wake_word_detector()
+
         # Start media after key is set/available
         self._robot.media.start_recording()
         self._robot.media.start_playing()
@@ -966,6 +1005,10 @@ class LocalStream:
                     detector = self._wake_detector
                     if detector is not None and detector.process(input_sample_rate, audio_frame):
                         await self._exit_standby("wake_word")
+                elif self._standby_pending:
+                    # Sleep requested but standby not armed yet: drop the
+                    # frame — nothing may reach the backend anymore.
+                    pass
                 else:
                     await self.handler.receive((input_sample_rate, audio_frame))
                     self._emit_level("user", audio_frame)

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -134,6 +134,11 @@ class LocalStream:
         self._last_turn_state: Optional[str] = None
         # Per-role throttle timestamps for conversation.level (orb audio meter).
         self._last_level_emit: dict[str, float] = {}
+        # Standby: backend disconnected, mic routed to the local wake-word
+        # detector only. _on_wake runs the physical wake-up (motors, wobbling).
+        self._standby = False
+        self._wake_detector: Any = None
+        self._on_wake: Callable[[], None] | None = None
         self._install_handler(handler)
 
     def _install_handler(self, handler: ConversationHandler) -> None:
@@ -215,6 +220,79 @@ class LocalStream:
     def seconds_since_activity(self) -> float:
         """Seconds since the live handler last saw conversation activity."""
         return time.monotonic() - self.handler.last_activity_time
+
+    # ── Standby / wake word ──────────────────────────────────────────────
+    @property
+    def in_standby(self) -> bool:
+        """Return whether the stream is in standby (backend down, local wake word armed)."""
+        return self._standby
+
+    def set_on_wake(self, on_wake: Callable[[], None] | None) -> None:
+        """Set the callback that physically wakes the robot on standby exit."""
+        self._on_wake = on_wake
+
+    def enter_standby(self) -> bool:
+        """Enter standby from any thread. Returns False if standby is unavailable.
+
+        Refuses (rather than degrades) when the wake-word detector cannot be
+        built or the handler cannot be rebuilt later: entering an unwakeable
+        standby would strand the robot.
+        """
+        if self._standby:
+            return True
+        if not self._can_rebuild_handler():
+            logger.error("Standby unavailable: no handler factory to reconnect with later.")
+            return False
+        if self._wake_detector is None:
+            from reachy_mini_conversation_app.standby import build_wake_word_detector
+
+            self._wake_detector = build_wake_word_detector(
+                config.WAKE_WORD_MODEL, config.WAKE_WORD_THRESHOLD
+            )
+        if self._wake_detector is None:
+            logger.error("Standby unavailable: wake word detector could not be initialized.")
+            return False
+
+        loop = self._asyncio_loop
+        if loop is None or not loop.is_running():
+            logger.error("Standby unavailable: stream loop is not running.")
+            return False
+        asyncio.run_coroutine_threadsafe(self._enter_standby(), loop)
+        return True
+
+    async def _enter_standby(self) -> None:
+        """Loop-side standby entry: close the backend and arm the wake word."""
+        if self._standby:
+            return
+        self._wake_detector.reset()
+        self._standby = True
+        self._set_backend_connection_state("standby")
+        self._emit_phase("standby", "go_to_sleep")
+        await self._shutdown_active_handler()
+        logger.info("Standby: backend connection closed; local wake word armed.")
+
+    def exit_standby(self, reason: str) -> bool:
+        """Exit standby from any thread. Returns False if not in standby."""
+        loop = self._asyncio_loop
+        if not self._standby or loop is None or not loop.is_running():
+            return False
+        asyncio.run_coroutine_threadsafe(self._exit_standby(reason), loop)
+        return True
+
+    async def _exit_standby(self, reason: str) -> None:
+        """Loop-side standby exit: wake the robot and reconnect the backend."""
+        if not self._standby:
+            return
+        logger.info("Waking from standby (%s).", reason)
+        self._standby = False
+        self._emit_phase("waking", reason)
+        if self._on_wake is not None:
+            try:
+                await asyncio.to_thread(self._on_wake)
+            except Exception:
+                logger.exception("Physical wake-up failed; reconnecting backend anyway.")
+        self._set_backend_connection_state("connecting")
+        self._restart_requested.set()
 
     def _read_env_lines(self, env_path: Path) -> list[str]:
         """Load env file contents or a template as a list of lines."""
@@ -559,6 +637,7 @@ class LocalStream:
                 "can_proceed": has_hf_connection,
                 "can_proceed_with_hf": has_hf_connection,
                 "requires_restart": not self._can_rebuild_handler(),
+                "in_standby": self._standby,
                 **backend_connection,
             }
 
@@ -602,6 +681,12 @@ class LocalStream:
             self._last_turn_state = "listening"
             rpc.broadcast_threadsafe("conversation.turn", {"state": "listening", "reason": "interrupted"})
             return {"ok": True}
+
+        @rpc.method("conversation.wake")  # type: ignore[untyped-decorator]
+        def _rpc_wake(_params: dict[str, object]) -> dict[str, object]:
+            if not self._standby:
+                raise JsonRpcError("not in standby", reason="not_in_standby")
+            return {"ok": self.exit_standby("rpc")}
 
         @rpc.method("conversation.mic")  # type: ignore[untyped-decorator]
         def _rpc_mic(params: dict[str, object]) -> dict[str, object]:
@@ -667,6 +752,10 @@ class LocalStream:
     async def _run_handler_startup_loop(self) -> None:
         """Start the realtime handler and keep settings UI alive after backend failures."""
         while not self._stop_event.is_set():
+            if self._standby:
+                # Backend stays down until exit_standby() requests a restart.
+                await self._sleep_or_restart_requested(0.5)
+                continue
             if self._restart_requested.is_set():
                 await self._shutdown_active_handler()
                 if not self._can_rebuild_handler():
@@ -711,6 +800,9 @@ class LocalStream:
             else:
                 if self._stop_event.is_set():
                     return
+                if self._standby:
+                    logger.info("Backend stopped for standby.")
+                    continue
                 self._set_backend_connection_state("disconnected")
                 if self._restart_requested.is_set():
                     logger.info("Backend stopped for requested restart.")
@@ -868,8 +960,15 @@ class LocalStream:
         while not self._stop_event.is_set():
             audio_frame = self._robot.media.get_audio_sample()
             if audio_frame is not None and not self._mic_muted:
-                await self.handler.receive((input_sample_rate, audio_frame))
-                self._emit_level("user", audio_frame)
+                if self._standby:
+                    # Local wake-word scoring only — the backend is down and
+                    # this frame goes no further than the detector's window.
+                    detector = self._wake_detector
+                    if detector is not None and detector.process(input_sample_rate, audio_frame):
+                        await self._exit_standby("wake_word")
+                else:
+                    await self.handler.receive((input_sample_rate, audio_frame))
+                    self._emit_level("user", audio_frame)
             await asyncio.sleep(0)  # avoid busy loop
 
     async def play_loop(self) -> None:

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -286,8 +286,21 @@ def run(
     deps.go_to_sleep = go_to_sleep_and_stop_app
 
     def wake_robot_from_standby() -> None:
-        """Physically wake the robot when standby exits (runs off the event loop)."""
-        app_lifecycle.wake_up_if_sleeping(robot, logger)
+        """Physically wake the robot when standby exits (runs off the event loop).
+
+        Unconditional (no sleep-pose check): standby always follows
+        goto_sleep, and the head MUST be back in the open pose before the
+        backend reconnects — speaking from inside the sleep shell muffles
+        audio into the robot's own mic.
+        """
+        try:
+            robot.enable_motors()
+        except Exception as e:
+            logger.debug("Error enabling motors on wake: %s", e)
+        try:
+            robot.wake_up()  # blocking: head is up before this returns
+        except Exception as e:
+            logger.error("Wake-up movement failed: %s", e)
         movement_manager.start()
         try:
             robot.enable_wobbling()

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -34,15 +34,23 @@ def _start_inactivity_timeout_thread(
     go_to_sleep: Callable[[], dict[str, Any]] | None = None,
 ) -> threading.Thread:
     """Start a daemon that puts the app to sleep after inactivity."""
-    timeout_seconds = timeout_minutes * 60.0
 
     def poll_inactivity_timeout() -> None:
+        from reachy_mini_conversation_app.config import resolve_app_timeout_minutes
+
         logger.info("App inactivity timeout enabled: %.1f minutes.", timeout_minutes)
         while app_stop_event is None or not app_stop_event.is_set():
             if stream_manager.in_standby:
                 # Asleep already; the wake word re-arms the timer via a fresh handler.
                 time.sleep(1.0)
                 continue
+            # Re-read each pass so runtime changes (e.g. a voice tool updating
+            # the env var) take effect without an app restart.
+            current_minutes = resolve_app_timeout_minutes()
+            if current_minutes is None:
+                time.sleep(5.0)
+                continue
+            timeout_seconds = current_minutes * 60.0
             elapsed = stream_manager.seconds_since_activity()
             if elapsed >= timeout_seconds:
                 logger.info("No activity for %.1f minutes; going to sleep.", elapsed / 60.0)

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -39,13 +39,19 @@ def _start_inactivity_timeout_thread(
     def poll_inactivity_timeout() -> None:
         logger.info("App inactivity timeout enabled: %.1f minutes.", timeout_minutes)
         while app_stop_event is None or not app_stop_event.is_set():
+            if stream_manager.in_standby:
+                # Asleep already; the wake word re-arms the timer via a fresh handler.
+                time.sleep(1.0)
+                continue
             elapsed = stream_manager.seconds_since_activity()
             if elapsed >= timeout_seconds:
                 logger.info("No activity for %.1f minutes; going to sleep.", elapsed / 60.0)
                 try:
-                    if go_to_sleep is not None:
-                        go_to_sleep()
-                    else:
+                    result = go_to_sleep() if go_to_sleep is not None else None
+                    if result is not None and str(result.get("status", "")).startswith("standby"):
+                        time.sleep(1.0)
+                        continue
+                    if go_to_sleep is None:
                         stream_manager.close()
                 except Exception as e:
                     logger.error("Error while going to sleep after inactivity timeout: %s", e)
@@ -88,6 +94,7 @@ def run(
     from reachy_mini_conversation_app.moves import MovementManager
     from reachy_mini_conversation_app.config import (
         HF_LOCAL_CONNECTION_MODE,
+        config,
         set_instance_path,
         get_hf_connection_selection,
         resolve_app_timeout_minutes,
@@ -214,16 +221,19 @@ def run(
     go_to_sleep_requested = threading.Event()
 
     def go_to_sleep_and_stop_app() -> dict[str, Any]:
-        """Put Reachy to sleep, then stop the current app."""
+        """Put Reachy to sleep, then enter standby or stop the current app."""
         if not go_to_sleep_lock.acquire(blocking=False):
             return {"status": "already_requested"}
 
         try:
             if go_to_sleep_requested.is_set():
                 return {"status": "already_requested"}
-            go_to_sleep_requested.set()
 
-            logger.info("Going to sleep before stopping conversation app.")
+            standby_enabled = bool(getattr(config, "STANDBY_ON_SLEEP", False))
+            logger.info(
+                "Going to sleep (%s).",
+                "standby with local wake word" if standby_enabled else "stopping conversation app",
+            )
             sleep_error: str | None = None
 
             try:
@@ -239,6 +249,16 @@ def run(
                 sleep_error = f"{type(e).__name__}: {e}"
                 logger.error("Failed to move Reachy Mini to sleep pose: %s", e)
 
+            if standby_enabled and stream_manager.enter_standby():
+                result_status = "standby" if sleep_error is None else "standby_requested"
+                standby_result: dict[str, Any] = {"status": result_status}
+                if sleep_error is not None:
+                    standby_result["error"] = f"go_to_sleep movement failed: {sleep_error}"
+                return standby_result
+            if standby_enabled:
+                logger.warning("Standby unavailable; falling back to stopping the app.")
+
+            go_to_sleep_requested.set()
             stop_current_app_requested = False
             if app_stop_event is None or not app_stop_event.is_set():
                 stop_current_app_requested = app_lifecycle.request_stop_current_app(robot, logger)
@@ -264,6 +284,17 @@ def run(
             go_to_sleep_lock.release()
 
     deps.go_to_sleep = go_to_sleep_and_stop_app
+
+    def wake_robot_from_standby() -> None:
+        """Physically wake the robot when standby exits (runs off the event loop)."""
+        app_lifecycle.wake_up_if_sleeping(robot, logger)
+        movement_manager.start()
+        try:
+            robot.enable_wobbling()
+        except Exception as e:
+            logger.debug("Error re-enabling wobbling on wake: %s", e)
+
+    stream_manager.set_on_wake(wake_robot_from_standby)
 
     def run_go_to_sleep_tool() -> dict[str, Any]:
         return app_lifecycle.run_go_to_sleep_tool(deps, logger)

--- a/src/reachy_mini_conversation_app/standby.py
+++ b/src/reachy_mini_conversation_app/standby.py
@@ -1,0 +1,102 @@
+"""Local wake-word detection for standby mode.
+
+While the app is in standby the realtime backend connection is closed, so no
+audio leaves the robot. Mic frames are routed here instead: they are resampled
+to 16 kHz, chunked, and scored by an openWakeWord model entirely on-device.
+Frames are never buffered beyond the ~80 ms analysis window and never stored.
+
+openwakeword is an optional dependency (``pip install
+reachy-mini-conversation-app[wakeword]``); standby mode refuses to engage
+without it rather than leaving the robot unwakeable by voice.
+"""
+
+from __future__ import annotations
+import logging
+from math import gcd
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from reachy_mini_conversation_app.streaming import audio_to_float32
+
+
+logger = logging.getLogger(__name__)
+
+TARGET_SAMPLE_RATE = 16000
+# openWakeWord scores fixed 80 ms windows (1280 samples @ 16 kHz).
+CHUNK_SAMPLES = 1280
+
+
+class WakeWordDetector:
+    """Streaming wrapper around an openWakeWord model.
+
+    Feed arbitrary-size mic frames via :meth:`process`; it returns ``True``
+    once the wake phrase is detected, after which internal state is reset so
+    the detector can be reused for the next standby period.
+    """
+
+    def __init__(self, model_name: str, threshold: float) -> None:
+        """Load ``model_name`` (a pretrained name or a path to an .onnx file)."""
+        # Deferred import: openwakeword is an optional extra.
+        from openwakeword.model import Model as OwwModel
+
+        self._model = OwwModel(wakeword_models=[model_name], inference_framework="onnx")
+        self._threshold = threshold
+        self._buffer: NDArray[np.int16] = np.empty(0, dtype=np.int16)
+        logger.info(
+            "Wake word detector ready (model=%s, threshold=%.2f)", model_name, threshold
+        )
+
+    def reset(self) -> None:
+        """Drop buffered audio and model state (call when leaving standby)."""
+        self._buffer = np.empty(0, dtype=np.int16)
+        try:
+            self._model.reset()
+        except Exception:
+            logger.debug("openwakeword model reset failed (ignored)", exc_info=True)
+
+    def _to_mono_16k_int16(self, sample_rate: int, frame: Any) -> NDArray[np.int16]:
+        """Convert one mic frame to mono 16 kHz int16 samples."""
+        samples = audio_to_float32(frame)
+        if samples.ndim == 2:
+            # channels-last convention, mirror LocalStream.play_loop
+            if samples.shape[1] > samples.shape[0]:
+                samples = samples.T
+            samples = samples.mean(axis=1)
+        if sample_rate != TARGET_SAMPLE_RATE:
+            from scipy.signal import resample_poly
+
+            divisor = gcd(sample_rate, TARGET_SAMPLE_RATE)
+            samples = resample_poly(samples, TARGET_SAMPLE_RATE // divisor, sample_rate // divisor)
+        return np.clip(samples * 32767.0, -32768, 32767).astype(np.int16)
+
+    def process(self, sample_rate: int, frame: Any) -> bool:
+        """Score one mic frame; return True when the wake phrase is detected."""
+        self._buffer = np.concatenate([self._buffer, self._to_mono_16k_int16(sample_rate, frame)])
+
+        detected = False
+        while self._buffer.size >= CHUNK_SAMPLES and not detected:
+            chunk, self._buffer = self._buffer[:CHUNK_SAMPLES], self._buffer[CHUNK_SAMPLES:]
+            scores = self._model.predict(chunk)
+            best = max(scores.values()) if scores else 0.0
+            if best >= self._threshold:
+                logger.info("Wake word detected (score=%.2f)", best)
+                detected = True
+
+        if detected:
+            self.reset()
+        return detected
+
+
+def build_wake_word_detector(model_name: str, threshold: float) -> WakeWordDetector | None:
+    """Build the detector, returning None (with a log) when unavailable."""
+    try:
+        return WakeWordDetector(model_name, threshold)
+    except ImportError:
+        logger.error(
+            "openwakeword is not installed; install the [wakeword] extra to use standby mode."
+        )
+    except Exception:
+        logger.exception("Failed to initialize wake word model %r", model_name)
+    return None

--- a/tests/test_standby.py
+++ b/tests/test_standby.py
@@ -1,0 +1,102 @@
+"""Tests for standby wake-word detection plumbing."""
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from reachy_mini_conversation_app.standby import (
+    CHUNK_SAMPLES,
+    TARGET_SAMPLE_RATE,
+    WakeWordDetector,
+    build_wake_word_detector,
+)
+
+
+class _FakeOwwModel:
+    """Stands in for openwakeword.model.Model; scores are driven by the test."""
+
+    def __init__(self, wakeword_models, inference_framework="onnx"):
+        self.wakeword_models = wakeword_models
+        self.inference_framework = inference_framework
+        self.chunks: list[np.ndarray] = []
+        self.scores: list[float] = []
+        self.reset_calls = 0
+
+    def predict(self, chunk):
+        self.chunks.append(chunk)
+        score = self.scores.pop(0) if self.scores else 0.0
+        return {"fake_model": score}
+
+    def reset(self):
+        self.reset_calls += 1
+
+
+@pytest.fixture
+def fake_openwakeword(monkeypatch):
+    """Install a fake openwakeword package and return the model instances it builds."""
+    instances: list[_FakeOwwModel] = []
+
+    def factory(*args, **kwargs):
+        model = _FakeOwwModel(*args, **kwargs)
+        instances.append(model)
+        return model
+
+    module = types.ModuleType("openwakeword")
+    model_module = types.ModuleType("openwakeword.model")
+    model_module.Model = factory
+    module.model = model_module
+    monkeypatch.setitem(sys.modules, "openwakeword", module)
+    monkeypatch.setitem(sys.modules, "openwakeword.model", model_module)
+    return instances
+
+
+def _int16_frame(num_samples: int) -> np.ndarray:
+    return np.zeros(num_samples, dtype=np.int16)
+
+
+def test_detector_buffers_until_full_chunk(fake_openwakeword):
+    """Frames smaller than one chunk buffer without scoring."""
+    detector = WakeWordDetector("fake_model", threshold=0.5)
+    model = fake_openwakeword[0]
+
+    assert detector.process(TARGET_SAMPLE_RATE, _int16_frame(CHUNK_SAMPLES // 2)) is False
+    assert model.chunks == []
+
+    assert detector.process(TARGET_SAMPLE_RATE, _int16_frame(CHUNK_SAMPLES // 2)) is False
+    assert len(model.chunks) == 1
+    assert model.chunks[0].size == CHUNK_SAMPLES
+    assert model.chunks[0].dtype == np.int16
+
+
+def test_detector_fires_at_threshold_and_resets(fake_openwakeword):
+    """Detection fires at threshold and resets detector state."""
+    detector = WakeWordDetector("fake_model", threshold=0.5)
+    model = fake_openwakeword[0]
+    model.scores = [0.2, 0.9]
+
+    assert detector.process(TARGET_SAMPLE_RATE, _int16_frame(CHUNK_SAMPLES)) is False
+    assert detector.process(TARGET_SAMPLE_RATE, _int16_frame(CHUNK_SAMPLES)) is True
+    # Detection resets buffered audio and model state for the next standby.
+    assert model.reset_calls == 1
+    assert detector._buffer.size == 0
+
+
+def test_detector_resamples_other_rates(fake_openwakeword):
+    """Non-16 kHz stereo input is resampled and mono-ized to chunks."""
+    detector = WakeWordDetector("fake_model", threshold=0.5)
+    model = fake_openwakeword[0]
+
+    # 48 kHz stereo frame, channels-last: enough for exactly one 16 kHz chunk.
+    frame = np.zeros((CHUNK_SAMPLES * 3, 2), dtype=np.float32)
+    detector.process(48000, frame)
+    assert len(model.chunks) == 1
+    assert model.chunks[0].size == CHUNK_SAMPLES
+
+
+def test_build_detector_returns_none_without_openwakeword(monkeypatch):
+    """Missing openwakeword dependency yields None, not a crash."""
+    monkeypatch.setitem(sys.modules, "openwakeword", None)
+    monkeypatch.setitem(sys.modules, "openwakeword.model", None)
+    assert build_wake_word_detector("hey_jarvis_v0.1", 0.5) is None


### PR DESCRIPTION
## Motivation

For an always-on (especially Wireless) Reachy Mini, `go_to_sleep` currently stops the app, so waking means a full app restart (~15–25 s). This PR adds an **opt-in standby mode** aimed at privacy-conscious always-on use:

- "Go to sleep" closes the realtime backend connection (zero audio leaves the robot) but keeps the app alive.
- Mic frames are routed only to an on-device [openWakeWord](https://github.com/dscripka/openWakeWord) model (default phrase: "hey Jarvis").
- On detection, the robot physically wakes and the backend reconnects — measured **under 3 seconds** voice-to-ready on a Wireless unit, vs the current full restart.

## Design

- `STANDBY_ON_SLEEP=1` env flag (default **off** — stock behavior unchanged), plus `WAKE_WORD_MODEL` / `WAKE_WORD_THRESHOLD`.
- New `standby.py`: streaming `WakeWordDetector` (any input rate → mono 16 kHz int16 chunks, ONNX inference only).
- `LocalStream`: `enter_standby()` / `exit_standby()` with startup-loop gating so the retry loop can't silently reconnect while asleep; `conversation.wake` RPC method; `in_standby` in status.
- `main.py`: the `go_to_sleep` tool branches into standby; the inactivity timer re-arms across sleep/wake cycles; a wake hook re-enables motors/wobbling (builds on #510).
- **Fail-safe**: if the detector or handler factory is unavailable, standby refuses and the existing stop-the-app path runs — the robot is never left unwakeable.
- `openwakeword` is an optional `[wakeword]` extra.

## Testing

- Unit tests for the detector (buffering, thresholds, resampling, missing-dependency fallback).
- End-to-end on a physical Reachy Mini Wireless (RPi CM4, Python 3.12) via a v0.10.0 backport of this branch (`standby-v0.10.0` on the fork, since the robot ships SDK 1.9.0): inactivity → standby (backend closed, wake word armed) → wake → reconnected in <3 s. Detector validated on-device with synthesized positive/negative phrases.
- Marked **draft** because this `main`-based branch itself hasn't run on hardware with SDK 1.10 yet.

## Caveat worth discussing

`openwakeword>=0.6.0` declares `tflite-runtime` on Linux, which has **no Python 3.12 wheels** — on the robot we installed it `--no-deps` (the ONNX path needs nothing from tflite). Happy to adapt if you'd prefer vendoring the ONNX inference, or wiring in pollen-robotics/wake-word-detector instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)