### PR TITLE
Refuse settings values that cannot round-trip through the instance .env

### DIFF
--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -339,6 +339,13 @@ class LocalStream:
     def _persist_env_values(self, updates: dict[str, str]) -> None:
         """Persist non-empty environment values in memory and in the instance `.env`."""
         normalized_updates = {name: (value or "").strip() for name, value in updates.items()}
+        # Check before writing anything: a line break would add a second
+        # assignment, and python-dotenv expands ${...} with no way to escape it.
+        unsafe_names = sorted(
+            name for name, value in normalized_updates.items() if "\n" in value or "\r" in value or "${" in value
+        )
+        if unsafe_names:
+            raise ValueError(f"Values must not contain line breaks or '${{': {', '.join(unsafe_names)}.")
         normalized_updates = {name: value for name, value in normalized_updates.items() if value}
         if not normalized_updates:
             return
@@ -610,7 +617,7 @@ class LocalStream:
                 host = str(params.get("hf_host") or "").strip() or existing_host or ""
                 if not host:
                     raise JsonRpcError("Hugging Face host required", reason="empty_hf_host", code=-32602)
-                if "://" in host or "/" in host or "?" in host or "#" in host:
+                if any(char.isspace() for char in host) or "://" in host or "/" in host or "?" in host or "#" in host:
                     raise JsonRpcError("invalid Hugging Face host", reason="invalid_hf_host", code=-32602)
                 raw_port = params.get("hf_port")
                 port = int(raw_port) if isinstance(raw_port, (int, float, str)) else (existing_port or 8765)

--- a/tests/test_env_persistence.py
+++ b/tests/test_env_persistence.py
@@ -1,0 +1,55 @@
+"""Values the settings UI persists must not corrupt the instance `.env`."""
+
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import dotenv
+import pytest
+
+from reachy_mini_conversation_app.console import LocalStream
+
+
+def _stream(instance_path: Path) -> LocalStream:
+    robot = SimpleNamespace(media=SimpleNamespace(audio=SimpleNamespace()))
+    stream = LocalStream(MagicMock(), robot)
+    stream._instance_path = str(instance_path)
+    return stream
+
+
+def test_persist_env_values_rejects_a_line_break_before_writing_anything(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A line break ends the record, so the remainder is parsed as its own assignment."""
+    monkeypatch.setenv("SOME_TOKEN", "")
+    stream = _stream(tmp_path)
+
+    with pytest.raises(ValueError, match="line breaks"):
+        stream._persist_env_values({"SOME_TOKEN": "value\nOPENAI_API_KEY=injected"})
+
+    # Nothing was written.
+    assert not (tmp_path / ".env").exists()
+
+
+def test_persist_env_values_rejects_interpolation_syntax(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """python-dotenv expands `${VAR}` and offers no way to escape it."""
+    monkeypatch.setenv("SOME_TOKEN", "")
+    stream = _stream(tmp_path)
+
+    with pytest.raises(ValueError, match=r"line breaks"):
+        stream._persist_env_values({"SOME_TOKEN": "literal-${HOME}-please"})
+
+    assert not (tmp_path / ".env").exists()
+
+
+def test_persist_env_values_still_writes_an_ordinary_value(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A normal token still persists."""
+    monkeypatch.setenv("SOME_TOKEN", "")
+    env_path = tmp_path / ".env"
+    env_path.write_text("OTHER=keep-me\nSOME_TOKEN=old\n", encoding="utf-8")
+
+    _stream(tmp_path)._persist_env_values({"SOME_TOKEN": "hf_abc123"})
+
+    values = dotenv.dotenv_values(env_path)
+    assert values["OTHER"] == "keep-me"
+    assert values["SOME_TOKEN"] == "hf_abc123"


### PR DESCRIPTION
## Summary

Fixes #532.

This fix rejects both scenarios mentioned in #532 before anything is applied, so a rejected value doesn't result in a partial update. The host check now also rejects whitespace, which keeps that input surfacing the existing `invalid_hf_host` error rather than a `ValueError`.

## Tests

`tests/test_env_persistence.py` drives everything through `_persist_env_values` and asserts on the file python-dotenv reads back. Both rejection tests fail against `main`; the third checks an ordinary token still persists, so the guard is not in the way.

`ruff check .`, `ruff format --check .`, `mypy` (45 files, no issues), `pytest tests/` → 310 passed.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added) — n/a, no new config vars
- [ ] Installation from the desktop app tested (if applicable)

## Notes

Found while working on custom MCP servers (#434), where the settings UI needs to persist a bearer token. Splitting it out because it applies to every value the UI saves today, not just MCP tokens.