### PR TITLE
feat: make the instance path configurable via REACHY_MINI_INSTANCE_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Copy `.env.example` to `.env` when you want to point Hugging Face at your own lo
 | `HF_REALTIME_WS_URL` | Direct websocket endpoint for your own Hugging Face backend. Accepts either a base URL like `ws://127.0.0.1:8765/v1` or the full websocket URL `ws://127.0.0.1:8765/v1/realtime`. Used when `HF_REALTIME_CONNECTION_MODE=local`. |
 | `HF_TOKEN` | Optional token for Hugging Face access. Local endpoints receive only this explicitly configured token. |
 | `REACHY_MINI_APP_TIMEOUT_MINUTES` | Minutes of inactivity before Reachy goes to sleep and the app stops. Defaults to `1440` (one day); set to `0` to disable. |
+| `REACHY_MINI_INSTANCE_PATH` | Directory for this instance's data: long-term memory, profiles and settings. Defaults to the installed package directory, where an app reinstall deletes it. Set this to a directory you own to keep that data across updates. |
 
 ### Hugging Face Connection Modes
 

--- a/src/reachy_mini_conversation_app/main.py
+++ b/src/reachy_mini_conversation_app/main.py
@@ -1,6 +1,7 @@
 """Entrypoint for the Reachy Mini conversation app."""
 
 from __future__ import annotations
+import os
 import sys
 import time
 import asyncio
@@ -346,6 +347,36 @@ def run(
         logger.info("Shutdown complete.")
 
 
+def _resolve_instance_path(default: Path) -> Path:
+    """Return the instance directory, honouring REACHY_MINI_INSTANCE_PATH.
+
+    ``default`` is the installed package directory. Writing user data there
+    means an app reinstall deletes it, and it is not somewhere a user can
+    reasonably find or back up their own stored facts. Setting the environment
+    variable puts memory, profiles and settings in a directory the user owns.
+
+    Unset keeps the previous behaviour, so existing installs are unaffected.
+    """
+    override = os.getenv("REACHY_MINI_INSTANCE_PATH")
+    if not override:
+        return default
+
+    path = Path(override).expanduser()
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logging.getLogger(__name__).warning(
+            "REACHY_MINI_INSTANCE_PATH=%s is unusable (%s); falling back to %s",
+            override,
+            exc,
+            default,
+        )
+        return default
+
+    logging.getLogger(__name__).info("Using instance path %s", path)
+    return path
+
+
 class ReachyMiniConversationApp(ReachyMiniApp):  # type: ignore[misc]
     """Reachy Mini Apps entry point for the conversation app."""
 
@@ -358,7 +389,7 @@ class ReachyMiniConversationApp(ReachyMiniApp):  # type: ignore[misc]
 
         args, _ = parse_args()
 
-        instance_path = self._get_instance_path().parent
+        instance_path = _resolve_instance_path(self._get_instance_path().parent)
         run(
             args,
             robot=reachy_mini,


### PR DESCRIPTION
Fixes #544.

### Problem

Long-term memory, profiles and settings are written to the app's instance path, which
resolves to the **installed package directory** when the daemon launches the app:

```python
instance_path = self._get_instance_path().parent   # -> site-packages/reachy_mini_conversation_app/
```

Two consequences:

- Reinstalling or updating the app deletes whatever the user asked Reachy to remember.
- The data is in `site-packages`, where users cannot reasonably find, back up or delete
  their own stored personal information — and `remember` is documented to store names,
  preferences, hobbies, important people and plans.

Launching standalone instead takes the `instance_path is None` branch and lands in an XDG
directory, so the same user on the same machine can end up with two different memory
stores depending on how the app was started.

### Change

`REACHY_MINI_INSTANCE_PATH` overrides the instance directory. Unset, behaviour is
identical to today, so existing installs are unaffected.

```bash
REACHY_MINI_INSTANCE_PATH=~/reachy-mini-data
```

This matches the pattern the app already uses for `REACHY_MINI_EXTERNAL_TOOLS_DIRECTORY`
and `REACHY_MINI_EXTERNAL_PROFILES_DIRECTORY`, so it should feel familiar rather than new
surface.

An unusable value warns and falls back to the previous path instead of failing to start:
a bad env var should not stop the robot from talking.

### Verified

| case | result |
| --- | --- |
| unset | returns the package directory, unchanged |
| valid path | used, and created if missing |
| `~/...` | expanded |
| unusable (`/dev/null/nope`) | warns, falls back, no crash |

`ruff check` and `ruff format --check` pass on the changed file.

### Not included

A larger fix would default to the XDG path — the branch already present in
`memory_path_for_instance` — and treat `instance_path` as packaged-asset lookup only. That
changes behaviour for existing installs and would want a migration step, so I kept this
opt-in and non-breaking. Happy to follow up if you would prefer that direction.
