### PR TITLE
feat: add opt-in Qwen Realtime provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,15 @@
 # Defaults to "en". Set to a backend-supported code such as "zh" for Chinese.
 # REALTIME_TRANSCRIPTION_LANGUAGE="en"
 
+# Optional realtime provider. Defaults to "huggingface".
+# REALTIME_BACKEND="qwen"
+# DASHSCOPE_API_KEY=
+# QWEN_WORKSPACE_ID=
+# QWEN_REGION=cn-beijing
+# QWEN_MODEL_NAME=qwen3.5-omni-flash-realtime
+# Alternatively provide a complete official WSS endpoint:
+# QWEN_REALTIME_URL=
+
 # Hugging Face connection mode: "deployed" or "local".
 # Deployed mode uses the built-in Hugging Face server.
 # Defaults to "deployed" when unset.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ pip install -e .[dev]                   # Development tools
 
 ## Configuration
 
+### Optional Qwen Realtime backend
+
+Hugging Face remains the default backend. To opt into Alibaba Cloud Qwen Omni Realtime, configure:
+
+```env
+REALTIME_BACKEND=qwen
+DASHSCOPE_API_KEY=your-key
+QWEN_WORKSPACE_ID=your-workspace-id
+QWEN_REGION=cn-beijing
+QWEN_MODEL_NAME=qwen3.5-omni-flash-realtime
+```
+
+The Qwen handler reuses the existing local and remote MCP Tool registry, accepts 16 kHz PCM microphone input,
+returns 24 kHz PCM audio, and supports image-buffer camera turns. API keys and workspace identifiers must not be
+committed. The settings UI remains Hugging Face-oriented in this initial provider port; Qwen is configured through
+the app environment.
+
 The default setup uses the Hugging Face backend and does not require an API key.
 
 Copy `.env.example` to `.env` when you want to point Hugging Face at your own local endpoint.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     #OpenAI (used by the Hugging Face backend)
     "openai==2.28.0",
 
+    #Qwen Realtime
+    "websockets>=15.0.1",
+
     #Reachy mini
     "reachy_mini_dances_library",
     "reachy-mini>=1.10.0rc5",

--- a/src/reachy_mini_conversation_app/config.py
+++ b/src/reachy_mini_conversation_app/config.py
@@ -4,7 +4,7 @@ import sys
 import logging
 from pathlib import Path
 from dataclasses import dataclass
-from urllib.parse import urlsplit, parse_qsl, urlunsplit
+from urllib.parse import urlsplit, parse_qsl, urlencode, urlunsplit
 from importlib.resources import files
 
 from dotenv import find_dotenv, load_dotenv
@@ -61,6 +61,10 @@ HF_AVAILABLE_VOICES: list[str] = [
 ]
 
 HF_BACKEND = "huggingface"
+QWEN_BACKEND = "qwen"
+REALTIME_BACKEND_ENV = "REALTIME_BACKEND"
+QWEN_AVAILABLE_VOICES = ["Tina", "Cherry", "Serena", "Ethan", "Chelsie"]
+QWEN_REALTIME_REGIONS = {"cn-beijing", "ap-southeast-1"}
 HF_REALTIME_CONNECTION_MODE_ENV = "HF_REALTIME_CONNECTION_MODE"
 HF_REALTIME_WS_URL_ENV = "HF_REALTIME_WS_URL"
 REALTIME_TRANSCRIPTION_LANGUAGE_ENV = "REALTIME_TRANSCRIPTION_LANGUAGE"
@@ -318,6 +322,12 @@ class Config:
     HF_REALTIME_WS_URL = os.getenv(HF_REALTIME_WS_URL_ENV)
     REALTIME_TRANSCRIPTION_LANGUAGE = _normalize_transcription_language(os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV))
     HF_TOKEN = os.getenv("HF_TOKEN")  # Optional, falls back to hf auth login if not set
+    REALTIME_BACKEND = (os.getenv(REALTIME_BACKEND_ENV) or HF_BACKEND).strip().lower()
+    QWEN_API_KEY = os.getenv("DASHSCOPE_API_KEY") or os.getenv("QWEN_API_KEY")
+    QWEN_REALTIME_URL = os.getenv("QWEN_REALTIME_URL")
+    QWEN_WORKSPACE_ID = os.getenv("QWEN_WORKSPACE_ID")
+    QWEN_REGION = os.getenv("QWEN_REGION", "cn-beijing")
+    QWEN_MODEL_NAME = os.getenv("QWEN_MODEL_NAME", "qwen3.5-omni-flash-realtime")
 
     logger.debug(
         "HF mode: %s, HF session URL set: %s, HF direct URL set: %s",
@@ -430,17 +440,78 @@ def refresh_runtime_config_from_env() -> None:
         os.getenv(REALTIME_TRANSCRIPTION_LANGUAGE_ENV)
     )
     config.HF_TOKEN = os.getenv("HF_TOKEN")
+    config.REALTIME_BACKEND = (os.getenv(REALTIME_BACKEND_ENV) or HF_BACKEND).strip().lower()
+    config.QWEN_API_KEY = os.getenv("DASHSCOPE_API_KEY") or os.getenv("QWEN_API_KEY")
+    config.QWEN_REALTIME_URL = os.getenv("QWEN_REALTIME_URL")
+    config.QWEN_WORKSPACE_ID = os.getenv("QWEN_WORKSPACE_ID")
+    config.QWEN_REGION = os.getenv("QWEN_REGION", "cn-beijing")
+    config.QWEN_MODEL_NAME = os.getenv("QWEN_MODEL_NAME", "qwen3.5-omni-flash-realtime")
     config.REACHY_MINI_CUSTOM_PROFILE = LOCKED_PROFILE or os.getenv("REACHY_MINI_CUSTOM_PROFILE")
 
 
 def get_available_voices() -> list[str]:
-    """Return the curated Hugging Face voice list."""
-    return list(HF_AVAILABLE_VOICES)
+    """Return the curated voice list for the selected backend."""
+    return list(QWEN_AVAILABLE_VOICES if get_realtime_backend() == QWEN_BACKEND else HF_AVAILABLE_VOICES)
 
 
 def get_default_voice() -> str:
-    """Return the default Hugging Face voice."""
-    return HF_DEFAULTS.voice
+    """Return the default voice for the selected backend."""
+    return "Tina" if get_realtime_backend() == QWEN_BACKEND else HF_DEFAULTS.voice
+
+
+def get_realtime_backend() -> str:
+    """Return the selected realtime provider, preserving Hugging Face as the default."""
+    backend = (getattr(config, "REALTIME_BACKEND", None) or HF_BACKEND).strip().lower()
+    if backend not in {HF_BACKEND, QWEN_BACKEND}:
+        raise RuntimeError(f"{REALTIME_BACKEND_ENV} must be set to {HF_BACKEND} or {QWEN_BACKEND}.")
+    return backend
+
+
+def get_qwen_realtime_url() -> str | None:
+    """Return the configured Qwen Realtime WebSocket endpoint."""
+    model = (config.QWEN_MODEL_NAME or "qwen3.5-omni-flash-realtime").strip()
+    configured_url = (config.QWEN_REALTIME_URL or "").strip()
+    if configured_url:
+        parts = urlsplit(configured_url)
+        query = dict(parse_qsl(parts.query, keep_blank_values=True))
+        query.setdefault("model", model)
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+    workspace_id = (config.QWEN_WORKSPACE_ID or "").strip()
+    region = (config.QWEN_REGION or "cn-beijing").strip()
+    if not workspace_id or not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?", workspace_id):
+        return None
+    if region not in QWEN_REALTIME_REGIONS:
+        return None
+    return f"wss://{workspace_id}.{region}.maas.aliyuncs.com/api-ws/v1/realtime?{urlencode({'model': model})}"
+
+
+def is_qwen_realtime_url_allowed(url: str | None) -> bool:
+    """Return whether the URL is an official Alibaba Cloud Realtime endpoint."""
+    if not url:
+        return False
+    parts = urlsplit(url)
+    host = (parts.hostname or "").lower()
+    try:
+        port = parts.port
+    except ValueError:
+        return False
+    suffixes = tuple(f".{region}.maas.aliyuncs.com" for region in QWEN_REALTIME_REGIONS)
+    return (
+        parts.scheme == "wss"
+        and parts.username is None
+        and parts.password is None
+        and port in {None, 443}
+        and host.endswith(suffixes)
+        and parts.path == "/api-ws/v1/realtime"
+    )
+
+
+def has_realtime_target() -> bool:
+    """Return whether the selected backend has its required connection settings."""
+    if get_realtime_backend() == QWEN_BACKEND:
+        url = get_qwen_realtime_url()
+        return bool((config.QWEN_API_KEY or "").strip() and is_qwen_realtime_url_allowed(url))
+    return has_hf_realtime_target()
 
 
 def get_hf_session_url() -> str | None:

--- a/src/reachy_mini_conversation_app/console.py
+++ b/src/reachy_mini_conversation_app/console.py
@@ -20,6 +20,7 @@ from reachy_mini.apps.jsonrpc_server import JsonRpcServer
 from reachy_mini.media.media_manager import MediaBackend
 from reachy_mini_conversation_app.config import (
     HF_BACKEND,
+    QWEN_BACKEND,
     LOCKED_PROFILE,
     HF_REALTIME_WS_URL_ENV,
     HF_LOCAL_CONNECTION_MODE,
@@ -29,10 +30,11 @@ from reachy_mini_conversation_app.config import (
     get_default_voice,
     get_hf_session_url,
     set_custom_profile,
+    has_realtime_target,
     get_available_voices,
     get_hf_direct_ws_url,
+    get_realtime_backend,
     build_hf_direct_ws_url,
-    has_hf_realtime_target,
     parse_hf_direct_target,
     get_hf_connection_selection,
     refresh_runtime_config_from_env,
@@ -532,12 +534,25 @@ class LocalStream:
                 raise
 
         def _status_payload() -> dict[str, object]:
+            backend = get_realtime_backend()
+            backend_connection = self._backend_connection_status()
+            if backend == QWEN_BACKEND:
+                has_qwen_connection = has_realtime_target()
+                return {
+                    "backend": QWEN_BACKEND,
+                    "has_key": has_qwen_connection,
+                    "has_qwen_connection": has_qwen_connection,
+                    "can_proceed": has_qwen_connection,
+                    "can_proceed_with_qwen": has_qwen_connection,
+                    "requires_restart": not self._can_rebuild_handler(),
+                    **backend_connection,
+                }
+
             hf_session_url = get_hf_session_url()
             hf_ws_url = get_hf_direct_ws_url()
             hf_direct_host, hf_direct_port = parse_hf_direct_target(hf_ws_url)
             hf_connection_selection = get_hf_connection_selection()
             has_hf_connection = hf_connection_selection.has_target
-            backend_connection = self._backend_connection_status()
             return {
                 "backend": HF_BACKEND,
                 "has_key": has_hf_connection,
@@ -699,9 +714,15 @@ class LocalStream:
                     await self._sleep_or_restart_requested(self._backend_retry_delay)
                     continue
 
-            if not has_hf_realtime_target():
+            if not has_realtime_target():
+                backend = get_realtime_backend()
                 self._set_backend_connection_state(
-                    "waiting_for_config", f"{HF_REALTIME_WS_URL_ENV} is not configured."
+                    "waiting_for_config",
+                    (
+                        f"{HF_REALTIME_WS_URL_ENV} is not configured."
+                        if backend == HF_BACKEND
+                        else "DASHSCOPE_API_KEY and QWEN_REALTIME_URL/QWEN_WORKSPACE_ID are not configured."
+                    ),
                 )
                 await self._sleep_or_restart_requested(0.5)
                 continue
@@ -758,22 +779,28 @@ class LocalStream:
         # (do this AFTER loading the instance .env so status endpoint sees the right value)
         self._init_settings_ui_if_needed()
 
-        # If the Hugging Face target is still missing -> wait until provided via the settings UI
-        if not has_hf_realtime_target():
-            self._set_backend_connection_state("waiting_for_config", f"{HF_REALTIME_WS_URL_ENV} is not configured.")
+        # If the selected backend target is still missing, keep the settings UI available.
+        if not has_realtime_target():
+            backend = get_realtime_backend()
+            missing_config = (
+                HF_REALTIME_WS_URL_ENV
+                if backend == HF_BACKEND
+                else "DASHSCOPE_API_KEY and QWEN_REALTIME_URL/QWEN_WORKSPACE_ID"
+            )
+            self._set_backend_connection_state("waiting_for_config", f"{missing_config} is not configured.")
             if self._settings_app is None:
                 logger.error(
-                    "%s not found. Set it in the app .env before starting the Hugging Face backend.",
-                    HF_REALTIME_WS_URL_ENV,
+                    "%s not found. Set it in the app .env before starting the selected backend.",
+                    missing_config,
                 )
                 return
-            logger.warning("%s not found. Open the app settings page to configure it.", HF_REALTIME_WS_URL_ENV)
+            logger.warning("%s not found. Open the app settings page to configure it.", missing_config)
             # Poll until a target becomes available (set via the settings UI)
             try:
-                while not self._stop_event.is_set() and not has_hf_realtime_target():
+                while not self._stop_event.is_set() and not has_realtime_target():
                     time.sleep(0.2)
             except KeyboardInterrupt:
-                logger.info("Interrupted while waiting for Hugging Face configuration.")
+                logger.info("Interrupted while waiting for backend configuration.")
                 return
             if self._stop_event.is_set():
                 return

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -87,8 +87,10 @@ def run(
     # Putting these dependencies here makes the dashboard faster to load when the conversation app is installed
     from reachy_mini_conversation_app.moves import MovementManager
     from reachy_mini_conversation_app.config import (
+        QWEN_BACKEND,
         HF_LOCAL_CONNECTION_MODE,
         set_instance_path,
+        get_realtime_backend,
         get_hf_connection_selection,
         resolve_app_timeout_minutes,
         refresh_runtime_config_from_env,
@@ -120,10 +122,14 @@ def run(
         except Exception as e:
             logger.warning("Failed to load startup settings: %s", e)
 
-    logger.info(
-        "Configured Hugging Face realtime backend, connection mode: %s",
-        get_hf_connection_selection().mode,
-    )
+    realtime_backend = get_realtime_backend()
+    if realtime_backend == QWEN_BACKEND:
+        logger.info("Configured Qwen Realtime backend")
+    else:
+        logger.info(
+            "Configured Hugging Face realtime backend, connection mode: %s",
+            get_hf_connection_selection().mode,
+        )
 
     from reachy_mini_conversation_app.console import LocalStream
     from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
@@ -165,7 +171,17 @@ def run(
     )
 
     def build_handler(startup_voice: Optional[str] = None) -> ConversationHandler:
-        """Build a Hugging Face realtime handler for the current runtime config."""
+        """Build the selected realtime handler for the current runtime config."""
+        if get_realtime_backend() == QWEN_BACKEND:
+            from reachy_mini_conversation_app.qwen_realtime import QwenRealtimeHandler
+
+            logger.info("Using Qwen Realtime handler")
+            return QwenRealtimeHandler(
+                deps,
+                instance_path=instance_path,
+                startup_voice=startup_voice,
+            )
+
         from reachy_mini_conversation_app.huggingface_realtime import HuggingFaceRealtimeHandler
 
         hf_connection_selection = get_hf_connection_selection()

--- a/src/reachy_mini_conversation_app/qwen_realtime.py
+++ b/src/reachy_mini_conversation_app/qwen_realtime.py
@@ -1,0 +1,452 @@
+"""DashScope/Qwen Realtime API handler for low-latency audio conversation."""
+
+import json
+import uuid
+import base64
+import asyncio
+import logging
+from typing import Any, Final
+
+import numpy as np
+import websockets
+from numpy.typing import NDArray
+from scipy.signal import resample
+from websockets.exceptions import ConnectionClosedError
+
+from reachy_mini_conversation_app.config import (
+    QWEN_AVAILABLE_VOICES,
+    config,
+    set_custom_profile,
+    get_qwen_realtime_url,
+    is_qwen_realtime_url_allowed,
+)
+from reachy_mini_conversation_app.prompts import get_session_voice, get_session_instructions
+from reachy_mini_conversation_app.streaming import AdditionalOutputs, audio_to_int16
+from reachy_mini_conversation_app.tools.core_tools import ToolSpec, ToolDependencies, get_tool_specs
+from reachy_mini_conversation_app.conversation_handler import ConversationHandler
+from reachy_mini_conversation_app.tools.background_tool_manager import (
+    ToolCallRoutine,
+    ToolNotification,
+    BackgroundToolManager,
+)
+
+
+logger = logging.getLogger(__name__)
+
+QWEN_INPUT_SAMPLE_RATE: Final[int] = 16000
+QWEN_OUTPUT_SAMPLE_RATE: Final[int] = 24000
+QWEN_MAX_BASE64_IMAGE_BYTES: Final[int] = 256 * 1024
+QWEN_CAMERA_SILENCE_SAMPLES: Final[int] = QWEN_INPUT_SAMPLE_RATE // 10
+
+
+def _openai_tool_specs_to_qwen(specs: list[ToolSpec]) -> list[dict[str, Any]]:
+    """Convert this app's OpenAI-style tool specs to Qwen Realtime tool specs."""
+    converted: list[dict[str, Any]] = []
+    for spec in specs:
+        function_spec: dict[str, Any] = {"name": spec["name"]}
+        if "description" in spec:
+            function_spec["description"] = spec["description"]
+        if "parameters" in spec and spec["parameters"]:
+            function_spec["parameters"] = spec["parameters"]
+        converted.append({"type": "function", "function": function_spec})
+    return converted
+
+
+def _resolve_qwen_voice(profile_voice: str) -> str:
+    """Map a profile voice name to a supported Qwen voice."""
+    voice_map = {voice.lower(): voice for voice in QWEN_AVAILABLE_VOICES}
+    return voice_map.get(profile_voice.lower(), "Tina")
+
+
+def _json_get(obj: Any, *keys: str) -> Any:
+    """Read nested dict attributes safely."""
+    current = obj
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+class QwenRealtimeHandler(ConversationHandler):
+    """DashScope/Qwen implementation of the shared realtime handler contract."""
+
+    SAMPLE_RATE = QWEN_OUTPUT_SAMPLE_RATE
+
+    def __init__(
+        self,
+        deps: ToolDependencies,
+        instance_path: str | None = None,
+        startup_voice: str | None = None,
+    ) -> None:
+        """Initialize the handler."""
+        super().__init__()
+
+        self.deps = deps
+        self.instance_path = instance_path
+        self._voice_override = _resolve_qwen_voice(startup_voice) if startup_voice else None
+
+        self.websocket: Any = None
+        self.output_queue: asyncio.Queue[tuple[int, NDArray[np.int16]] | AdditionalOutputs] = asyncio.Queue()
+        self._input_buffer_lock = asyncio.Lock()
+
+        self.tool_manager = BackgroundToolManager()
+
+    def get_current_voice(self) -> str:
+        """Return the resolved Qwen voice currently selected for this handler."""
+        return _resolve_qwen_voice(self._voice_override or get_session_voice(self.instance_path))
+
+    async def get_available_voices(self) -> list[str]:
+        """Return the curated Qwen Realtime voices."""
+        return list(QWEN_AVAILABLE_VOICES)
+
+    async def apply_personality(self, profile: str | None) -> str:
+        """Apply a new personality by updating the active session if connected."""
+        try:
+            set_custom_profile(profile)
+            self._voice_override = None
+            if self.websocket is not None:
+                await self._send_session_update()
+                return "Applied personality to Qwen realtime session."
+            return "Applied personality. Will take effect on next connection."
+        except Exception as e:
+            logger.error("Error applying personality '%s': %s", profile, e)
+            return f"Failed to apply personality: {e}"
+
+    async def change_voice(self, voice: str) -> str:
+        """Change only the voice and update the active session if connected."""
+        self._voice_override = voice
+        if self.websocket is not None:
+            try:
+                await self._send_session_update()
+                return f"Voice changed to {voice}."
+            except Exception as e:
+                logger.warning("Failed to update Qwen voice: %s", e)
+                return "Voice change failed. Will take effect on next connection."
+        return "Voice changed. Will take effect on next connection."
+
+    async def start_up(self) -> None:
+        """Start the handler with minimal retries on unexpected websocket closure."""
+        qwen_api_key = config.QWEN_API_KEY
+        if not qwen_api_key or not qwen_api_key.strip():
+            raise ValueError("DASHSCOPE_API_KEY (or QWEN_API_KEY) is required for Qwen Realtime")
+
+        max_attempts = 3
+        for attempt in range(1, max_attempts + 1):
+            try:
+                await self._run_realtime_session(qwen_api_key)
+                return
+            except ConnectionClosedError as e:
+                logger.warning("Qwen websocket closed unexpectedly (attempt %d/%d): %s", attempt, max_attempts, e)
+                if attempt < max_attempts:
+                    await asyncio.sleep(2 ** (attempt - 1))
+                    continue
+                raise
+            finally:
+                self.websocket = None
+
+    def _is_connected(self) -> bool:
+        """Return whether the Qwen WebSocket is open."""
+        return self.websocket is not None
+
+    def _connect(self, url: str, headers: dict[str, str]) -> Any:
+        """Return a Qwen WebSocket connection context."""
+        return websockets.connect(
+            url,
+            additional_headers=headers,
+            ping_interval=20,
+            ping_timeout=20,
+            proxy=None,
+        )
+
+    async def _send_event(self, event: dict[str, Any]) -> None:
+        """Send a JSON event to Qwen Realtime."""
+        if self.websocket is None:
+            raise ConnectionError("Qwen websocket is not connected")
+        await self.websocket.send(json.dumps(event, ensure_ascii=False))
+
+    async def _send_session_update(self) -> None:
+        """Send the current session configuration to Qwen Realtime."""
+        session_config: dict[str, Any] = {
+            "modalities": ["text", "audio"],
+            "instructions": get_session_instructions(self.instance_path),
+            "voice": self.get_current_voice(),
+            "input_audio_format": "pcm",
+            "output_audio_format": "pcm",
+            "input_audio_transcription": {"model": "qwen3-asr-flash-realtime"},
+            "turn_detection": {"type": "server_vad"},
+            "tools": _openai_tool_specs_to_qwen(get_tool_specs()),
+        }
+        await self._send_event(
+            {
+                "event_id": f"event_{uuid.uuid4().hex}",
+                "type": "session.update",
+                "session": session_config,
+            }
+        )
+
+    async def _run_realtime_session(self, qwen_api_key: str) -> None:
+        """Establish and manage a single Qwen realtime session."""
+        url = get_qwen_realtime_url()
+        if not url:
+            raise ValueError("Qwen realtime URL missing. Set QWEN_REALTIME_URL or QWEN_WORKSPACE_ID")
+        if not is_qwen_realtime_url_allowed(url):
+            raise ValueError("QWEN_REALTIME_URL must be an official Alibaba Cloud Qwen Realtime wss:// endpoint")
+
+        headers = {"Authorization": f"Bearer {qwen_api_key}"}
+        async with self._connect(url, headers) as websocket:
+            self.websocket = websocket
+            await self._send_session_update()
+            logger.info(
+                "Qwen realtime session initialized with model=%s voice=%s",
+                config.QWEN_MODEL_NAME,
+                self.get_current_voice(),
+            )
+
+            self.tool_manager.start_up(tool_callbacks=[self._handle_tool_result])
+            try:
+                async for raw_event in websocket:
+                    try:
+                        event = json.loads(raw_event)
+                    except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+                        logger.debug("Ignoring non-JSON Qwen event: %r", raw_event)
+                        continue
+                    if not isinstance(event, dict):
+                        logger.debug("Ignoring non-object Qwen event: %r", event)
+                        continue
+                    await self._handle_server_event(event)
+            finally:
+                await self.tool_manager.shutdown()
+
+    async def _handle_server_event(self, event: dict[str, Any]) -> None:
+        """Handle one Qwen Realtime server event."""
+        event_type = str(event.get("type", ""))
+        logger.debug("Qwen event: %s", event_type)
+
+        if event_type == "input_audio_buffer.speech_started":
+            self._mark_activity("user_speech_started")
+            if self._clear_queue is not None:
+                self._clear_queue()
+            self.deps.movement_manager.set_listening(True)
+            return
+
+        if event_type == "input_audio_buffer.speech_stopped":
+            self._mark_activity("user_speech_stopped")
+            self.deps.movement_manager.set_listening(False)
+            return
+
+        if event_type == "response.audio.done":
+            self.deps.movement_manager.set_speaking(False)
+            return
+
+        if event_type == "conversation.item.input_audio_transcription.completed":
+            transcript = str(event.get("transcript") or event.get("text") or "")
+            if transcript:
+                self._mark_activity("user_transcription_completed")
+                await self.output_queue.put(AdditionalOutputs({"role": "user", "content": transcript}))
+                self._emit_transcript("user", transcript, True)
+            return
+
+        if event_type == "response.audio_transcript.done":
+            transcript = str(event.get("transcript") or event.get("text") or "")
+            if transcript:
+                self._mark_activity("assistant_transcript_done")
+                await self.output_queue.put(AdditionalOutputs({"role": "assistant", "content": transcript}))
+                self._emit_transcript("assistant", transcript, True)
+            return
+
+        if event_type == "response.audio.delta":
+            audio_delta = event.get("delta")
+            if isinstance(audio_delta, str) and audio_delta:
+                self._mark_activity("assistant_audio_delta")
+                self.deps.movement_manager.set_speaking(True)
+                await self.output_queue.put(
+                    (
+                        QWEN_OUTPUT_SAMPLE_RATE,
+                        np.frombuffer(base64.b64decode(audio_delta), dtype=np.int16).reshape(1, -1),
+                    )
+                )
+            return
+
+        if event_type == "response.function_call_arguments.done":
+            self._mark_activity("tool_call_received")
+            await self._start_tool_from_event(event)
+            return
+
+        if event_type == "error":
+            error_payload = event.get("error")
+            error_message = error_payload.get("message") if isinstance(error_payload, dict) else None
+            msg = str(error_message or event.get("message") or "unknown error")
+            logger.error("Qwen realtime error: %s", msg)
+            await self.output_queue.put(AdditionalOutputs({"role": "assistant", "content": f"[error] {msg}"}))
+
+    async def _start_tool_from_event(self, event: dict[str, Any]) -> None:
+        """Start a background tool from a Qwen function-call event."""
+        tool_name = event.get("name") or _json_get(event, "function", "name")
+        args_json_str = event.get("arguments") or _json_get(event, "function", "arguments") or "{}"
+        call_id = str(event.get("call_id") or event.get("id") or uuid.uuid4())
+
+        if not isinstance(tool_name, str) or not isinstance(args_json_str, str):
+            logger.error("Invalid Qwen tool call: name=%r args=%r call_id=%s", tool_name, args_json_str, call_id)
+            return
+
+        bg_tool = await self.tool_manager.start_tool(
+            call_id=call_id,
+            tool_call_routine=ToolCallRoutine(
+                tool_name=tool_name,
+                args_json_str=args_json_str,
+                deps=self.deps,
+            ),
+            is_idle_tool_call=False,
+        )
+        await self.output_queue.put(
+            AdditionalOutputs(
+                {
+                    "role": "assistant",
+                    "content": f"🛠️ Used tool {tool_name} with args {args_json_str}. The tool is now running. Tool ID: {bg_tool.tool_id}",
+                }
+            )
+        )
+
+    async def _handle_tool_result(self, bg_tool: ToolNotification) -> None:
+        """Send a completed background tool result back to Qwen."""
+        if bg_tool.error is not None:
+            tool_result: dict[str, Any] = {"error": bg_tool.error}
+        elif bg_tool.result is not None:
+            tool_result = dict(bg_tool.result)
+        else:
+            tool_result = {"error": "No result returned from tool execution"}
+
+        if self.websocket is None:
+            logger.warning("Qwen websocket closed during tool '%s' result; cannot send result back", bg_tool.tool_name)
+            return
+
+        image_b64 = tool_result.pop("b64_im", None)
+        if bg_tool.tool_name == "camera" and isinstance(image_b64, str):
+            if len(image_b64.encode("ascii", errors="ignore")) <= QWEN_MAX_BASE64_IMAGE_BYTES:
+                async with self._input_buffer_lock:
+                    await self._send_event(
+                        {
+                            "event_id": f"event_{uuid.uuid4().hex}",
+                            "type": "session.update",
+                            "session": {"turn_detection": None},
+                        }
+                    )
+                    try:
+                        silence = np.zeros(QWEN_CAMERA_SILENCE_SAMPLES, dtype=np.int16)
+                        await self._send_event(
+                            {
+                                "event_id": f"event_{uuid.uuid4().hex}",
+                                "type": "input_audio_buffer.append",
+                                "audio": base64.b64encode(silence.tobytes()).decode("ascii"),
+                            }
+                        )
+                        await self._send_event(
+                            {
+                                "event_id": f"event_{uuid.uuid4().hex}",
+                                "type": "input_image_buffer.append",
+                                "image": image_b64,
+                            }
+                        )
+                        await self._send_event(
+                            {
+                                "event_id": f"event_{uuid.uuid4().hex}",
+                                "type": "input_audio_buffer.commit",
+                            }
+                        )
+                    finally:
+                        await self._send_event(
+                            {
+                                "event_id": f"event_{uuid.uuid4().hex}",
+                                "type": "session.update",
+                                "session": {"turn_detection": {"type": "server_vad"}},
+                            }
+                        )
+                tool_result["image"] = "Camera frame submitted to Qwen."
+            else:
+                tool_result["error"] = "Camera frame exceeds Qwen's 256 KB Base64 image limit."
+
+        await self._send_event(
+            {
+                "event_id": f"event_{uuid.uuid4().hex}",
+                "type": "conversation.item.create",
+                "item": {
+                    "type": "function_call_output",
+                    "call_id": bg_tool.id,
+                    "output": json.dumps(tool_result, ensure_ascii=False),
+                },
+            }
+        )
+
+        await self.output_queue.put(
+            AdditionalOutputs(
+                {
+                    "role": "assistant",
+                    "content": json.dumps(tool_result, ensure_ascii=False),
+                    "metadata": {
+                        "title": f"🛠️ Used tool {bg_tool.tool_name}",
+                        "status": "done",
+                    },
+                }
+            )
+        )
+
+        await self._send_event(
+            {
+                "event_id": f"event_{uuid.uuid4().hex}",
+                "type": "response.create",
+            }
+        )
+
+    async def receive(self, frame: tuple[int, NDArray[np.int16]]) -> None:
+        """Receive audio frame from the microphone and send it to Qwen."""
+        if self.websocket is None:
+            return
+
+        input_sample_rate, audio_frame = frame
+        if audio_frame.ndim == 2:
+            if audio_frame.shape[1] > audio_frame.shape[0]:
+                audio_frame = audio_frame.T
+            if audio_frame.shape[1] > 1:
+                audio_frame = audio_frame[:, 0]
+
+        if QWEN_INPUT_SAMPLE_RATE != input_sample_rate:
+            audio_frame = resample(audio_frame, int(len(audio_frame) * QWEN_INPUT_SAMPLE_RATE / input_sample_rate))
+
+        audio_frame = audio_to_int16(audio_frame)
+        self._mark_activity("microphone_audio")
+        audio_message = base64.b64encode(audio_frame.tobytes()).decode("utf-8")
+        try:
+            async with self._input_buffer_lock:
+                await self._send_event(
+                    {
+                        "event_id": f"event_{uuid.uuid4().hex}",
+                        "type": "input_audio_buffer.append",
+                        "audio": audio_message,
+                    }
+                )
+        except Exception as e:
+            logger.debug("Dropping Qwen audio frame: connection not ready (%s)", e)
+
+    async def say(self, text: str) -> None:
+        """Reject injected text turns until Qwen exposes a safe message event."""
+        raise NotImplementedError("Qwen Realtime text injection is not supported")
+
+    async def shutdown(self) -> None:
+        """Shutdown the handler."""
+        await self.tool_manager.shutdown()
+        if self.websocket is not None:
+            try:
+                await self.websocket.close()
+            except ConnectionClosedError as e:
+                logger.debug("Qwen websocket already closed during shutdown: %s", e)
+            except Exception as e:
+                logger.debug("Qwen websocket close ignored: %s", e)
+            finally:
+                self.websocket = None
+
+        while not self.output_queue.empty():
+            try:
+                self.output_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,3 +20,39 @@ def test_resolve_app_timeout_minutes(monkeypatch, raw_value, expected) -> None:
     monkeypatch.setenv(config.APP_TIMEOUT_MINUTES_ENV, raw_value)
 
     assert config.resolve_app_timeout_minutes() == expected
+
+
+def test_realtime_backend_defaults_to_huggingface(monkeypatch) -> None:
+    """The existing Hugging Face backend remains the default."""
+    monkeypatch.delenv(config.REALTIME_BACKEND_ENV, raising=False)
+    config.refresh_runtime_config_from_env()
+
+    assert config.get_realtime_backend() == config.HF_BACKEND
+
+
+def test_qwen_backend_resolves_workspace_url_and_voices(monkeypatch) -> None:
+    """Qwen settings resolve an authorized endpoint and provider voices."""
+    monkeypatch.setenv(config.REALTIME_BACKEND_ENV, config.QWEN_BACKEND)
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+    monkeypatch.setenv("QWEN_WORKSPACE_ID", "workspace-test")
+    monkeypatch.setenv("QWEN_REGION", "ap-southeast-1")
+    monkeypatch.setenv("QWEN_MODEL_NAME", "qwen3.5-omni-flash-realtime")
+    config.refresh_runtime_config_from_env()
+
+    assert config.get_realtime_backend() == config.QWEN_BACKEND
+    assert config.has_realtime_target() is True
+    assert config.get_default_voice() == "Tina"
+    assert "Tina" in config.get_available_voices()
+    assert config.get_qwen_realtime_url() == (
+        "wss://workspace-test.ap-southeast-1.maas.aliyuncs.com/api-ws/v1/realtime?model=qwen3.5-omni-flash-realtime"
+    )
+
+
+def test_qwen_backend_rejects_untrusted_full_url(monkeypatch) -> None:
+    """Qwen readiness rejects endpoints outside the Alibaba allowlist."""
+    monkeypatch.setattr(config.config, "REALTIME_BACKEND", config.QWEN_BACKEND)
+    monkeypatch.setattr(config.config, "QWEN_API_KEY", "test-key")
+    monkeypatch.setattr(config.config, "QWEN_REALTIME_URL", "wss://attacker.example/api-ws/v1/realtime")
+    monkeypatch.setattr(config.config, "QWEN_WORKSPACE_ID", None)
+
+    assert config.has_realtime_target() is False

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -433,7 +433,7 @@ def test_backend_startup_failure_is_recorded_without_raising(
 
 def test_media_warmup_overlaps_audio_startup_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Audio configuration should run while the media pipelines warm up."""
-    monkeypatch.setattr("reachy_mini_conversation_app.console.has_hf_realtime_target", lambda: True)
+    monkeypatch.setattr("reachy_mini_conversation_app.console.has_realtime_target", lambda: True)
 
     handler = MagicMock()
     handler.shutdown = AsyncMock()

--- a/tests/test_qwen_realtime.py
+++ b/tests/test_qwen_realtime.py
@@ -1,0 +1,227 @@
+import json
+import base64
+import asyncio
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from reachy_mini_conversation_app import config as config_mod
+from reachy_mini_conversation_app.streaming import AdditionalOutputs
+from reachy_mini_conversation_app.qwen_realtime import QwenRealtimeHandler
+from reachy_mini_conversation_app.tools.core_tools import ToolDependencies
+from reachy_mini_conversation_app.conversation_handler import ConversationHandler
+from reachy_mini_conversation_app.tools.tool_constants import ToolState
+from reachy_mini_conversation_app.tools.background_tool_manager import ToolNotification
+
+
+class _FakeWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(json.loads(payload))
+
+    async def close(self) -> None:
+        return None
+
+
+class _BlockingImageWebSocket(_FakeWebSocket):
+    def __init__(self) -> None:
+        super().__init__()
+        self.image_started = asyncio.Event()
+        self.release_image = asyncio.Event()
+
+    async def send(self, payload: str) -> None:
+        event = json.loads(payload)
+        self.sent.append(event)
+        if event["type"] == "input_image_buffer.append":
+            self.image_started.set()
+            await self.release_image.wait()
+
+
+class _FailingImageWebSocket(_FakeWebSocket):
+    async def send(self, payload: str) -> None:
+        event = json.loads(payload)
+        self.sent.append(event)
+        if event["type"] == "input_image_buffer.append":
+            raise ConnectionError("image send failed")
+
+
+def _handler() -> QwenRealtimeHandler:
+    deps = ToolDependencies(reachy_mini=MagicMock(), movement_manager=MagicMock())
+    deps.movement_manager.is_idle.return_value = False
+    return QwenRealtimeHandler(deps)
+
+
+def test_qwen_handler_implements_shared_conversation_contract() -> None:
+    """The Qwen provider conforms to the shared handler boundary."""
+    assert isinstance(_handler(), ConversationHandler)
+
+
+def test_qwen_url_builds_from_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A workspace ID builds the official regional Qwen WebSocket URL."""
+    monkeypatch.setattr(config_mod.config, "QWEN_REALTIME_URL", None)
+    monkeypatch.setattr(config_mod.config, "QWEN_WORKSPACE_ID", "workspace-test")
+    monkeypatch.setattr(config_mod.config, "QWEN_REGION", "cn-beijing")
+    monkeypatch.setattr(config_mod.config, "QWEN_MODEL_NAME", "qwen3.5-omni-flash-realtime")
+
+    assert config_mod.get_qwen_realtime_url() == (
+        "wss://workspace-test.cn-beijing.maas.aliyuncs.com/api-ws/v1/realtime?model=qwen3.5-omni-flash-realtime"
+    )
+
+
+@pytest.mark.asyncio
+async def test_qwen_session_update_uses_pcm_and_nested_tools() -> None:
+    """Qwen receives PCM formats and its required nested function schema."""
+    handler = _handler()
+    websocket = _FakeWebSocket()
+    handler.websocket = websocket
+
+    await handler._send_session_update()
+
+    event = websocket.sent[0]
+    session = event["session"]
+    assert isinstance(session, dict)
+    assert session["input_audio_format"] == "pcm"
+    assert session["output_audio_format"] == "pcm"
+    assert session["turn_detection"] == {"type": "server_vad"}
+    assert all("function" in tool for tool in session["tools"])
+
+
+def test_qwen_connection_bypasses_system_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The realtime socket avoids system proxies that break direct TLS."""
+    connect = MagicMock(return_value=object())
+    monkeypatch.setattr("reachy_mini_conversation_app.qwen_realtime.websockets.connect", connect)
+
+    result = _handler()._connect("wss://workspace.example", {"Authorization": "Bearer test"})
+
+    assert result is connect.return_value
+    assert connect.call_args.kwargs["proxy"] is None
+
+
+@pytest.mark.asyncio
+async def test_qwen_audio_and_transcripts_feed_shared_outputs() -> None:
+    """Qwen audio and transcripts flow through the shared output contract."""
+    handler = _handler()
+    observed: list[tuple[str, str, bool]] = []
+    handler.set_transcript_observer(lambda role, text, final: observed.append((role, text, final)))
+    audio_bytes = np.array([1, 2, 3], dtype=np.int16).tobytes()
+
+    await handler._handle_server_event(
+        {"type": "response.audio.delta", "delta": base64.b64encode(audio_bytes).decode()}
+    )
+    await handler._handle_server_event({"type": "response.audio_transcript.done", "transcript": "hello"})
+
+    audio_output = await handler.output_queue.get()
+    transcript_output = await handler.output_queue.get()
+    assert audio_output[0] == 24000
+    assert np.array_equal(audio_output[1], np.array([1, 2, 3], dtype=np.int16).reshape(1, -1))
+    assert isinstance(transcript_output, AdditionalOutputs)
+    assert observed == [("assistant", "hello", True)]
+
+
+@pytest.mark.asyncio
+async def test_camera_result_commits_image_in_manual_mode_then_restores_vad() -> None:
+    """Camera input uses manual commit before restoring server VAD."""
+    handler = _handler()
+    websocket = _FakeWebSocket()
+    handler.websocket = websocket
+    image_b64 = base64.b64encode(b"jpeg-data").decode()
+    notification = ToolNotification(
+        id="call_camera",
+        tool_name="camera",
+        is_idle_tool_call=False,
+        status=ToolState.COMPLETED,
+        result={"b64_im": image_b64},
+    )
+
+    await handler._handle_tool_result(notification)
+
+    assert [event["type"] for event in websocket.sent] == [
+        "session.update",
+        "input_audio_buffer.append",
+        "input_image_buffer.append",
+        "input_audio_buffer.commit",
+        "session.update",
+        "conversation.item.create",
+        "response.create",
+    ]
+    assert websocket.sent[0]["session"] == {"turn_detection": None}
+    assert websocket.sent[4]["session"] == {"turn_detection": {"type": "server_vad"}}
+    assert image_b64 not in json.dumps(websocket.sent[5])
+
+
+@pytest.mark.asyncio
+async def test_camera_turn_blocks_microphone_frames_until_vad_is_restored() -> None:
+    """A live microphone frame cannot enter the manual camera commit."""
+    handler = _handler()
+    websocket = _BlockingImageWebSocket()
+    handler.websocket = websocket
+    notification = ToolNotification(
+        id="call_camera",
+        tool_name="camera",
+        is_idle_tool_call=False,
+        status=ToolState.COMPLETED,
+        result={"b64_im": base64.b64encode(b"jpeg-data").decode()},
+    )
+
+    camera_task = asyncio.create_task(handler._handle_tool_result(notification))
+    await websocket.image_started.wait()
+    microphone_task = asyncio.create_task(handler.receive((16000, np.array([7, 8], dtype=np.int16))))
+    await asyncio.sleep(0)
+
+    assert [event["type"] for event in websocket.sent].count("input_audio_buffer.append") == 1
+
+    websocket.release_image.set()
+    await camera_task
+    await microphone_task
+    event_types = [event["type"] for event in websocket.sent]
+    restore_index = event_types.index("session.update", 1)
+    assert event_types.index("input_audio_buffer.append", 2) > restore_index
+
+
+@pytest.mark.asyncio
+async def test_camera_turn_restores_vad_when_image_send_fails() -> None:
+    """A failed camera upload cannot leave the session in manual VAD mode."""
+    handler = _handler()
+    websocket = _FailingImageWebSocket()
+    handler.websocket = websocket
+    notification = ToolNotification(
+        id="call_camera",
+        tool_name="camera",
+        is_idle_tool_call=False,
+        status=ToolState.COMPLETED,
+        result={"b64_im": base64.b64encode(b"jpeg-data").decode()},
+    )
+
+    with pytest.raises(ConnectionError, match="image send failed"):
+        await handler._handle_tool_result(notification)
+
+    assert websocket.sent[-1] == {
+        "event_id": websocket.sent[-1]["event_id"],
+        "type": "session.update",
+        "session": {"turn_detection": {"type": "server_vad"}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_qwen_say_is_explicitly_unsupported() -> None:
+    """RPC text injection fails clearly instead of mutating session instructions."""
+    handler = _handler()
+    websocket = _FakeWebSocket()
+    handler.websocket = websocket
+
+    with pytest.raises(NotImplementedError, match="text injection"):
+        await handler.say("hello")
+
+    assert websocket.sent == []
+
+
+@pytest.mark.asyncio
+async def test_qwen_startup_requires_dashscope_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Qwen startup fails clearly when the DashScope key is absent."""
+    monkeypatch.setattr(config_mod.config, "QWEN_API_KEY", None)
+
+    with pytest.raises(ValueError, match="DASHSCOPE_API_KEY"):
+        await _handler().start_up()

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-13T04:33:04.464345Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2567,6 +2567,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "reachy-mini" },
     { name = "reachy-mini-dances-library" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -2589,6 +2590,7 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "reachy-mini", specifier = ">=1.10.0rc5" },
     { name = "reachy-mini-dances-library" },
+    { name = "websockets", specifier = ">=15.0.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- add an opt-in Alibaba Cloud Qwen Omni Realtime provider on the shared `ConversationHandler` boundary
- preserve Hugging Face as the default backend and keep the existing MCP/tool-space runtime
- support 16 kHz microphone input, 24 kHz audio output, transcripts, function tools, and camera image-buffer turns
- serialize camera manual-VAD commits against microphone frames and restore server VAD on failure
- restrict credential-bearing WebSocket connections to allowlisted official Alibaba Cloud endpoints

Related to #539.

## Category
- [ ] Fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [x] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>

## Notes

Configuration is environment-only in this initial port:

```env
REALTIME_BACKEND=qwen
DASHSCOPE_API_KEY=<your-key>
QWEN_WORKSPACE_ID=<your-workspace-id>
QWEN_REGION=cn-beijing
QWEN_MODEL_NAME=qwen3.5-omni-flash-realtime
```

The provider converts the existing flat tool registry to Qwen's nested function schema, so installed remote MCP tool spaces remain available. This PR intentionally does not add an Exa-specific client because v1 already has provider-neutral MCP plumbing.

Qwen's current client-event API does not expose a safe general text-message injection event, so the RPC `say()` operation raises a clear `NotImplementedError` instead of promoting user text into session instructions.

Local verification on Windows:

- `ruff check . --fix` and `ruff format .`
- strict Mypy: 46 source files
- Pytest: 333 passed
- `uv lock --check --offline`
- wheel build and package-content inspection
- secret and personal-data scans of source and wheel

Known validation gap: this upstream v1 wheel has not yet been exercised against a live DashScope workspace or Reachy Mini hardware. The PR is intentionally opened as Draft for maintainer feedback and cross-platform CI.
