### PR TITLE
perf(startup): warm openai+scipy imports during robot init; pre-import the openai realtime tree

### DIFF
--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -26,6 +26,34 @@ if TYPE_CHECKING:
     from reachy_mini_conversation_app.console import LocalStream
 
 
+_import_warmup_thread: threading.Thread | None = None
+
+
+def start_import_warmup() -> threading.Thread:
+    """Preload heavy modules in the background while the robot connects.
+
+    openai (~1.5s) and scipy (~1s on the robot) are needed by the realtime
+    handler and the movement manager, but not before the robot / media
+    pipelines are up. Importing them on a side thread overlaps that cost with
+    robot initialization instead of paying it serially. Idempotent; errors are
+    deferred to the real import site, which reports them with full context.
+    """
+    global _import_warmup_thread
+    if _import_warmup_thread is None:
+
+        def _preload() -> None:
+            try:
+                import scipy.spatial.transform  # noqa: F401
+
+                import reachy_mini_conversation_app.huggingface_realtime  # noqa: F401
+            except Exception:
+                logging.getLogger(__name__).debug("Import warmup failed", exc_info=True)
+
+        _import_warmup_thread = threading.Thread(target=_preload, name="import-warmup", daemon=True)
+        _import_warmup_thread.start()
+    return _import_warmup_thread
+
+
 def _start_inactivity_timeout_thread(
     timeout_minutes: float,
     stream_manager: LocalStream,
@@ -84,6 +112,7 @@ def run(
     instance_path: Optional[str] = None,
 ) -> None:
     """Run the Reachy Mini conversation app."""
+    start_import_warmup()
     # Putting these dependencies here makes the dashboard faster to load when the conversation app is installed
     from reachy_mini_conversation_app.moves import MovementManager
     from reachy_mini_conversation_app.config import (
@@ -351,6 +380,11 @@ class ReachyMiniConversationApp(ReachyMiniApp):  # type: ignore[misc]
 
     custom_app_url = "http://0.0.0.0:7860/"
     dont_start_webserver = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Start preloading heavy imports before the robot/media init in wrapped_run."""
+        start_import_warmup()
+        super().__init__(*args, **kwargs)
 
     def run(self, reachy_mini: ReachyMini, stop_event: threading.Event) -> None:
         """Run the Reachy Mini conversation app."""

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -45,6 +45,13 @@ def start_import_warmup() -> threading.Thread:
             try:
                 import scipy.spatial.transform  # noqa: F401
 
+                # AsyncOpenAI.realtime is a cached_property whose module tree
+                # (~1.6s on the CM4) otherwise loads lazily INSIDE the ws
+                # connect phase; same for the websockets client the SDK pulls
+                # in __aenter__. Importing openai above does NOT cover these.
+                import openai.resources.realtime  # noqa: F401
+                import websockets.asyncio.client  # noqa: F401
+
                 import reachy_mini_conversation_app.huggingface_realtime  # noqa: F401
             except Exception:
                 logging.getLogger(__name__).debug("Import warmup failed", exc_info=True)


### PR DESCRIPTION
Two commits that move import cost off the app-start critical path: total work is unchanged, but it runs during phases where the main thread is just waiting (robot connect, the ~2 s wake move, media init), so it costs ~zero wall-clock.

1. **Warmup thread**: a background thread imports openai + scipy while the robot initializes. Pairs with the SDK import diet (pollen-robotics/reachy_mini#1308), which makes those imports deferrable in the first place — you can't warm what eager imports already loaded before `main()` ran.
2. **openai realtime pre-import**: the "2.2 s websocket connect" was profiled at ~70 % CPU — `AsyncOpenAI.realtime` is a `cached_property` whose module tree (~1.6 s on the CM4) loaded lazily *inside* the connect phase, masquerading as network time. Two import lines in the warmup thread fix it (true network cost of the connect: ~470 ms).

**Measured** (2026-07-30, wireless robot with #1308 installed, standard warm protocol: fresh daemon → sleep pose → start-app POST → "usable" = max(session updated, audio config applied); 3 runs each, first run after each install discarded):

| app start → usable | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| current HF release | 13.78 | 13.66 | 13.96 | **13.8 s** |
| this branch | 10.03 | 10.05 | 10.28 | **10.12 s** |

**−3.7 s (−27 %)** on the wake-later path — the flow users actually experience (robot boots asleep, app starts on wake). Cold power-on → talking is *not* claimed by this PR: during boot all cores are busy, so there are no idle windows to hide imports in.

**Risk**: ~nil — imports only, no reordering of audio/motion/session logic. If the warmup thread dies, behavior is exactly today's (imports happen at first use). 294 non-audio tests pass; ruff/mypy clean.
