### PR TITLE
Fix/524 and migrate to mcp v2 sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ dependencies = [
     #Reachy mini
     "reachy_mini_dances_library",
     "reachy-mini>=1.10.0rc2",
-    "mcp>=1.27.1",
+    "mcp==2.0.0",
+    "mcp-types==2.0.0",
+    "httpx2>=2.5.0",
 ]
 
 [dependency-groups]

--- a/src/reachy_mini_conversation_app/mcp_client.py
+++ b/src/reachy_mini_conversation_app/mcp_client.py
@@ -8,16 +8,15 @@ downloading third-party Python code.
 from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, AsyncIterator
-from datetime import timedelta
 from contextlib import asynccontextmanager
 from dataclasses import field, dataclass
 from urllib.parse import urlparse
 
 
 if TYPE_CHECKING:
-    from mcp import ClientSession
-    from mcp.types import Tool as McpTool
-    from mcp.types import CallToolResult as McpCallToolResult
+    from mcp import Client
+    from mcp_types import Tool as McpTool
+    from mcp_types import CallToolResult as McpCallToolResult
 
 
 _NAME_SEGMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -110,9 +109,21 @@ def _join_text_content(content_blocks: list[dict[str, Any]]) -> str | None:
     return "\n\n".join(text_parts)
 
 
+def _is_timeout_mcp_error(exc: BaseException) -> bool:
+    """Whether this is the SDK's request-timeout error (JSON-RPC -32001)."""
+    try:
+        from mcp import MCPError
+        from mcp_types import REQUEST_TIMEOUT
+    except ImportError:
+        return False
+    return isinstance(exc, MCPError) and getattr(exc, "code", None) == REQUEST_TIMEOUT
+
+
 def _exception_contains_timeout(exc: BaseException) -> bool:
     timeout_exception = _httpx_timeout_exception_type()
     if isinstance(exc, timeout_exception):
+        return True
+    if _is_timeout_mcp_error(exc):
         return True
 
     if "timed out" in str(exc).lower() or "deadline exceeded" in str(exc).lower():
@@ -130,30 +141,30 @@ def _exception_contains_timeout(exc: BaseException) -> bool:
     return any(_exception_contains_timeout(item) for item in nested)
 
 
-def _load_mcp_sdk() -> tuple[type["ClientSession"], Any]:
+def _load_mcp_sdk() -> tuple[type["Client"], Any]:
     try:
-        from mcp import ClientSession
+        from mcp import Client
         from mcp.client.streamable_http import streamable_http_client
     except ImportError as exc:
         raise McpDependencyError(
             "Remote MCP tools require the app's MCP client dependencies. Reinstall or update the app environment."
         ) from exc
-    return ClientSession, streamable_http_client
+    return Client, streamable_http_client
 
 
-def _load_httpx() -> Any:
+def _load_httpx2() -> Any:
     try:
-        import httpx
+        import httpx2
     except ImportError as exc:
         raise McpDependencyError(
             "Remote MCP tools require the app's HTTP client dependencies. Reinstall or update the app environment."
         ) from exc
-    return httpx
+    return httpx2
 
 
 def _httpx_timeout_exception_type() -> tuple[type[BaseException], ...]:
     try:
-        timeout_exception = _load_httpx().TimeoutException
+        timeout_exception = _load_httpx2().TimeoutException
     except McpDependencyError:
         return (TimeoutError,)
     return (TimeoutError, timeout_exception)
@@ -194,7 +205,7 @@ class RemoteToolSpec:
     def from_mcp_tool(cls, server_alias: str, tool: "McpTool") -> "RemoteToolSpec":
         """Build an app-facing spec from an MCP SDK tool descriptor."""
         description = (getattr(tool, "description", None) or "").strip()
-        parameters_schema = getattr(tool, "inputSchema", None)
+        parameters_schema = getattr(tool, "input_schema", None)
         if not isinstance(parameters_schema, dict):
             parameters_schema = {"type": "object", "properties": {}, "required": []}
 
@@ -246,10 +257,10 @@ class RemoteToolCallResponse:
             server_alias=server_alias,
             remote_tool_name=remote_tool_name,
             namespaced_tool_name=build_namespaced_tool_name(server_alias, remote_tool_name),
-            status="error" if bool(getattr(result, "isError", False)) else "ok",
+            status="error" if bool(getattr(result, "is_error", False)) else "ok",
             content_blocks=content_blocks,
             text=_join_text_content(content_blocks),
-            structured_content=getattr(result, "structuredContent", None),
+            structured_content=getattr(result, "structured_content", None),
         )
 
     def to_tool_result(self) -> dict[str, Any]:
@@ -279,8 +290,8 @@ class RemoteMcpToolClient:
     async def list_tool_specs(self) -> list[RemoteToolSpec]:
         """Discover remote tools and translate them into app-facing specs."""
         try:
-            async with self._session() as session:
-                discovered = await self._list_all_tools(session)
+            async with self._connected_client() as client:
+                discovered = await self._list_all_tools(client)
         except McpDependencyError:
             raise
         except Exception as exc:
@@ -302,11 +313,11 @@ class RemoteMcpToolClient:
         timeout_exception = _httpx_timeout_exception_type()
 
         try:
-            async with self._session() as session:
-                result = await session.call_tool(
+            async with self._connected_client() as client:
+                result = await client.call_tool(
                     spec.remote_name,
                     arguments=dict(arguments or {}),
-                    read_timeout_seconds=timedelta(seconds=self.server.tool_timeout_s),
+                    read_timeout_seconds=self.server.tool_timeout_s,
                 )
         except McpDependencyError:
             raise
@@ -340,32 +351,32 @@ class RemoteMcpToolClient:
             raise ValueError(f"Unknown remote MCP tool '{namespaced_tool_name}' for server '{self.server.alias}'.")
         return spec
 
-    async def _list_all_tools(self, session: "ClientSession") -> list["McpTool"]:
+    async def _list_all_tools(self, client: "Client") -> list["McpTool"]:
         tools: list[McpTool] = []
         cursor: str | None = None
         while True:
-            page = await session.list_tools(cursor=cursor)
+            page = await client.list_tools(cursor=cursor)
             tools.extend(page.tools)
-            cursor = getattr(page, "nextCursor", None)
+            cursor = getattr(page, "next_cursor", None)
             if cursor is None:
                 return tools
 
     @asynccontextmanager
-    async def _session(self) -> AsyncIterator["ClientSession"]:
-        client_session_cls, streamable_http_client = _load_mcp_sdk()
-        httpx = _load_httpx()
+    async def _connected_client(self) -> AsyncIterator["Client"]:
+        client_cls, streamable_http_client = _load_mcp_sdk()
+        httpx2 = _load_httpx2()
         client_timeout = max(self.server.request_timeout_s, self.server.tool_timeout_s)
 
-        async with httpx.AsyncClient(
+        async with httpx2.AsyncClient(
             headers=self.server.headers,
             follow_redirects=False,
             timeout=client_timeout,
         ) as http_client:
-            async with streamable_http_client(self.server.url, http_client=http_client) as transport:
-                read_stream, write_stream, _ = transport
-                async with client_session_cls(read_stream, write_stream) as session:
-                    await session.initialize()
-                    yield session
+            transport = streamable_http_client(self.server.url, http_client=http_client)
+            # The default mode='auto' probes `server/discover` and falls back to the
+            # `initialize` handshake, so one client speaks every protocol revision.
+            async with client_cls(transport) as client:
+                yield client
 
 
 def _index_remote_tools(specs: list[RemoteToolSpec]) -> dict[str, RemoteToolSpec]:

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import pytest
 
 
-pytest.importorskip("mcp.types")
+pytest.importorskip("mcp_types")
 
-from mcp.types import Tool, TextContent, CallToolResult
+from mcp_types import Tool, TextContent, CallToolResult, ListToolsResult
 
 from reachy_mini_conversation_app.mcp_client import (
     RemoteToolSpec,
+    RemoteMcpToolClient,
+    RemoteMcpServerConfig,
     RemoteToolCallResponse,
     validate_http_mcp_url,
     build_namespaced_tool_name,
@@ -37,7 +39,7 @@ def test_remote_tool_spec_translates_to_function_spec() -> None:
     tool = Tool(
         name="search-docs",
         description="Search the docs",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"query": {"type": "string"}},
             "required": ["query"],
@@ -64,8 +66,8 @@ def test_remote_tool_error_result_maps_to_app_payload() -> None:
     """Remote tool errors should remain visible after response mapping."""
     result = CallToolResult(
         content=[TextContent(type="text", text="Search backend unavailable")],
-        structuredContent=None,
-        isError=True,
+        structured_content=None,
+        is_error=True,
     )
 
     payload = RemoteToolCallResponse.from_call_tool_result(
@@ -77,3 +79,74 @@ def test_remote_tool_error_result_maps_to_app_payload() -> None:
     assert payload["status"] == "error"
     assert payload["namespaced_tool_name"] == "gradio_docs__search_docs"
     assert payload["text"] == "Search backend unavailable"
+
+
+def test_remote_tool_spec_reads_fields_the_sdk_actually_exposes() -> None:
+    """Pins the v1→v2 rename: the wire names are pydantic *aliases*, not attributes.
+
+    Reading `tool.inputSchema` returns nothing on v2, which silently degrades every
+    remote tool to an empty parameters schema instead of raising anywhere.
+    """
+    tool = Tool(
+        name="search-docs",
+        description="Search the docs",
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+    )
+    assert not hasattr(tool, "inputSchema")
+
+    spec = RemoteToolSpec.from_mcp_tool("gradio_docs", tool)
+    assert spec.parameters_schema["properties"] == {"query": {"type": "string"}}
+    assert spec.parameters_schema["required"] == ["query"]
+
+
+def test_remote_tool_call_response_reads_fields_the_sdk_actually_exposes() -> None:
+    """Same rename on results: `isError`/`structuredContent` are aliases, so an error would read as success."""
+    result = CallToolResult(
+        content=[TextContent(type="text", text="done")],
+        structured_content={"rows": 2},
+        is_error=True,
+    )
+    assert not hasattr(result, "isError")
+    assert not hasattr(result, "structuredContent")
+
+    response = RemoteToolCallResponse.from_call_tool_result(
+        server_alias="gradio_docs",
+        remote_tool_name="search-docs",
+        result=result,
+    )
+    assert response.status == "error"
+    assert response.structured_content == {"rows": 2}
+
+
+@pytest.mark.asyncio
+async def test_list_all_tools_follows_the_pagination_cursor() -> None:
+    """Pins the v1→v2 rename on the *paging* field, which fails silently.
+
+    `nextCursor` is a pydantic alias on v2, so a client still reading it gets
+    None on a page that genuinely has a successor: discovery stops after page
+    one and every tool beyond it simply never exists, with no error raised
+    anywhere. Servers with a small tool count hide this, which is why it
+    survives casual testing.
+    """
+    first = ListToolsResult(
+        tools=[Tool(name="alpha", description="first page", input_schema={"type": "object"})],
+        nextCursor="page-2",
+    )
+    last = ListToolsResult(
+        tools=[Tool(name="omega", description="second page", input_schema={"type": "object"})],
+    )
+    assert not hasattr(first, "nextCursor")
+
+    pages = [first, last]
+    seen_cursors: list[str | None] = []
+
+    class _PagingClient:
+        async def list_tools(self, *, cursor: str | None = None) -> ListToolsResult:
+            seen_cursors.append(cursor)
+            return pages[len(seen_cursors) - 1]
+
+    client = RemoteMcpToolClient(RemoteMcpServerConfig(alias="gradio_docs", url="https://example.invalid/mcp"))
+    tools = await client._list_all_tools(_PagingClient())
+
+    assert [tool.name for tool in tools] == ["alpha", "omega"]
+    assert seen_cursors == [None, "page-2"]

--- a/tests/test_mcp_client_integration.py
+++ b/tests/test_mcp_client_integration.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 import asyncio
-from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
 
 import pytest
 import uvicorn
 import pytest_asyncio
-from starlette.routing import Mount
 from starlette.responses import PlainTextResponse
-from starlette.applications import Starlette
 
 
-pytest.importorskip("mcp.server.fastmcp")
+pytest.importorskip("mcp.server")
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from reachy_mini_conversation_app.mcp_client import (
     RemoteToolSpec,
@@ -41,7 +38,7 @@ class _BearerAuthMiddleware:
 
 
 def _build_local_mcp_app(required_token: str) -> object:
-    mcp_server = FastMCP("Reachy Test MCP", stateless_http=True, json_response=True)
+    mcp_server = MCPServer("Reachy Test MCP")
 
     @mcp_server.tool()
     def echo_text(message: str) -> dict[str, str]:
@@ -54,14 +51,7 @@ def _build_local_mcp_app(required_token: str) -> object:
         await asyncio.sleep(delay_s)
         return {"echo": message}
 
-    mcp_app = mcp_server.streamable_http_app()
-
-    @asynccontextmanager
-    async def lifespan(_: Starlette) -> AsyncIterator[None]:
-        async with mcp_server.session_manager.run():
-            yield
-
-    app = Starlette(routes=[Mount("/", app=mcp_app)], lifespan=lifespan)
+    app = mcp_server.streamable_http_app(json_response=True, stateless_http=True)
     return _BearerAuthMiddleware(app, required_token)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-13T14:36:32.296430344Z"
+exclude-newer = "2026-08-03T01:25:26.4860129Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1037,6 +1037,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1095,12 +1108,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -1483,15 +1503,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1501,9 +1521,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1902,6 +1935,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2283,20 +2328,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2561,8 +2592,10 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "huggingface-hub" },
     { name = "mcp" },
+    { name = "mcp-types" },
     { name = "openai" },
     { name = "python-dotenv" },
     { name = "reachy-mini" },
@@ -2583,8 +2616,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", specifier = ">=2.5.0" },
     { name = "huggingface-hub", specifier = ">=1.17.0" },
-    { name = "mcp", specifier = ">=1.27.1" },
+    { name = "mcp", specifier = "==2.0.0" },
+    { name = "mcp-types", specifier = "==2.0.0" },
     { name = "openai", specifier = "==2.28.0" },
     { name = "python-dotenv" },
     { name = "reachy-mini", specifier = ">=1.10.0rc2" },
@@ -3226,6 +3261,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #524.

`pyproject.toml` declares `mcp>=1.27.1` with no upper bound. `uv.lock` pins 1.28.1, but the daemon installs apps with `uv pip install` (`reachy_mini/apps/sources/local_common_venv.py`), which ignores the lock and re-resolves to mcp 2.0.0.

v2 renamed the model fields to snake_case and kept the wire names as pydantic aliases. Construction still works, so only attribute reads changed.

This pins `mcp==2.0.0` (plus `mcp-types`, which `mcp` exact-pins) and migrates the client.

Note that `Client`'s default `mode="auto"` probes `server/discover` and falls back to the `initialize` handshake, so one client still speaks both protocol revisions.

## Tests

It appeared that `tests/test_mcp_client_integration.py` was being skipped. It now runs against a real in-process `MCPServer` over uvicorn, exercising the transport, discovery, invocation and the tool timeout.

I also added a pagination regression test for the `nextCursor` rename, since that one fails silently and a small tool list hides it.

Verified against a real `mcp==2.0.0` env: `ruff check .`, `ruff format --check .`, `mypy` (45 files, no issues), `pytest tests/` → **310 passed, 0 skipped**. Swapping the current `mcp_client.py` back in fails 7 of the 10 MCP tests, including both integration tests.

Not yet run against a physical robot with a remote MCP Space.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added) — n/a, no new config vars
- [ ] Installation from the desktop app tested (if applicable)
