### PR TITLE
Ensure repeated emotion requests call the tool

### DIFF
--- a/profiles/default/profile.md
+++ b/profiles/default/profile.md
@@ -58,6 +58,7 @@ Keep safety in mind when giving guidance.
 
 ## TOOL & MOVEMENT RULES
 Use tools only when helpful and summarize results briefly.
+Whenever the user asks to show or express an emotion—including “again,” “another,” or “different”—call play_emotion in that turn; prior calls and speech do not perform it.
 Use the web search tool for explicit web lookup requests like "check the web", "look up", "today's events", or current/latest information.
 Use the camera for real visuals only — never invent details.
 The head can move (left/right/up/down/front).

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -70,11 +70,3 @@ def test_bundled_profiles_enable_head_tracking_by_default() -> None:
         profile = read_profile_from_directory(profile_name, DEFAULT_PROFILES_DIRECTORY / profile_name)
 
         assert "head_tracking" in profile.default_tools, profile_name
-
-
-def test_default_profile_replays_requested_emotions() -> None:
-    """Repeated emotion requests should each trigger the emotion tool."""
-    profile = read_profile_from_directory("default", DEFAULT_PROFILES_DIRECTORY / "default")
-
-    assert "call play_emotion in that turn" in profile.instructions
-    assert all(repeat_request in profile.instructions for repeat_request in ("again", "another", "different"))

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -70,3 +70,11 @@ def test_bundled_profiles_enable_head_tracking_by_default() -> None:
         profile = read_profile_from_directory(profile_name, DEFAULT_PROFILES_DIRECTORY / profile_name)
 
         assert "head_tracking" in profile.default_tools, profile_name
+
+
+def test_default_profile_replays_requested_emotions() -> None:
+    """Repeated emotion requests should each trigger the emotion tool."""
+    profile = read_profile_from_directory("default", DEFAULT_PROFILES_DIRECTORY / "default")
+
+    assert "call play_emotion in that turn" in profile.instructions
+    assert all(repeat_request in profile.instructions for repeat_request in ("again", "another", "different"))


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
<!-- What does this PR change and why? -->
Port the repeated-emotion instruction validated in the Reachy Mini 3D voice Space into the bundled default profile. Requests such as "again", "another", or "different" now explicitly require a fresh `play_emotion` call, preventing a spoken acknowledgment from replacing the movement.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/CD
- [ ] Other

## Pre-merge checklist
- [ ] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [ ] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [x] Profiles or custom tools
</details>

## Notes
<!-- Optional: context, caveats, migration notes -->
Profile tests: 9 passed. Ruff passed.
