### PR TITLE
Keep a corrupt tool-Spaces manifest from taking down the tool registry

### DIFF
--- a/src/reachy_mini_conversation_app/tools/core_tools.py
+++ b/src/reachy_mini_conversation_app/tools/core_tools.py
@@ -322,8 +322,16 @@ def _read_profile_tool_names(instance_path: str | Path | None) -> list[str]:
 
 def _resolve_remote_tools(tool_names: list[str], instance_path: str | Path | None) -> list[RemoteMcpTool]:
     """Build Space tools enabled by the active profile from the cached install manifest, without any network calls."""
+    try:
+        manifest = read_installed_tool_spaces(instance_path)
+    except (RuntimeError, ValueError) as exc:
+        # Skip the installed Spaces rather than take the whole registry down.
+        # ValueError too: validate_space_slug and validate_space_mcp_url raise it.
+        logger.error("Skipping installed tool Spaces: %s", exc)
+        return []
+
     remote_tools: list[RemoteMcpTool] = []
-    for installed_space in read_installed_tool_spaces(instance_path).spaces:
+    for installed_space in manifest.spaces:
         enabled_tool_names = {name for name in tool_names if name.startswith(f"{installed_space.alias}__")}
         if not enabled_tool_names:
             continue

--- a/tests/test_tool_space_runtime.py
+++ b/tests/test_tool_space_runtime.py
@@ -259,3 +259,58 @@ async def test_remote_tool_does_not_retry_timeout(
 
     assert "error" in result
     assert client.call_tool.await_count == 1
+
+
+def test_initialize_tools_survives_a_corrupt_installed_spaces_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A damaged manifest should cost the Space tools, not the whole tool registry.
+
+    `read_installed_tool_spaces` raises RuntimeError for a malformed payload and
+    ValueError straight out of `validate_space_slug` / `validate_space_mcp_url`
+    for a bad entry (see the reader's own tests). Either one used to propagate
+    out of tool initialization, so a single bad character in the manifest left
+    the app with no tools at all instead of just no Space tools.
+    """
+    monkeypatch.chdir(tmp_path)
+    external_profiles_root = tmp_path / "external_profiles"
+    profile_dir = external_profiles_root / "remote_profile"
+    write_profile("remote_profile", profile_dir, "hello", [SEARCH_TOOL_ID])
+
+    monkeypatch.setattr(config_mod.config, "REACHY_MINI_CUSTOM_PROFILE", "remote_profile")
+    monkeypatch.setattr(config_mod.config, "PROFILES_DIRECTORY", external_profiles_root)
+    monkeypatch.setattr(config_mod.config, "TOOLS_DIRECTORY", None)
+    monkeypatch.setattr(config_mod.config, "AUTOLOAD_EXTERNAL_TOOLS", False)
+
+    # A well-formed envelope whose entry trips the URL validator (ValueError),
+    # which is the path that no exception handler covered.
+    manifest_path = tmp_path / "external_content" / "installed_tool_spaces.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "spaces": [
+                    {
+                        "slug": SEARCH_SPACE_SLUG,
+                        "alias": SEARCH_ALIAS,
+                        "mcp_url": "https://attacker.example/gradio_api/mcp/",
+                        "private": True,
+                        "tools": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    core_tools_mod = _reload_core_tools()
+    with caplog.at_level("ERROR"):
+        core_tools_mod.initialize_tools()
+
+    assert any("Skipping installed tool Spaces" in record.message for record in caplog.records)
+    assert SEARCH_TOOL_ID not in core_tools_mod.ALL_TOOLS
+    # The registry still came up: built-in tools are unaffected by a bad manifest.
+    assert core_tools_mod.ALL_TOOLS


### PR DESCRIPTION
## Summary

Fixes #534 

## Tests

Added `test_initialize_tools_survives_a_corrupt_installed_spaces_manifest`, which writes a manifest whose envelope is valid but whose entry trips the URL validator, then asserts `initialize_tools()` completes and the built-in tools are still registered. Against `main` it fails with the raw `ValueError` escaping tool initialization.

`ruff check .`, `ruff format --check .`, `mypy` (45 files, no issues), `pytest tests/` → 308 passed.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added) — n/a, no new config vars
- [ ] Installation from the desktop app tested (if applicable)

## Notes

Found while working on custom MCP servers (#434), which adds a second manifest with the same failure mode. Splitting it out because it stands alone and applies to `main` as it is today.