### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reachy_mini_conversation_app"
-version = "0.10.0"
+version = "1.0.0"
 authors = [{ name = "Pollen Robotics", email = "contact@pollen-robotics.com" }]
 description = ""
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2557,7 +2557,7 @@ wheels = [
 
 [[package]]
 name = "reachy-mini-conversation-app"
-version = "0.10.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
Bump the package and lockfile version from `0.10.0` to `1.0.0` to prepare the v1.0.0 release.

Closes #516.

## Category
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [x] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>

## Notes
Validated locally with the locked environment: Ruff, formatting, mypy, lockfile sync, and all 307 tests pass.

After merge, tag the merge commit as `v1.0.0`; the release workflow will publish the GitHub release.
