### PR TITLE
Fix Linux system dependency installation

### DIFF
--- a/.github/workflows/allure.yml
+++ b/.github/workflows/allure.yml
@@ -28,10 +28,12 @@ jobs:
       HF_HUB_DOWNLOAD_TIMEOUT: "120"
     steps:
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9  # v1.6.3
-        with:
-          packages: libcairo2-dev libgirepository1.0-dev gir1.2-gst-plugins-base-1.0
-          version: 1.0
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libcairo2-dev \
+            libgirepository1.0-dev \
+            gir1.2-gst-plugins-base-1.0
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,10 +36,12 @@ jobs:
       # System deps (platform-specific)
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9  # v1.6.3
-        with:
-          packages: libcairo2-dev libgirepository1.0-dev gir1.2-gst-plugins-base-1.0
-          version: 1.0
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libcairo2-dev \
+            libgirepository1.0-dev \
+            gir1.2-gst-plugins-base-1.0
 
       - name: Install system deps (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -24,10 +24,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
-        with:
-          packages: libcairo2-dev libgirepository1.0-dev
-          version: 1.0
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libcairo2-dev \
+            libgirepository1.0-dev
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:


### PR DESCRIPTION
<!-- New here? Check out our CONTRIBUTING.md before opening your PR -->

## Summary
<!-- What does this PR change and why? -->
Replace the apt package cache action with direct apt installation in the Linux pytest, mypy, and Allure jobs. The cache action swallowed stale-mirror 404 errors and saved empty caches, which left Cairo unavailable when pycairo built from source and blocked PR #546 before tests or type checking could run.

## Category
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] CI/CD
- [ ] Other

## Pre-merge checklist
- [x] CI is green (lint, types, tests — runs on Linux, macOS & Windows)
- [x] Code is clear (types, docs, comments where needed)
- [x] `.env.example` updated (if new config vars were added)
- [ ] Installation from the desktop app tested (if applicable)

<details>
<summary><strong>UI / run modes</strong> — expand if your PR touches these</summary>

- [ ] Console mode (default)
- [ ] Web UI (`--ui`)
</details>

<details>
<summary><strong>Vision / motion</strong> — expand if your PR touches these</summary>

- [ ] Camera pipeline (with/without `--no-camera`)
- [ ] Movement manager (dances, emotions, head motion)
- [ ] Profiles or custom tools
</details>

## Notes
<!-- Optional: context, caveats, migration notes -->
Local gate: Ruff, formatting, mypy, and 320 tests pass. Workflow YAML parses successfully.